### PR TITLE
Use Temurin JDK 11 instead of AdoptOpenJdk / OracleJdk in branch `1.x`

### DIFF
--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -8,7 +8,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -9,7 +9,7 @@ pipeline {
   agent any
   tools {
     maven 'apache-maven-latest'
-    jdk 'adoptopenjdk-hotspot-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')

--- a/.jenkins/release.jenkins
+++ b/.jenkins/release.jenkins
@@ -37,7 +37,7 @@ pipeline {
   }
   tools {
     maven 'apache-maven-latest'
-    jdk 'oracle-jdk11-latest'
+    jdk 'temurin-jdk11-latest'
   }
   options {
     timeout (time: 30, unit: 'MINUTES')


### PR DESCRIPTION
Same as https://github.com/eclipse-leshan/leshan/pull/1496 for branch `1.x`