### PR TITLE
Some polish relative to Peer Identity refactoring

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/DynamicIPSendTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/DynamicIPSendTest.java
@@ -16,7 +16,7 @@
 package org.eclipse.leshan.integration.tests.send;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.leshan.core.ResponseCode.NOT_FOUND;
+import static org.eclipse.leshan.core.ResponseCode.BAD_REQUEST;
 import static org.eclipse.leshan.integration.tests.util.Credentials.GOOD_PSK_ID;
 import static org.eclipse.leshan.integration.tests.util.Credentials.GOOD_PSK_KEY;
 import static org.eclipse.leshan.integration.tests.util.Credentials.clientPrivateKey;
@@ -142,7 +142,7 @@ public class DynamicIPSendTest {
                 Arrays.asList("/3/0/1", "/3/0/2"), 1000);
 
         // it should failed !
-        assertThat(response).hasCode(NOT_FOUND);
+        assertThat(response).hasCode(BAD_REQUEST);
     }
 
     // TODO OSCORE implement a test with OSCORE

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/ReverseProxy.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/ReverseProxy.java
@@ -121,6 +121,18 @@ public class ReverseProxy {
                 logAndRaiseException("Unexpected IO Exception when running proxy", e);
             }
         });
+
+        // Wait until proxy is really running
+        for (int i = 0; i < 10 && running; i++) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                LOGGER.debug("Start was interrupted", e);
+            }
+        }
+        if (!running) {
+            LOGGER.error("Unable to start ReverseProxy");
+        }
     }
 
     private void handleClientPackets() throws IOException {
@@ -234,7 +246,7 @@ public class ReverseProxy {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                LOGGER.debug("Change Server Side Proxy Address was interrupted", e);
             }
         }
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/send/SendResource.java
@@ -61,7 +61,7 @@ public class SendResource extends LwM2mCoapResource {
 
         // check we have a registration for this identity
         if (clientProfile == null) {
-            exchange.respond(ResponseCode.NOT_FOUND, "no registration found");
+            exchange.respond(ResponseCode.BAD_REQUEST, "no registration found");
             return;
         }
 


### PR DESCRIPTION
Since #1445, I saw some test instability some first commit aims to fix it.

Second commit, is about changing error code on send operation.

Reading [LWM2M-v1.1.1@transpor§Table: 6.7.-4 Response Codes: Information Reporting Interface](https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/HTML-Version/OMA-TS-LightweightM2M_Transport-V1_1_1-20190617-A.html#Table-67-4-Response-Codes-Information-Reporting-Interface), BAD_REQUEST seems fit better as NOT_FOUND is reserved for 'Reported Object was not registered to Server'.

Note that currently, returning NOT_FOUND when  'Reported Object was not registered to Server' is currently not implemented, I created the corresponding issue : https://github.com/eclipse-leshan/leshan/issues/1472