### PR TITLE
Use Temurin JDK 11 instead of AdoptOpenJdk / OracleJdk

### DIFF
--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -8,7 +8,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -9,7 +9,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/release.jenkins
+++ b/.jenkins/release.jenkins
@@ -37,7 +37,7 @@ pipeline {
   }
   tools {
     maven 'apache-maven-latest'
-    jdk 'oracle-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')


### PR DESCRIPTION
AdoptOpenJDK was the predecessor of Eclipse Adoptium and should be be used anymore. **Temurin** should be used instead.

See : 
 - https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/
 - https://adoptium.net/
 
 We also switch from Oracle to Temurin too following this recommendation : https://whichjdk.com/