### PR TITLE
Store yarn and nodejs artificat at download.eclipse.org for jenkins build.

### DIFF
--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -20,9 +20,12 @@ pipeline {
     stage('Build') {
       steps {
         // Build 
-        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom 
-               mvn -B clean install javadoc:javadoc -PeclipseJenkins 
-        '''
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom ''' 
+        // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
+        // see : https://github.com/eclipse-leshan/leshan/pull/1484
+        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins '''
+        }
         // Copy artifacts
         sh ''' cp leshan-server-demo/target/leshan-server-demo-*-jar-with-dependencies.jar leshan-server-demo.jar
                cp leshan-bsserver-demo/target/leshan-bsserver-demo-*-jar-with-dependencies.jar leshan-bsserver-demo.jar

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -23,10 +23,13 @@ pipeline {
   stages {
     stage('Build') {
       steps {
-        // Build
-        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom 
-               mvn -B clean install javadoc:javadoc -PeclipseJenkins 
-        '''
+        // Build 
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom ''' 
+        // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
+        // see : https://github.com/eclipse-leshan/leshan/pull/1484
+        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins '''
+        }
       }
     }
     stage('Deploy') {

--- a/.jenkins/release.jenkins
+++ b/.jenkins/release.jenkins
@@ -67,7 +67,11 @@ pipeline {
         // Update to release version and build artifacts 
         sh '''mvn -B versions:set -PallPom -DnewVersion=${RELEASE_VERSION}'''
         sh '''mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom'''
-        sh '''mvn -B clean install javadoc:javadoc -PeclipseJenkins'''
+        // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
+        // see : https://github.com/eclipse-leshan/leshan/pull/1484
+        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+            sh '''mvn -B clean install javadoc:javadoc -PeclipseJenkins'''
+        }
         
         // Commit new version change
         sshagent(['github-bot-ssh']) {

--- a/build-config/demo-build-config/pom.xml
+++ b/build-config/demo-build-config/pom.xml
@@ -29,6 +29,11 @@ Contributors:
   <name>leshan - shared demo build config</name>
   <description>Shared Maven configuration for all Leshan demos</description>
 
+  <properties>
+    <node-version>v12.22.5</node-version>
+    <yarn-version>v1.22.19</yarn-version>
+  </properties>
+
   <build>
     <pluginManagement>
       <plugins>
@@ -61,8 +66,8 @@ Contributors:
           <artifactId>frontend-maven-plugin</artifactId>
           <configuration>
             <workingDirectory>webapp</workingDirectory>
-            <nodeVersion>v12.22.5</nodeVersion>
-            <yarnVersion>v1.22.19</yarnVersion>
+            <nodeVersion>${node-version}</nodeVersion>
+            <yarnVersion>${yarn-version}</yarnVersion>
           </configuration>
           <executions>
             <execution>
@@ -105,15 +110,54 @@ Contributors:
   <profiles>
     <profile>
       <id>eclipseJenkins</id>
+      <properties>
+        <download-eclipse-path>/home/data/httpd/download.eclipse.org/leshan/</download-eclipse-path>
+        <download-remote-publish-path>genie.leshan@projects-storage.eclipse.org:${download-eclipse-path}</download-remote-publish-path>
+        <node-yarn-mirror-folder>build/mirror/</node-yarn-mirror-folder>
+        <node-folder>${node-yarn-mirror-folder}node/</node-folder>
+        <yarn-folder>${node-yarn-mirror-folder}yarn/</yarn-folder>
+        <node-download-root>https://nodejs.org/dist/</node-download-root>
+        <yarn-download-root>https://sourceforge.net/projects/yarn.mirror/files/</yarn-download-root>
+        <node-source-url>${node-download-root}${node-version}/node-${node-version}-linux-x64.tar.gz</node-source-url>
+        <yarn-source-url>${yarn-download-root}${yarn-version}/yarn-${yarn-version}.tar.gz</yarn-source-url>
+        <download-eclipse-url>https://download.eclipse.org/leshan/</download-eclipse-url>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>
             <plugin>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>wagon-maven-plugin</artifactId>
+              <executions>
+                <execution>
+                  <id>prepare-build</id>
+                  <goals>
+                    <goal>sshexec</goal>
+                  </goals>
+                  <phase>initialize</phase>
+                  <configuration>
+                    <url>scpexe://${download-remote-publish-path}</url>
+                    <commands>
+                      <command>mkdir -p ${download-eclipse-path}${node-folder}${node-version}</command>
+                      <command>wget -nc ${node-source-url} -P ${download-eclipse-path}${node-folder}${node-version}</command>
+                      <command>mkdir -p ${download-eclipse-path}${yarn-folder}${yarn-version}</command>
+                      <command>wget -nc ${yarn-source-url} -P ${download-eclipse-path}${yarn-folder}${yarn-version}</command>
+                    </commands>
+                    <displayCommandOutputs>true</displayCommandOutputs>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+            <plugin>
               <groupId>com.github.eirslett</groupId>
               <artifactId>frontend-maven-plugin</artifactId>
               <configuration>
-                <!-- See why we use a mirror : https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1032 -->
-                <yarnDownloadRoot>https://sourceforge.net/projects/yarn.mirror/files/</yarnDownloadRoot>
+                <!-- See why we use a mirror : 
+                     https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1032
+                     https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3429#note_1184525
+                -->
+                <nodeDownloadRoot>${download-eclipse-url}${node-folder}</nodeDownloadRoot>
+                <yarnDownloadRoot>${download-eclipse-url}${yarn-folder}</yarnDownloadRoot>
               </configuration>
             </plugin>
           </plugins>

--- a/leshan-bsserver-demo/pom.xml
+++ b/leshan-bsserver-demo/pom.xml
@@ -57,6 +57,10 @@ Contributors:
         <artifactId>buildnumber-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
       </plugin>

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -73,6 +73,10 @@ Contributors:
         <artifactId>buildnumber-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>wagon-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,11 @@ Contributors:
             </dependency>
           </dependencies>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>wagon-maven-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -544,6 +549,13 @@ Contributors:
         </executions>
       </plugin>
     </plugins>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.wagon</groupId>
+        <artifactId>wagon-ssh-external</artifactId>
+        <version>3.5.3</version>
+      </extension>
+    </extensions>
   </build>
 
   <profiles>


### PR DESCRIPTION
**Problem :**
Sometime on CI jenkins instance we face some trouble to download **nodejs** or **yarn** with **frontend-maven-plugin**.

This kind of error :  
 - `[ERROR] The archive file /home/jenkins/.m2/repository/com/github/eirslett/node/12.22.5/node-12.22.5-linux-x64.tar.gz is corrupted and will be deleted. Please try the build again.`
 - `[ERROR] Failed to execute goal com.github.eirslett:frontend-maven-plugin:1.13.4:install-node-and-yarn (install node and yarn) on project leshan-server-demo: Could not download Node.js: Got error code 500 from the server. -> [Help 1]`
 
 The [solution proposed](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3429#note_1184525) was to : 
 > I would recommend to download the node archive from another mirror or store it in the Leshan download directory on download.eclipse.org

 This could maybe also make the build faster limiting this [old issue](https://bugs.eclipse.org/bugs/show_bug.cgi?id=571834).
 
**Solution :**
 This PR aims to cache yarn and node binaries to https://download.eclipse.org/leshan/build/mirror/.
 
 **Documentation:**
- https://wiki.eclipse.org/Jenkins#How_do_I_deploy_artifacts_to_download.eclipse.org.3F
- https://wiki.eclipse.org/Jenkins#How_do_I_deploy_artifacts_to_download.eclipse.org.3F
- https://www.mojohaus.org/wagon-maven-plugin/sshexec-mojo.html
- https://github.com/eirslett/frontend-maven-plugin#installing-node-and-yarn