### PR TITLE
Migration Jenkins Build from Freestyle Job to Jenkins Pipeline.

### DIFF
--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -1,0 +1,50 @@
+/************************************************************************************
+
+  Simple build to check all is OK
+  This job do  : clean install javadoc:javadoc
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'adoptopenjdk-hotspot-jdk8-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  stages {
+    stage('Build') {
+      steps {
+        // Build 
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom 
+               mvn -B clean install javadoc:javadoc -PeclipseJenkins 
+        '''
+        // Copy artifacts
+        sh ''' cp leshan-server-demo/target/leshan-server-demo-*-jar-with-dependencies.jar leshan-server-demo.jar
+               cp leshan-bsserver-demo/target/leshan-bsserver-demo-*-jar-with-dependencies.jar leshan-bsserver-demo.jar
+               cp leshan-client-demo/target/leshan-client-demo-*-jar-with-dependencies.jar leshan-client-demo.jar
+        '''
+      }
+    }
+  }
+  post {
+    unsuccessful {
+      mail to: 'sbernard@sierrawireless.com',
+           subject: "Build ${env.BUILD_TAG} failed!",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    fixed {
+      mail to: 'sbernard@sierrawireless.com',
+           subject: "Build ${env.BUILD_TAG} back to normal.",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    always {
+      junit '**/target/surefire-reports/*.xml'
+      archiveArtifacts artifacts: 'leshan-server-demo.jar,leshan-bsserver-demo.jar,leshan-client-demo.jar'
+    }
+  }
+}

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -1,0 +1,54 @@
+/************************************************************************************
+  
+  Nightly Build : 
+  Build current branch and deploy it to eclipse nexus instance at : 
+  https://repo.eclipse.org/content/repositories/leshan-snapshots/
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'adoptopenjdk-hotspot-jdk8-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    pollSCM ignorePostCommitHooks: true, scmpoll_spec: 'H H * * *'
+  }
+  stages {
+    stage('Build') {
+      steps {
+        // Build
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom 
+               mvn -B clean install javadoc:javadoc -PeclipseJenkins 
+        '''
+      }
+    }
+    stage('Deploy') {
+      steps {
+        // Build 
+        sh '''mvn -B deploy -Prelease-nightly -DskipTests -Dskip.yarn'''
+      }
+    }
+  }
+  post {
+    unsuccessful {
+      mail to: 'sbernard@sierrawireless.com',
+           subject: "Build ${env.BUILD_TAG} failed!",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    fixed {
+      mail to: 'sbernard@sierrawireless.com',
+           subject: "Build ${env.BUILD_TAG} back to normal.",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    always {
+      junit '**/target/surefire-reports/*.xml'
+    }
+  }
+}

--- a/.jenkins/release.jenkins
+++ b/.jenkins/release.jenkins
@@ -1,0 +1,111 @@
+/************************************************************************************
+
+  Manual job used to release Leshan to maven central.
+  Take 4 parameters (BRANCH, RELEASE_VERSION,NEXT_VERSION, DRY_RUN).
+
+    Checks out current ${BRANCH}'s HEAD
+    Change version to ${RELEASE_VERSION}
+    Builds and tests it : mvn clean install javadoc:javadoc
+    Tags it with ${RELEASE_VERSION}
+    Deploys artifacts to Maven Central's staging repo with autoReleaseAfterClose=true 
+    Change version to ${NEXT_VERSION}
+    Pushes newly created tags to GitHub
+    
+  DRY_RUN can be used to skip auto-close/auto-release 
+  and avoid to push commit on git ${BRANCH}.
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  parameters {
+    string(
+        name: 'BRANCH',
+        defaultValue: 'master',
+        description: 'The branch to build and release from. Examples: master, 1.x')
+    string(
+        name: 'RELEASE_VERSION',
+        defaultValue: '2.0.0-M10',
+        description: 'The version identifier to use for the artifacts built by this job. Examples: `2.0.0-M10`, `2.0.0-RC1`, `2.0.1`')
+    string(
+        name: 'NEXT_VERSION',
+        defaultValue: '2.0.0-SNAPSHOT',
+        description: 'The version identifier to use during development of the next version. Examples: 2.0.0-SNAPSHOT 2.1.0-SNAPSHOT')
+    booleanParam(
+        name: 'DRY_RUN',
+        defaultValue: true,
+        description: 'When DRY_RUN is used, commits/tags are not pushed to git repo & sonatype repository is not automatically closed')
+  }
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'oracle-jdk8-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    skipDefaultCheckout()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  stages {
+    stage('Build') {
+      steps {
+        // Get Key to sign artifacts
+        withCredentials([file(credentialsId: 'secret-subkeys.asc', variable: 'KEYRING')]) {
+          sh '''gpg --batch --import "${KEYRING}"
+                for fpr in $(gpg --list-keys --with-colons  | awk -F: \'/fpr:/ {print $10}\' | sort -u);
+                do
+                  echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
+                done
+          '''
+        }
+
+        // Checkout code
+        git url: 'git@github.com:eclipse-leshan/leshan.git',
+            credentialsId: 'github-bot-ssh',
+            branch: '${BRANCH}'
+
+        // Update to release version and build artifacts 
+        sh '''mvn -B versions:set -PallPom -DnewVersion=${RELEASE_VERSION}'''
+        sh '''mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom'''
+        sh '''mvn -B clean install javadoc:javadoc -PeclipseJenkins'''
+        
+        // Commit new version change
+        sshagent(['github-bot-ssh']) {
+          sh '''git config user.email "leshan-bot@eclipse.orgg"
+                git config user.name "Leshan Bot"
+                shopt -s globstar
+                git add **/pom.xml
+                shopt -u globstar
+                git config user.email "leshan-bot@eclipse.orgg"
+                git config user.name "Leshan Bot"
+                git commit -m "Bump version to ${RELEASE_VERSION}"
+                git tag leshan-${RELEASE_VERSION} 
+          '''
+        }
+      }
+    }
+
+    stage('Deploy') {
+      steps {
+        // deploy then update to post release version
+        sh '''mvn -B deploy -Prelease -DskipTests -Dskip.yarn -DskipStagingRepositoryClose=${DRY_RUN}'''
+        sh '''mvn -B versions:set -PallPom -DnewVersion=${NEXT_VERSION}'''
+        
+        // Commit post release version change and push if not dry-run
+        sshagent(['github-bot-ssh']) {
+          sh '''shopt -s globstar
+                git add **/pom.xml
+                shopt -u globstar
+                git commit -m "Bump version to ${NEXT_VERSION}"
+          '''
+          sh '''if [ "$DRY_RUN" == "false" ]
+                then
+                  git push --set-upstream origin ${BRANCH}
+                  git push --tags
+                fi
+          '''
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR aims to migrate our current Build from **Jenkins Freestyle Job** to **Jenkins Pipeline**. 
This PR only target `master` and same kind of modification should be done to `1.x` branch. It will be done in another PR.

**Why?**
 1. Eclipse IT are planning to recommend switching to Jenkins pipelines soon and will eventually stop supporting freestyle builds.
 2. (Build-)configuration-as-code has become an industry best practice, so overall support for freestyle jobs is fading away.
 3. This allow to reduce the number of Jenkins Job. (using multi-branch-pipeline)
 
source : 
 - https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3435#note_1185195
 
**Solution:**
Each branches we need to build will contains a `.jenkins` folder containing : 
- `ci.jenkins` file : describe how to build the branch for continuous check. 
- `nightly.jenkins` file : describe how to release nightly to eclipse repository.
- `release.jenkins` file : describe how to release stable/milestone version to maven central. 

**Documentation :** 
- https://www.jenkins.io/doc/book/pipeline/
- https://wiki.eclipse.org/Jenkins

**Temporary jobs to test :** 
- https://ci.eclipse.org/leshan/job/leshan-mbp/ to test `ci.jenkins`
- https://ci.eclipse.org/leshan/job/leshan-mbp-nightly/ to test `nightly.jenkins`.
- https://ci.eclipse.org/leshan/job/leshan-bp/ to test `release.jenkins`