### PR TITLE
This aims to modify maven build to use JVM `release` option 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,10 @@ jobs:
     - name: Checkout Code
       uses: actions/checkout@v3
 
-    - name: Set up JDK 8
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '8'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
 

--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -8,7 +8,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk8-latest'
+    jdk 'adoptopenjdk-hotspot-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -9,7 +9,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk8-latest'
+    jdk 'adoptopenjdk-hotspot-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/release.jenkins
+++ b/.jenkins/release.jenkins
@@ -37,7 +37,7 @@ pipeline {
   }
   tools {
     maven 'apache-maven-latest'
-    jdk 'oracle-jdk8-latest'
+    jdk 'oracle-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -39,8 +39,7 @@ Contributors:
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
+            <release>8</release>
             <debug>true</debug>
             <showDeprecation>true</showDeprecation>
           </configuration>

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationService.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationService.java
@@ -41,7 +41,7 @@ public interface RegistrationService {
      * Returns an iterator over all registrations. There are no guarantees concerning the order in which the elements
      * are returned.
      *
-     * @return an <tt>Iterator</tt> over registrations
+     * @return an {@link Iterator} over registrations
      */
     Iterator<Registration> getAllRegistrations();
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/registration/RegistrationStore.java
@@ -84,7 +84,7 @@ public interface RegistrationStore {
      * Returns an iterator over the registration of this store. There are no guarantees concerning the order in which
      * the elements are returned (unless the implementation provides a guarantee).
      *
-     * @return an <tt>Iterator</tt> over the registration in this store
+     * @return an {@link Iterator} over the registration in this store
      */
     Iterator<Registration> getAllRegistrations();
 

--- a/pom.xml
+++ b/pom.xml
@@ -537,6 +537,9 @@ Contributors:
           <rules>
             <requireUpperBoundDeps></requireUpperBoundDeps>
             <dependencyConvergence></dependencyConvergence>
+            <requireJavaVersion>
+              <version>1.11</version>
+            </requireJavaVersion>
             <requireMavenVersion>
               <version>3.6.0</version>
             </requireMavenVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -387,8 +387,7 @@ Contributors:
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <!-- can not upgrade because of we stuck with java8 : https://github.com/Ekryd/sortpom/issues/225 -->
-          <version>3.0.1</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -440,21 +439,19 @@ Contributors:
         </plugin>
         <plugin>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.3.0</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <!--  stuck to 9.x for java8 compatibility -->
-              <version>9.3</version>
+              <version>10.12.2</version>
             </dependency>
           </dependencies>
         </plugin>
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <!--  stuck to 1.6.x for java8 compatibility -->
-          <version>1.6.2</version>
+          <version>1.9.0</version>
           <dependencies>
             <!-- Needed because of maven 3.9.0 backward compatibility issue,
                  See : https://github.com/eclipse/leshan/issues/1410 -->
@@ -468,8 +465,9 @@ Contributors:
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <!--  stuck to 2.16.0 for java8 compatibility -->
-          <version>2.16.0</version>
+          <!-- stuck to 2.18, because higher version seems to detected bad formatting, 
+               need to investigate before to upgrade -->
+          <version>2.18.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
This should allow to generate java8 compatible artifacts with java11. 
(As java11 becomes more and more minimal version for most of maven plugin)

See https://github.com/eclipse-leshan/leshan/issues/1412 for more details.