### PR TITLE
Fix leshanServerBuilder.setUpdateRegistrationOnNotification

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/DynamicIPObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/DynamicIPObserveTest.java
@@ -202,8 +202,6 @@ public class DynamicIPObserveTest {
         assertThat(registrationAfterObserve).isEqualTo(registrationBeforeObserve);
     }
 
-    // TODO Registration is not correctly updated we must fix it.
-    @Disabled
     @TestTlsTransport
     public void update_registration_on_notification_using_psk(Protocol givenProtocol,
             String givenClientEndpointProvider, String givenServerEndpointProvider)
@@ -230,7 +228,7 @@ public class DynamicIPObserveTest {
         Registration registrationBeforeObserve = server.getRegistrationFor(client);
         assertSuccessfulNotificationSendingAfterAddressChanged(registrationBeforeObserve);
 
-        // check that client registration is not updated.
+        // check that client registration is updated.
         Registration registrationAfterObserve = server.getRegistrationFor(client);
         assertThat(registrationAfterObserve.getSocketAddress())
                 .isNotEqualTo(registrationBeforeObserve.getSocketAddress());

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/server/redis/RedisRegistrationStoreTest.java
@@ -44,6 +44,7 @@ import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.ObservationIdentifier;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.core.peer.LwM2mPeer;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.ObserveCompositeRequest;
@@ -86,16 +87,17 @@ public class RedisRegistrationStoreTest {
         observationStore = new LwM2mObservationStore(store, new LwM2mNotificationReceiver() {
 
             @Override
-            public void onNotification(CompositeObservation observation, ClientProfile profile,
+            public void onNotification(CompositeObservation observation, LwM2mPeer sender, ClientProfile profile,
                     ObserveCompositeResponse response) {
             }
 
             @Override
-            public void onNotification(SingleObservation observation, ClientProfile profile, ObserveResponse response) {
+            public void onNotification(SingleObservation observation, LwM2mPeer sender, ClientProfile profile,
+                    ObserveResponse response) {
             }
 
             @Override
-            public void onError(Observation observation, ClientProfile profile, Exception error) {
+            public void onError(Observation observation, LwM2mPeer sender, ClientProfile profile, Exception error) {
             }
 
             @Override

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointsProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointsProvider.java
@@ -164,14 +164,14 @@ public class CaliforniumServerEndpointsProvider implements LwM2mServerEndpointsP
                             AbstractLwM2mResponse response = messagetranslator.createObservation(observation,
                                     coapResponse, toolbox, profile);
                             if (observation instanceof SingleObservation) {
-                                notificatonReceiver.onNotification((SingleObservation) observation, profile,
+                                notificatonReceiver.onNotification((SingleObservation) observation, client, profile,
                                         (ObserveResponse) response);
                             } else if (observation instanceof CompositeObservation) {
-                                notificatonReceiver.onNotification((CompositeObservation) observation, profile,
+                                notificatonReceiver.onNotification((CompositeObservation) observation, client, profile,
                                         (ObserveCompositeResponse) response);
                             }
                         } catch (Exception e) {
-                            notificatonReceiver.onError(observation, profile, e);
+                            notificatonReceiver.onError(observation, client, profile, e);
                         }
 
                     }

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/LwM2mObservationStoreTest.java
@@ -43,6 +43,7 @@ import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.ObservationIdentifier;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.core.peer.LwM2mPeer;
 import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.ObserveCompositeRequest;
@@ -80,16 +81,17 @@ public class LwM2mObservationStoreTest {
         store = new InMemoryRegistrationStore();
         observationStore = new LwM2mObservationStore(store, new LwM2mNotificationReceiver() {
             @Override
-            public void onNotification(CompositeObservation observation, ClientProfile profile,
+            public void onNotification(CompositeObservation observation, LwM2mPeer sender, ClientProfile profile,
                     ObserveCompositeResponse response) {
             }
 
             @Override
-            public void onNotification(SingleObservation observation, ClientProfile profile, ObserveResponse response) {
+            public void onNotification(SingleObservation observation, LwM2mPeer sender, ClientProfile profile,
+                    ObserveResponse response) {
             }
 
             @Override
-            public void onError(Observation observation, ClientProfile profile, Exception error) {
+            public void onError(Observation observation, LwM2mPeer sender, ClientProfile profile, Exception error) {
             }
 
             @Override

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/LwM2mNotificationReceiver.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/observation/LwM2mNotificationReceiver.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.server.observation;
 import org.eclipse.leshan.core.observation.CompositeObservation;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.SingleObservation;
+import org.eclipse.leshan.core.peer.LwM2mPeer;
 import org.eclipse.leshan.core.response.ObserveCompositeResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.server.profile.ClientProfile;
@@ -44,26 +45,31 @@ public interface LwM2mNotificationReceiver {
      * Called on new notification.
      *
      * @param observation the observation for which new data are received
+     * @param sender the client which sent the notification
      * @param profile the client profile concerned by this observation
      * @param response the lwm2m response received (successful or error response)
      *
      */
-    void onNotification(SingleObservation observation, ClientProfile profile, ObserveResponse response);
+    void onNotification(SingleObservation observation, LwM2mPeer sender, ClientProfile profile,
+            ObserveResponse response);
 
     /**
      * Called on new notification.
      *
      * @param observation the composite-observation for which new data are received
+     * @param sender the client which sent the notification
      * @param profile the client profile concerned by this observation
      * @param response the lwm2m observe-composite response received (successful or error response)
      *
      */
-    void onNotification(CompositeObservation observation, ClientProfile profile, ObserveCompositeResponse response);
+    void onNotification(CompositeObservation observation, LwM2mPeer sender, ClientProfile profile,
+            ObserveCompositeResponse response);
 
     /**
      * Called when an error occurs on new notification.
      *
      * @param observation the observation for which new data are received
+     * @param sender the client which sent the notification
      * @param profile the client profile concerned by this observation
      * @param error the exception raised when we handle the notification. It can be :
      *        <ul>
@@ -71,5 +77,5 @@ public interface LwM2mNotificationReceiver {
      *        <li>or any other RuntimeException for unexpected issue.
      *        </ul>
      */
-    void onError(Observation observation, ClientProfile profile, Exception error);
+    void onError(Observation observation, LwM2mPeer sender, ClientProfile profile, Exception error);
 }


### PR DESCRIPTION
This aims to fix that `leshanServerBuilder.setUpdateRegistrationOnNotification` does not update client transport data.

See for more details : #1421.