### PR TITLE
First experimentation about Write Attributes support at cliend side.

### DIFF
--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
@@ -40,6 +40,7 @@ import org.eclipse.leshan.client.californium.endpoint.coap.CoapClientProtocolPro
 import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.servers.LwM2mServer;
@@ -146,7 +147,7 @@ public class CaliforniumClientEndpointsProvider implements LwM2mClientEndpointsP
 
     @Override
     public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
-            ClientEndpointToolbox toolbox) {
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox) {
         this.objectTree = objectTree;
 
         // create coap server
@@ -160,7 +161,7 @@ public class CaliforniumClientEndpointsProvider implements LwM2mClientEndpointsP
 
         // create resources
         List<Resource> resources = messagetranslator.createResources(coapServer, identityHandlerProvider,
-                identityExtrator, requestReceiver, toolbox, objectTree);
+                identityExtrator, requestReceiver, notificationManager, toolbox, objectTree);
         coapServer.add(resources.toArray(new Resource[resources.size()]));
     }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/ClientCoapMessageTranslator.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/ClientCoapMessageTranslator.java
@@ -30,6 +30,7 @@ import org.eclipse.leshan.client.californium.object.ObjectResource;
 import org.eclipse.leshan.client.californium.request.CoapRequestBuilder;
 import org.eclipse.leshan.client.californium.request.LwM2mResponseBuilder;
 import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
 import org.eclipse.leshan.client.resource.LwM2mObjectTree;
@@ -89,7 +90,7 @@ public class ClientCoapMessageTranslator {
 
     public List<Resource> createResources(CoapServer coapServer, IdentityHandlerProvider identityHandlerProvider,
             ServerIdentityExtractor identityExtrator, DownlinkRequestReceiver requestReceiver,
-            ClientEndpointToolbox toolbox, LwM2mObjectTree objectTree) {
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox, LwM2mObjectTree objectTree) {
         ArrayList<Resource> resources = new ArrayList<>();
 
         // create bootstrap resource
@@ -97,8 +98,8 @@ public class ClientCoapMessageTranslator {
 
         // create object resources
         for (LwM2mObjectEnabler enabler : objectTree.getObjectEnablers().values()) {
-            resources.add(
-                    createObjectResource(enabler, identityHandlerProvider, identityExtrator, requestReceiver, toolbox));
+            resources.add(createObjectResource(enabler, identityHandlerProvider, identityExtrator, requestReceiver,
+                    notificationManager, toolbox));
         }
 
         // link resource to object tree
@@ -106,7 +107,7 @@ public class ClientCoapMessageTranslator {
             @Override
             public void objectAdded(LwM2mObjectEnabler object) {
                 CoapResource clientObject = createObjectResource(object, identityHandlerProvider, identityExtrator,
-                        requestReceiver, toolbox);
+                        requestReceiver, notificationManager, toolbox);
                 coapServer.add(clientObject);
             }
 
@@ -124,9 +125,10 @@ public class ClientCoapMessageTranslator {
 
     public CoapResource createObjectResource(LwM2mObjectEnabler objectEnabler,
             IdentityHandlerProvider identityHandlerProvider, ServerIdentityExtractor identityExtractor,
-            DownlinkRequestReceiver requestReceiver, ClientEndpointToolbox toolbox) {
+            DownlinkRequestReceiver requestReceiver, NotificationManager notificationManager,
+            ClientEndpointToolbox toolbox) {
         ObjectResource objectResource = new ObjectResource(objectEnabler.getId(), identityHandlerProvider,
-                identityExtractor, requestReceiver, toolbox);
+                identityExtractor, requestReceiver, notificationManager, toolbox);
         objectEnabler.addListener(objectResource);
         return objectResource;
     }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/object/ObjectResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/object/ObjectResource.java
@@ -77,11 +77,15 @@ import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CoAP {@link Resource} in charge of handling requests targeting a lwM2M Object.
  */
 public class ObjectResource extends LwM2mClientCoapResource implements ObjectListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectResource.class);
 
     protected DownlinkRequestReceiver requestReceiver;
     protected ClientEndpointToolbox toolbox;
@@ -233,7 +237,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
                     }
                     return false;
                 } catch (Exception e) {
-                    LOGGER.error("Exception while sending notification [{}] for [{}] to {}", response, observeRequest,
+                    LOG.error("Exception while sending notification [{}] for [{}] to {}", response, observeRequest,
                             server, e);
                     exchange.respond(ResponseCode.INTERNAL_SERVER_ERROR, "failure sending notification");
                     return false;

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/object/ObjectResource.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/object/ObjectResource.java
@@ -43,6 +43,7 @@ import org.eclipse.leshan.client.resource.listener.ObjectListener;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.core.californium.identity.IdentityHandlerProvider;
 import org.eclipse.leshan.core.link.attributes.InvalidAttributeException;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
 import org.eclipse.leshan.core.node.LwM2mNode;
@@ -169,8 +170,16 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
                         if (isActiveObserveCancellation) {
                             notificationManager.clear(server, observeRequest);
                         } else if (isObserveRelationEstablishement) {
-                            notificationManager.initRelation(server, observeRequest, content,
-                                    createNotificationSender(exchange, server, observeRequest, requestedContentFormat));
+                            try {
+                                notificationManager.initRelation(server, observeRequest, content,
+                                        createNotificationSender(exchange, server, observeRequest,
+                                                requestedContentFormat));
+                            } catch (InvalidAttributesException e) {
+                                exchange.respond(
+                                        toCoapResponseCode(org.eclipse.leshan.core.ResponseCode.INTERNAL_SERVER_ERROR),
+                                        "Invalid Attributes state : " + e.getMessage());
+                            }
+
                         }
 
                         // send response

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
@@ -34,6 +34,7 @@ import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.RegistrationEngine;
 import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.observer.LwM2mClientObserver;
 import org.eclipse.leshan.client.observer.LwM2mClientObserverAdapter;
 import org.eclipse.leshan.client.observer.LwM2mClientObserverDispatcher;
@@ -82,6 +83,7 @@ public class LeshanClient implements LwM2mClient {
     private final RegistrationEngine engine;
     private final LwM2mClientObserverDispatcher observers;
     private final DataSenderManager dataSenderManager;
+    private final NotificationManager notificationManager;
 
     public LeshanClient(String endpoint, List<? extends LwM2mObjectEnabler> objectEnablers,
             List<DataSender> dataSenders, List<Certificate> trustStore, RegistrationEngineFactory engineFactory,
@@ -120,7 +122,13 @@ public class LeshanClient implements LwM2mClient {
                 engine);
         createRegistrationUpdateHandler(engine, endpointsManager, bootstrapHandler, objectTree, linkFormatHelper);
 
-        endpointsProvider.init(objectTree, requestReceiver, toolbox);
+        notificationManager = createNotificationManager(objectTree, requestReceiver);
+        endpointsProvider.init(objectTree, requestReceiver, notificationManager, toolbox);
+    }
+
+    protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
+            DownlinkRequestReceiver requestReceiver) {
+        return new NotificationManager(objectTree, requestReceiver);
     }
 
     protected LwM2mRootEnabler createRootEnabler(LwM2mObjectTree tree) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
@@ -34,6 +34,7 @@ import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.RegistrationEngine;
 import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.notification.NotificationDataStore;
 import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.observer.LwM2mClientObserver;
 import org.eclipse.leshan.client.observer.LwM2mClientObserverAdapter;
@@ -57,6 +58,7 @@ import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+import org.eclipse.leshan.core.request.BootstrapRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.ResponseCallback;
@@ -128,7 +130,19 @@ public class LeshanClient implements LwM2mClient {
 
     protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
             DownlinkRequestReceiver requestReceiver) {
-        return new NotificationManager(objectTree, requestReceiver);
+        final NotificationManager notificationManager = new NotificationManager(objectTree, requestReceiver,
+                createNotificationStore());
+        this.addObserver(new LwM2mClientObserverAdapter() {
+            @Override
+            public void onBootstrapStarted(LwM2mServer bsserver, BootstrapRequest request) {
+                notificationManager.clear();
+            }
+        });
+        return notificationManager;
+    }
+
+    protected NotificationDataStore createNotificationStore() {
+        return new NotificationDataStore();
     }
 
     protected LwM2mRootEnabler createRootEnabler(LwM2mObjectTree tree) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
@@ -126,14 +126,14 @@ public class LeshanClient implements LwM2mClient {
                 engine);
         createRegistrationUpdateHandler(engine, endpointsManager, bootstrapHandler, objectTree, linkFormatHelper);
 
-        notificationManager = createNotificationManager(objectTree, requestReceiver);
+        notificationManager = createNotificationManager(objectTree, requestReceiver, sharedExecutor);
         endpointsProvider.init(objectTree, requestReceiver, notificationManager, toolbox);
     }
 
     protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
-            DownlinkRequestReceiver requestReceiver) {
+            DownlinkRequestReceiver requestReceiver, ScheduledExecutorService sharedExecutor) {
         final NotificationManager notificationManager = new NotificationManager(objectTree, requestReceiver,
-                createNotificationStore(), createNotificationStrategy());
+                createNotificationStore(), createNotificationStrategy(), sharedExecutor);
         this.addObserver(new LwM2mClientObserverAdapter() {
             @Override
             public void onBootstrapStarted(LwM2mServer bsserver, BootstrapRequest request) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClient.java
@@ -34,8 +34,10 @@ import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.RegistrationEngine;
 import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.notification.DefaultNotificationStrategy;
 import org.eclipse.leshan.client.notification.NotificationDataStore;
 import org.eclipse.leshan.client.notification.NotificationManager;
+import org.eclipse.leshan.client.notification.NotificationStrategy;
 import org.eclipse.leshan.client.observer.LwM2mClientObserver;
 import org.eclipse.leshan.client.observer.LwM2mClientObserverAdapter;
 import org.eclipse.leshan.client.observer.LwM2mClientObserverDispatcher;
@@ -131,7 +133,7 @@ public class LeshanClient implements LwM2mClient {
     protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
             DownlinkRequestReceiver requestReceiver) {
         final NotificationManager notificationManager = new NotificationManager(objectTree, requestReceiver,
-                createNotificationStore());
+                createNotificationStore(), createNotificationStrategy());
         this.addObserver(new LwM2mClientObserverAdapter() {
             @Override
             public void onBootstrapStarted(LwM2mServer bsserver, BootstrapRequest request) {
@@ -143,6 +145,10 @@ public class LeshanClient implements LwM2mClient {
 
     protected NotificationDataStore createNotificationStore() {
         return new NotificationDataStore();
+    }
+
+    protected NotificationStrategy createNotificationStrategy() {
+        return new DefaultNotificationStrategy();
     }
 
     protected LwM2mRootEnabler createRootEnabler(LwM2mObjectTree tree) {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/DefaultCompositeClientEndpointsProvider.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/DefaultCompositeClientEndpointsProvider.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.servers.LwM2mServer;
@@ -46,9 +47,9 @@ public class DefaultCompositeClientEndpointsProvider implements CompositeClientE
 
     @Override
     public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
-            ClientEndpointToolbox toolbox) {
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox) {
         for (LwM2mClientEndpointsProvider provider : providers) {
-            provider.init(objectTree, requestReceiver, toolbox);
+            provider.init(objectTree, requestReceiver, notificationManager, toolbox);
         }
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/LwM2mClientEndpointsProvider.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/LwM2mClientEndpointsProvider.java
@@ -19,6 +19,7 @@ import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.List;
 
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.servers.LwM2mServer;
@@ -26,7 +27,8 @@ import org.eclipse.leshan.client.servers.ServerInfo;
 
 public interface LwM2mClientEndpointsProvider {
 
-    void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver, ClientEndpointToolbox toolbox);
+    void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox);
 
     LwM2mServer createEndpoint(ServerInfo serverInfo, boolean clientInitiatedOnly, List<Certificate> trustStore,
             ClientEndpointToolbox toolbox);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/DefaultNotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/DefaultNotificationStrategy.java
@@ -22,6 +22,7 @@ import org.eclipse.leshan.client.notification.checker.CriteriaBasedOnValueChecke
 import org.eclipse.leshan.client.notification.checker.FloatChecker;
 import org.eclipse.leshan.client.notification.checker.IntegerChecker;
 import org.eclipse.leshan.client.notification.checker.UnsignedIntegerChecker;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeModel;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
@@ -58,13 +59,15 @@ public class DefaultNotificationStrategy implements NotificationStrategy {
     }
 
     @Override
-    public NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path,
-            NotificationAttributeTree attributes) {
+    public NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path, NotificationAttributeTree attributes)
+            throws InvalidAttributesException {
 
         LwM2mAttributeSet set = attributes.getWithInheritance(path);
         if (set == null || set.isEmpty()) {
             return null;
         }
+        set.validate(path, null);
+
         NotificationAttributeTree result = new NotificationAttributeTree();
         result.put(path, set);
         return result;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/DefaultNotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/DefaultNotificationStrategy.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.leshan.client.notification.checker.CriteriaBasedOnValueChecker;
+import org.eclipse.leshan.client.notification.checker.FloatChecker;
+import org.eclipse.leshan.client.notification.checker.IntegerChecker;
+import org.eclipse.leshan.client.notification.checker.UnsignedIntegerChecker;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeModel;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mChildNode;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
+
+/**
+ * Default implementation of {@link NotificationStrategy}
+ */
+public class DefaultNotificationStrategy implements NotificationStrategy {
+
+    private final Map<Type, CriteriaBasedOnValueChecker> checkers;
+
+    public static Map<Type, CriteriaBasedOnValueChecker> createDefaultCheckers() {
+        Map<Type, CriteriaBasedOnValueChecker> checkers = new HashMap<>();
+        checkers.put(Type.FLOAT, new FloatChecker());
+        checkers.put(Type.INTEGER, new IntegerChecker());
+        checkers.put(Type.UNSIGNED_INTEGER, new UnsignedIntegerChecker());
+        return checkers;
+    }
+
+    public DefaultNotificationStrategy() {
+        this(createDefaultCheckers());
+    }
+
+    public DefaultNotificationStrategy(Map<Type, CriteriaBasedOnValueChecker> checkers) {
+        this.checkers = checkers;
+    }
+
+    @Override
+    public NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path,
+            NotificationAttributeTree attributes) {
+
+        LwM2mAttributeSet set = attributes.getWithInheritance(path);
+        if (set == null || set.isEmpty()) {
+            return null;
+        }
+        NotificationAttributeTree result = new NotificationAttributeTree();
+        result.put(path, set);
+        return result;
+    }
+
+    @Override
+    public boolean hasAttribute(NotificationAttributeTree attributes, LwM2mPath path, LwM2mAttributeModel<?> model) {
+        return getAttributeValue(attributes, path, model) != null;
+    }
+
+    @Override
+    public <T> T getAttributeValue(NotificationAttributeTree attributes, LwM2mPath path, LwM2mAttributeModel<T> model) {
+        LwM2mAttributeSet set = attributes.get(path);
+        if (set == null)
+            return null;
+        else {
+            LwM2mAttribute<T> attr = set.get(model);
+            if (attr == null)
+                return null;
+            else
+                return attr.getValue();
+        }
+    }
+
+    @Override
+    public boolean hasCriteriaBasedOnValue(NotificationAttributeTree attributes, LwM2mPath path) {
+        LwM2mAttributeSet set = attributes.get(path);
+        return set != null && (set.contains(LwM2mAttributes.GREATER_THAN) || set.contains(LwM2mAttributes.LESSER_THAN)
+                || set.contains(LwM2mAttributes.STEP));
+    }
+
+    @Override
+    public boolean shouldTriggerNotificationBasedOnValueChange(NotificationAttributeTree attributes, LwM2mPath path,
+            LwM2mNode lastSentNode, LwM2mChildNode newNode) {
+
+        // Get Previous and New Values
+        Object lastSentValue;
+        Object newValue;
+        Type resourceType;
+        if (lastSentNode instanceof LwM2mSingleResource && newNode instanceof LwM2mSingleResource) {
+            lastSentValue = ((LwM2mSingleResource) lastSentNode).getValue();
+            newValue = ((LwM2mSingleResource) newNode).getValue();
+            resourceType = ((LwM2mSingleResource) newNode).getType();
+        } else if (lastSentNode instanceof LwM2mResourceInstance && newNode instanceof LwM2mResourceInstance) {
+            lastSentValue = ((LwM2mResourceInstance) lastSentNode).getValue();
+            newValue = ((LwM2mResourceInstance) newNode).getValue();
+            resourceType = ((LwM2mResourceInstance) newNode).getType();
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "Unexpected nodes (last send node  %s new value %s) for check about value changed, only LwM2mSingleResource or LwM2mResourceInstance are supported",
+                    lastSentNode.getClass().getSimpleName(), newNode.getClass().getSimpleName()));
+        }
+
+        // Check criteria
+        CriteriaBasedOnValueChecker checker = checkers.get(resourceType);
+        if (checker == null) {
+            throw new IllegalArgumentException(
+                    String.format("Unexpected resource type : %s is not supported", resourceType));
+        }
+        LwM2mAttributeSet set = attributes.get(path);
+        return checker.shouldTriggerNotificationBasedOnValueChange(set, lastSentValue, newValue);
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification;
+
+import java.util.concurrent.ScheduledFuture;
+
+import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.request.ObserveRequest;
+
+/**
+ * This class store information needed to handle write attributes behavior.
+ * <p>
+ * It is used by {@link NotificationManager}
+ */
+public class NotificationDataStore {
+
+    // TODO create a real data structure
+    // for testing purpose we only store 1 NotificationData
+    private NotificationData data;
+
+    public NotificationData getNotificationData(LwM2mServer server, ObserveRequest request) {
+        return data;
+    }
+
+    public NotificationData addNotificationData(LwM2mServer server, ObserveRequest request, NotificationData data) {
+        // cancel task of previous data
+        NotificationData previousData = this.data;
+        if (previousData != null) {
+            if (previousData.getPminFuture() != null) {
+                previousData.getPminFuture().cancel(false);
+            }
+            if (previousData.getPmaxFuture() != null) {
+                previousData.getPmaxFuture().cancel(false);
+            }
+        }
+        // update data
+        this.data = data;
+
+        return previousData;
+    }
+
+    public static class NotificationData {
+        private final LwM2mAttributeSet attributes;
+        private final Long lastSendingTime; // time of last sent notification
+        private final LwM2mNode lastSentValue; // last value sent
+        private final ScheduledFuture<Void> pminTask; // task which will send delayed notification for pmin.
+        private final ScheduledFuture<Void> pmaxTask; // task which will send delayed notification for pmax.
+
+        public NotificationData(LwM2mAttributeSet attributes, Long lastSendingTime, LwM2mNode lastSentValue,
+                ScheduledFuture<Void> nextNotification) {
+            this.attributes = attributes;
+            this.lastSendingTime = lastSendingTime;
+            this.lastSentValue = lastSentValue;
+            this.pminTask = null;
+            this.pmaxTask = nextNotification;
+        }
+
+        public NotificationData(NotificationData previous, ScheduledFuture<Void> pminTask) {
+            this.attributes = previous.getAttributes();
+            this.lastSendingTime = previous.getLastSendingTime();
+            this.lastSentValue = previous.getLastSentValue();
+            this.pminTask = pminTask;
+            this.pmaxTask = previous.getPmaxFuture();
+        }
+
+        public LwM2mAttributeSet getAttributes() {
+            return attributes;
+        }
+
+        public Long getLastSendingTime() {
+            return lastSendingTime;
+        }
+
+        public LwM2mNode getLastSentValue() {
+            return lastSentValue;
+        }
+
+        public ScheduledFuture<Void> getPminFuture() {
+            return pminTask;
+        }
+
+        public ScheduledFuture<Void> getPmaxFuture() {
+            return pmaxTask;
+        }
+
+        public boolean usePmin() {
+            return lastSendingTime != null;
+        }
+
+        public boolean pminTaskScheduled() {
+            return pminTask != null;
+        }
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
@@ -213,6 +213,10 @@ public class NotificationDataStore {
             return lastSendingTime != null;
         }
 
+        public boolean usePmax() {
+            return pmaxTask != null;
+        }
+
         public boolean hasCriteriaBasedOnValue() {
             return lastSentValue != null;
         }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
@@ -41,13 +41,27 @@ public class NotificationDataStore {
 
     public NotificationData addNotificationData(LwM2mServer server, ObserveRequest request, NotificationData data) {
         // cancel task of previous data
-        NotificationData previousData = store.put(toKey(server, request), data);
+        return store.put(toKey(server, request), data);
+    }
+
+    public NotificationData updateNotificationData(LwM2mServer server, ObserveRequest request, NotificationData data) {
+
+        NotificationData previousData = store.replace(toKey(server, request), data);
         if (previousData != null) {
+            // If updated, cancel task of previous data
             if (previousData.getPminFuture() != null) {
                 previousData.getPminFuture().cancel(false);
             }
             if (previousData.getPmaxFuture() != null) {
                 previousData.getPmaxFuture().cancel(false);
+            }
+        } else {
+            // If NOT updated, cancel task of given data
+            if (data.getPminFuture() != null) {
+                data.getPminFuture().cancel(false);
+            }
+            if (data.getPmaxFuture() != null) {
+                data.getPmaxFuture().cancel(false);
             }
         }
         return previousData;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification;
 
+import java.util.Iterator;
 import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -68,6 +69,16 @@ public class NotificationDataStore {
         NotificationData removed = store.remove(toKey(server, request));
         if (removed != null) {
             cancelTasks(removed);
+        }
+    }
+
+    public synchronized void clearAllNotificationDataUnder(LwM2mPath parentPath) {
+        Iterator<NotificationDataKey> it = store.keySet().iterator();
+        while (it.hasNext()) {
+            NotificationDataKey key = it.next();
+            if (key.getPath().startWith(parentPath)) {
+                it.remove();
+            }
         }
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationDataStore.java
@@ -65,6 +65,10 @@ public class NotificationDataStore {
         store.clear();
     }
 
+    public boolean isEmpty() {
+        return store.isEmpty();
+    }
+
     private NotificationDataKey floorKeyFor(LwM2mServer server) {
         // TODO should be replaced by a ObservationRelationIdentifier probably based on Token
         return new NotificationDataKey(server.getId(), LwM2mPath.ROOTPATH);

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.leshan.client.notification.NotificationDataStore.NotificationData;
+import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
+import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.resource.LwM2mObjectTree;
+import org.eclipse.leshan.client.resource.NotificationSender;
+import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
+import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is responsible to modify default notification behavior based on write attributes.
+ */
+public class NotificationManager {
+
+    private final Logger LOG = LoggerFactory.getLogger(NotificationManager.class);
+
+    private final DownlinkRequestReceiver receiver;
+    private final NotificationDataStore store;
+    private final LwM2mObjectTree objectTree;
+    // TODO should be configurable and should be destroyed when needed.
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    public NotificationManager(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver) {
+        this.receiver = requestReceiver;
+        this.objectTree = objectTree;
+        this.store = new NotificationDataStore();
+
+        // Housekeeping
+        objectTree.addListener(new ObjectsListenerAdapter() {
+            @Override
+            public void objectInstancesRemoved(LwM2mObjectEnabler object, int... instanceIds) {
+                // TODO cleaning remove data
+            }
+
+            @Override
+            public void objectRemoved(LwM2mObjectEnabler object) {
+                // TODO cleaning remove data
+            }
+        });
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    public synchronized void initRelation(LwM2mServer server, ObserveRequest request, LwM2mNode node,
+            NotificationSender sender) {
+        // Get Attributes from ObjectTree
+        LwM2mAttributeSet attributes = getAttributes(server, request);
+
+        // If there is no attributes this is just classic observe so nothing to do.
+        if (attributes == null)
+            return;
+
+        LOG.debug("Handle observe relation for {} / {}", server, request);
+
+        // Store needed data for this observe relation.
+        updateNotificationData(server, request, attributes, node, sender);
+    }
+
+    protected LwM2mAttributeSet getAttributes(LwM2mServer server, ObserveRequest request) {
+        // TODO use objectTree to get attribute;
+        // for testing, we return hardcoded value for resource 6/0/1
+        if (request.getPath().equals(new LwM2mPath(6, 0, 1))) {
+            return new LwM2mAttributeSet( //
+                    LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 5l),
+                    LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 10l));
+        }
+        return null;
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    public synchronized void notificationTriggered(LwM2mServer server, ObserveRequest request,
+            NotificationSender sender) {
+        LOG.trace("Notification triggered for observe relation of {} / {}", server, request);
+
+        // Get Notification Data for given server / request
+        NotificationData notificationData = store.getNotificationData(server, request);
+        if (notificationData == null) {
+            // if there no notification data, this is classic observe (without notification attributes)
+            ObserveResponse observeResponse = createResponse(server, request);
+            sender.sendNotification(observeResponse);
+            return;
+        }
+
+        // ELSE handle Notification Attributes.
+        LwM2mAttributeSet attributes = notificationData.getAttributes();
+
+        // if previous value
+        // Get new value
+        // check LT / GT / ST criteria
+        // Then send notification if criteria doesn't match, stop
+
+        // TODO use case where PMIN == PMAX
+        // If PMIN is used
+        if (notificationData.usePmin()) {
+            LOG.trace("handle pmin for observe relation of {} / {}", server, request);
+
+            if (notificationData.pminTaskScheduled()) {
+                // nothing to do if a task is already scheduled
+                return;
+            }
+
+            // calculate time since last notification
+            Long timeSinceLastNotification = TimeUnit.SECONDS
+                    .convert(System.nanoTime() - notificationData.getLastSendingTime(), TimeUnit.NANOSECONDS);
+            Long pmin = attributes.get(LwM2mAttributes.MINIMUM_PERIOD).getValue();
+            if (timeSinceLastNotification < pmin) {
+                ScheduledFuture<Void> pminTask = executor.schedule(new Callable<Void>() {
+                    @Override
+                    public Void call() throws Exception {
+                        sendNotification(server, request, attributes, sender);
+                        return null;
+                    }
+                }, pmin - timeSinceLastNotification, TimeUnit.SECONDS);
+                // schedule next task for pmin but do not send notification
+                store.addNotificationData(server, request, new NotificationData(notificationData, pminTask));
+                return;
+            }
+        }
+
+        sendNotification(server, request, attributes, sender);
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    public synchronized void clear(LwM2mServer server, ObserveRequest request) {
+        // remove all data about observe relation for given server / request.
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    public synchronized void clear(LwM2mServer server) {
+        // remove all data about observe relation for given server.
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    public synchronized void clear() {
+        // remove all data about observe relation.
+    }
+
+    // TODO an optimization could be to synchronize by observe relation (identify by server / request)
+    protected synchronized void updateNotificationData(LwM2mServer server, ObserveRequest request,
+            LwM2mAttributeSet attributes, LwM2mNode newValue, NotificationSender sender) {
+
+        // Store last sending time if needed
+        Long lastSendingTime = null;
+        if (attributes.contains(LwM2mAttributes.MINIMUM_PERIOD)) {
+            lastSendingTime = System.nanoTime();
+        }
+
+        // Store last value sent if needed;
+        LwM2mNode lastValue = null;
+        if (attributes.contains(LwM2mAttributes.GREATER_THAN) || attributes.contains(LwM2mAttributes.LESSER_THAN)
+                || attributes.contains(LwM2mAttributes.STEP)) {
+            lastValue = newValue;
+        }
+
+        // Schedule notification for Max Period if needed
+        ScheduledFuture<Void> pmaxTask = null;
+        if (attributes.contains(LwM2mAttributes.MAXIMUM_PERIOD)) {
+            pmaxTask = executor.schedule(new Callable<Void>() {
+                @Override
+                public Void call() throws Exception {
+                    sendNotification(server, request, attributes, sender);
+                    return null;
+                }
+            }, attributes.getLwM2mAttribute(LwM2mAttributes.MAXIMUM_PERIOD).getValue(), TimeUnit.SECONDS);
+        }
+
+        // Create State for this observe relation
+        store.addNotificationData(server, request,
+                new NotificationData(attributes, lastSendingTime, lastValue, pmaxTask));
+    }
+
+    protected void sendNotification(LwM2mServer server, ObserveRequest request, LwM2mAttributeSet attributes,
+            NotificationSender sender) {
+        ObserveResponse observeResponse = createResponse(server, request);
+        if (!sender.sendNotification(observeResponse)) {
+            // remove data as relation doesn't exist anymore
+            clear(server, request);
+        } else {
+            if (observeResponse.isFailure()) {
+                // remove data as relation must removed on failure
+                clear(server, request);
+            } else {
+                updateNotificationData(server, request, attributes, observeResponse.getContent(), sender);
+            }
+        }
+    }
+
+    protected ObserveResponse createResponse(LwM2mServer server, ObserveRequest request) {
+        // TODO maybe we can remove "receiver" dependencie and directly use ObjectTree ?
+        return receiver.requestReceived(server, request).getResponse();
+    }
+
+    public void destroy() {
+        executor.shutdownNow();
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -51,15 +51,15 @@ public class NotificationManager {
     private final NotificationDataStore store;
     private final LwM2mObjectTree objectTree;
     private final NotificationStrategy strategy;
-    // TODO write attributes : should be configurable and should be destroyed when needed.
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor;
+    private final boolean executorAttached;
 
     public NotificationManager(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver) {
-        this(objectTree, requestReceiver, new NotificationDataStore(), new DefaultNotificationStrategy());
+        this(objectTree, requestReceiver, new NotificationDataStore(), new DefaultNotificationStrategy(), null);
     }
 
     public NotificationManager(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
-            NotificationDataStore store, NotificationStrategy strategy) {
+            NotificationDataStore store, NotificationStrategy strategy, ScheduledExecutorService executor) {
         Validate.notNull(objectTree);
         Validate.notNull(requestReceiver);
         Validate.notNull(store);
@@ -70,6 +70,13 @@ public class NotificationManager {
         this.store = store;
         this.strategy = strategy;
 
+        if (executor == null) {
+            this.executor = Executors.newSingleThreadScheduledExecutor();
+            this.executorAttached = true;
+        } else {
+            this.executor = executor;
+            this.executorAttached = false;
+        }
         this.objectTree.addListener(new ObjectsListenerAdapter() {
             @Override
             public void objectRemoved(LwM2mObjectEnabler object) {
@@ -244,6 +251,8 @@ public class NotificationManager {
     }
 
     public void destroy() {
-        executor.shutdownNow();
+        if (executorAttached) {
+            executor.shutdownNow();
+        }
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -52,9 +52,14 @@ public class NotificationManager {
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
     public NotificationManager(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver) {
+        this(objectTree, requestReceiver, new NotificationDataStore());
+    }
+
+    public NotificationManager(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
+            NotificationDataStore store) {
         this.receiver = requestReceiver;
         this.objectTree = objectTree;
-        this.store = new NotificationDataStore();
+        this.store = store;
 
         // Housekeeping
         objectTree.addListener(new ObjectsListenerAdapter() {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -93,7 +93,7 @@ public class NotificationManager {
         if (objectEnabler == null)
             return null;
         else {
-            return objectEnabler.getAttributesFor(request.getPath());
+            return objectEnabler.getAttributesFor(server);
         }
 
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.resource.NotificationSender;
 import org.eclipse.leshan.client.resource.listener.ObjectsListenerAdapter;
 import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
 import org.eclipse.leshan.core.node.LwM2mChildNode;
@@ -91,14 +92,15 @@ public class NotificationManager {
     }
 
     public synchronized void initRelation(LwM2mServer server, ObserveRequest request, LwM2mNode node,
-            NotificationSender sender) {
+            NotificationSender sender) throws InvalidAttributesException {
         // Get Attributes for this (server, request)
         LwM2mObjectEnabler objectEnabler = objectTree.getObjectEnabler(request.getPath().getObjectId());
         if (objectEnabler == null)
             return; // no object enabler : nothing to observe
         NotificationAttributeTree attributes = objectEnabler.getAttributesFor(server);
-        if (attributes != null && !attributes.isEmpty())
+        if (attributes != null && !attributes.isEmpty()) {
             attributes = strategy.selectNotificationsAttributes(request.getPath(), attributes);
+        }
 
         // If there is no attributes this is just classic observe so nothing to do.
         if (attributes == null || attributes.isEmpty())

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationManager.java
@@ -97,7 +97,7 @@ public class NotificationManager {
         if (objectEnabler == null)
             return; // no object enabler : nothing to observe
         NotificationAttributeTree attributes = objectEnabler.getAttributesFor(server);
-        if (attributes != null && attributes.isEmpty())
+        if (attributes != null && !attributes.isEmpty())
             attributes = strategy.selectNotificationsAttributes(request.getPath(), attributes);
 
         // If there is no attributes this is just classic observe so nothing to do.

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification;
+
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
+import org.eclipse.leshan.core.node.LwM2mChildNode;
+import org.eclipse.leshan.core.node.LwM2mNode;
+import org.eclipse.leshan.core.node.LwM2mPath;
+
+// TODO The way write attribute should be handle is not clear in LWM2M specification (-_-!) ... which is not an ideal situation ...
+// See : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/478
+// So we create a dedicated class about how this attributes should be handled.
+// The idea to then create a Interface + Default implement and let users implements their own strategy depending of their understanding or needs.
+public class NotificationStrategy {
+
+    // TODO this first implementaiton is a very over simple one. Just for validate design
+
+    public boolean hasPmin(NotificationAttributeTree attributes, LwM2mPath path) {
+        return getPmin(path, attributes) != null;
+    }
+
+    public Long getPmin(LwM2mPath path, NotificationAttributeTree attributes) {
+        LwM2mAttributeSet set = attributes.get(path);
+        if (set == null)
+            return null;
+        else {
+            LwM2mAttribute<Long> pmin = set.get(LwM2mAttributes.MINIMUM_PERIOD);
+            if (pmin == null)
+                return null;
+            else
+                return pmin.getValue();
+        }
+    }
+
+    public boolean hasPmax(LwM2mPath path, NotificationAttributeTree attributes) {
+        return getPmax(path, attributes) != null;
+    }
+
+    public Long getPmax(LwM2mPath path, NotificationAttributeTree attributes) {
+        LwM2mAttributeSet set = attributes.get(path);
+        if (set == null)
+            return null;
+        else {
+            LwM2mAttribute<Long> pmax = set.get(LwM2mAttributes.MAXIMUM_PERIOD);
+            if (pmax == null)
+                return null;
+            else
+                return pmax.getValue();
+        }
+    }
+
+    public boolean hasCriteriaBasedOnValue(LwM2mPath path, NotificationAttributeTree attributes) {
+        // attributes.contains(LwM2mAttributes.GREATER_THAN) || attributes.contains(LwM2mAttributes.LESSER_THAN)
+        // || attributes.contains(LwM2mAttributes.STEP
+        // TODO not implemented yet
+        return false;
+    }
+
+    public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mPath path, NotificationAttributeTree attributes,
+            LwM2mNode lastSentValue, LwM2mChildNode newValue) {
+        // TODO not implemented yet
+        return false;
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -15,13 +15,23 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.leshan.client.notification.checker.CriteriaBasedOnValueChecker;
+import org.eclipse.leshan.client.notification.checker.FloatChecker;
+import org.eclipse.leshan.client.notification.checker.IntegerChecker;
+import org.eclipse.leshan.client.notification.checker.UnsignedIntegerChecker;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mChildNode;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
 
 // TODO The way write attribute should be handle is not clear in LWM2M specification (-_-!) ... which is not an ideal situation ...
 // See : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/478
@@ -29,7 +39,23 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 // The idea to then create a Interface + Default implement and let users implements their own strategy depending of their understanding or needs.
 public class NotificationStrategy {
 
-    // TODO this first implementaiton is a very over simple one. Just for validate design
+    protected Map<Type, CriteriaBasedOnValueChecker> checkers = new HashMap<>();
+
+    public NotificationStrategy() {
+        checkers.put(Type.FLOAT, new FloatChecker());
+        checkers.put(Type.INTEGER, new IntegerChecker());
+        checkers.put(Type.UNSIGNED_INTEGER, new UnsignedIntegerChecker());
+    }
+
+    public NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path,
+            NotificationAttributeTree attributes) {
+
+        LwM2mAttributeSet set = attributes.getWithInheritance(path);
+        NotificationAttributeTree result = new NotificationAttributeTree();
+        result.put(path, set);
+
+        return result;
+    }
 
     public boolean hasPmin(NotificationAttributeTree attributes, LwM2mPath path) {
         return getPmin(path, attributes) != null;
@@ -66,15 +92,40 @@ public class NotificationStrategy {
     }
 
     public boolean hasCriteriaBasedOnValue(LwM2mPath path, NotificationAttributeTree attributes) {
-        // attributes.contains(LwM2mAttributes.GREATER_THAN) || attributes.contains(LwM2mAttributes.LESSER_THAN)
-        // || attributes.contains(LwM2mAttributes.STEP
-        // TODO not implemented yet
-        return false;
+        LwM2mAttributeSet set = attributes.get(path);
+        return set != null && (set.contains(LwM2mAttributes.GREATER_THAN) || set.contains(LwM2mAttributes.LESSER_THAN)
+                || set.contains(LwM2mAttributes.STEP));
     }
 
     public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mPath path, NotificationAttributeTree attributes,
-            LwM2mNode lastSentValue, LwM2mChildNode newValue) {
-        // TODO not implemented yet
-        return false;
+            LwM2mNode lastSentNode, LwM2mChildNode newNode) {
+
+        // Get Previous and New Values
+        Object lastSentValue;
+        Object newValue;
+        Type resourceType;
+        if (lastSentNode instanceof LwM2mSingleResource && newNode instanceof LwM2mSingleResource) {
+            lastSentValue = ((LwM2mSingleResource) lastSentNode).getValue();
+            newValue = ((LwM2mSingleResource) newNode).getValue();
+            resourceType = ((LwM2mSingleResource) newNode).getType();
+        } else if (lastSentNode instanceof LwM2mResourceInstance && newNode instanceof LwM2mResourceInstance) {
+            lastSentValue = ((LwM2mResourceInstance) lastSentNode).getValue();
+            newValue = ((LwM2mResourceInstance) newNode).getValue();
+            resourceType = ((LwM2mResourceInstance) newNode).getType();
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "Unexpected nodes (last send node  %s new value %s) for check about value changed, only LwM2mSingleResource or LwM2mResourceInstance are supported",
+                    lastSentNode.getClass().getSimpleName(), newNode.getClass().getSimpleName()));
+        }
+
+        // Check criteria
+        CriteriaBasedOnValueChecker checker = checkers.get(resourceType);
+        if (checker == null) {
+            throw new IllegalArgumentException(
+                    String.format("Unexpected resource type : %s is not supported", resourceType));
+        }
+        LwM2mAttributeSet set = attributes.get(path);
+        return checker.shouldTriggerNotificationBasedOnValueChange(set, lastSentValue, newValue);
     }
+
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -51,9 +51,11 @@ public class NotificationStrategy {
             NotificationAttributeTree attributes) {
 
         LwM2mAttributeSet set = attributes.getWithInheritance(path);
+        if (set == null || set.isEmpty()) {
+            return null;
+        }
         NotificationAttributeTree result = new NotificationAttributeTree();
         result.put(path, set);
-
         return result;
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -33,10 +33,11 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mResourceInstance;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 
-// TODO The way write attribute should be handle is not clear in LWM2M specification (-_-!) ... which is not an ideal situation ...
+// TODO write attributes : create an interface
+// The way write attribute should be handle is not clear in LWM2M specification (-_-!) ... which is not an ideal situation ...
 // See : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/478
 // So we create a dedicated class about how this attributes should be handled.
-// The idea to then create a Interface + Default implement and let users implements their own strategy depending of their understanding or needs.
+// The idea will be to create a Interface + Default implement and let users implements their own strategy depending of their understanding or needs.
 public class NotificationStrategy {
 
     protected Map<Type, CriteriaBasedOnValueChecker> checkers = new HashMap<>();

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -15,120 +15,66 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.eclipse.leshan.client.notification.checker.CriteriaBasedOnValueChecker;
-import org.eclipse.leshan.client.notification.checker.FloatChecker;
-import org.eclipse.leshan.client.notification.checker.IntegerChecker;
-import org.eclipse.leshan.client.notification.checker.UnsignedIntegerChecker;
-import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
-import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
-import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeModel;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
-import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mChildNode;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
-import org.eclipse.leshan.core.node.LwM2mResourceInstance;
-import org.eclipse.leshan.core.node.LwM2mSingleResource;
 
-// TODO write attributes : create an interface
-// The way write attribute should be handle is not clear in LWM2M specification (-_-!) ... which is not an ideal situation ...
-// See : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/478
-// So we create a dedicated class about how this attributes should be handled.
-// The idea will be to create a Interface + Default implement and let users implements their own strategy depending of their understanding or needs.
-public class NotificationStrategy {
+/**
+ * This class is responsible to implement how write attribute are assigned to given LWM2M node and how it should be
+ * handle.
+ * <p>
+ * This aims to provide some flexibility because LWM2M specification isn't really clear on this topic.
+ *
+ * @see <a href="https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/478"> Discussion about Write
+ *      Attributes on OMA LwM2M for Developers Github repository </a>
+ * @see DefaultNotificationStrategy
+ */
+public interface NotificationStrategy {
 
-    protected Map<Type, CriteriaBasedOnValueChecker> checkers = new HashMap<>();
+    /**
+     * Create a {@link NotificationAttributeTree} when observe relation is initiated with information needed later.
+     *
+     * @param path The path of the LWM2M node to observe
+     * @param attributes The whole {@link NotificationAttributeTree} currently attached to the object targeted by the
+     *        given path.
+     */
+    NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path, NotificationAttributeTree attributes);
 
-    public NotificationStrategy() {
-        checkers.put(Type.FLOAT, new FloatChecker());
-        checkers.put(Type.INTEGER, new IntegerChecker());
-        checkers.put(Type.UNSIGNED_INTEGER, new UnsignedIntegerChecker());
-    }
+    /**
+     * @param attributes The attributes returned by
+     *        {@link #selectNotificationsAttributes(LwM2mPath, NotificationAttributeTree)}
+     * @param path The path of the LWM2M node to observe
+     * @param model The {@link LwM2mAttributeModel} for which we want to know if the given attribute is assigned
+     */
+    boolean hasAttribute(NotificationAttributeTree attributes, LwM2mPath path, LwM2mAttributeModel<?> model);
 
-    public NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path,
-            NotificationAttributeTree attributes) {
+    /**
+     * @param attributes The attributes returned by
+     *        {@link #selectNotificationsAttributes(LwM2mPath, NotificationAttributeTree)}
+     * @param path The path of the LWM2M node to observe
+     * @param model he {@link LwM2mAttributeModel} for which we want to get the value
+     */
+    <T> T getAttributeValue(NotificationAttributeTree attributes, LwM2mPath path, LwM2mAttributeModel<T> model);
 
-        LwM2mAttributeSet set = attributes.getWithInheritance(path);
-        if (set == null || set.isEmpty()) {
-            return null;
-        }
-        NotificationAttributeTree result = new NotificationAttributeTree();
-        result.put(path, set);
-        return result;
-    }
+    /**
+     * @param attributes The attributes returned by
+     *        {@link #selectNotificationsAttributes(LwM2mPath, NotificationAttributeTree)}
+     * @param path The path of the LWM2M node to observe
+     * @return <code>True</code> some attributes assigned are based on value (e.g. gt, lt, st)
+     */
+    boolean hasCriteriaBasedOnValue(NotificationAttributeTree attributes, LwM2mPath path);
 
-    public boolean hasPmin(NotificationAttributeTree attributes, LwM2mPath path) {
-        return getPmin(path, attributes) != null;
-    }
-
-    public Long getPmin(LwM2mPath path, NotificationAttributeTree attributes) {
-        LwM2mAttributeSet set = attributes.get(path);
-        if (set == null)
-            return null;
-        else {
-            LwM2mAttribute<Long> pmin = set.get(LwM2mAttributes.MINIMUM_PERIOD);
-            if (pmin == null)
-                return null;
-            else
-                return pmin.getValue();
-        }
-    }
-
-    public boolean hasPmax(LwM2mPath path, NotificationAttributeTree attributes) {
-        return getPmax(path, attributes) != null;
-    }
-
-    public Long getPmax(LwM2mPath path, NotificationAttributeTree attributes) {
-        LwM2mAttributeSet set = attributes.get(path);
-        if (set == null)
-            return null;
-        else {
-            LwM2mAttribute<Long> pmax = set.get(LwM2mAttributes.MAXIMUM_PERIOD);
-            if (pmax == null)
-                return null;
-            else
-                return pmax.getValue();
-        }
-    }
-
-    public boolean hasCriteriaBasedOnValue(LwM2mPath path, NotificationAttributeTree attributes) {
-        LwM2mAttributeSet set = attributes.get(path);
-        return set != null && (set.contains(LwM2mAttributes.GREATER_THAN) || set.contains(LwM2mAttributes.LESSER_THAN)
-                || set.contains(LwM2mAttributes.STEP));
-    }
-
-    public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mPath path, NotificationAttributeTree attributes,
-            LwM2mNode lastSentNode, LwM2mChildNode newNode) {
-
-        // Get Previous and New Values
-        Object lastSentValue;
-        Object newValue;
-        Type resourceType;
-        if (lastSentNode instanceof LwM2mSingleResource && newNode instanceof LwM2mSingleResource) {
-            lastSentValue = ((LwM2mSingleResource) lastSentNode).getValue();
-            newValue = ((LwM2mSingleResource) newNode).getValue();
-            resourceType = ((LwM2mSingleResource) newNode).getType();
-        } else if (lastSentNode instanceof LwM2mResourceInstance && newNode instanceof LwM2mResourceInstance) {
-            lastSentValue = ((LwM2mResourceInstance) lastSentNode).getValue();
-            newValue = ((LwM2mResourceInstance) newNode).getValue();
-            resourceType = ((LwM2mResourceInstance) newNode).getType();
-        } else {
-            throw new IllegalArgumentException(String.format(
-                    "Unexpected nodes (last send node  %s new value %s) for check about value changed, only LwM2mSingleResource or LwM2mResourceInstance are supported",
-                    lastSentNode.getClass().getSimpleName(), newNode.getClass().getSimpleName()));
-        }
-
-        // Check criteria
-        CriteriaBasedOnValueChecker checker = checkers.get(resourceType);
-        if (checker == null) {
-            throw new IllegalArgumentException(
-                    String.format("Unexpected resource type : %s is not supported", resourceType));
-        }
-        LwM2mAttributeSet set = attributes.get(path);
-        return checker.shouldTriggerNotificationBasedOnValueChange(set, lastSentValue, newValue);
-    }
-
+    /**
+     * @param attributes The attributes returned by
+     *        {@link #selectNotificationsAttributes(LwM2mPath, NotificationAttributeTree)}
+     * @param path The path of the LWM2M node to observe
+     * @param lastSentNode The last LwM2mNode sent in a notification for this observe relation.
+     * @param newNode The a new value for which we should decide if a new notification should be sent following criteria
+     *        based on value.
+     * @return <code>True</code> if a new notification should be sent.
+     */
+    boolean shouldTriggerNotificationBasedOnValueChange(NotificationAttributeTree attributes, LwM2mPath path,
+            LwM2mNode lastSentNode, LwM2mChildNode newNode);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/NotificationStrategy.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification;
 
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeModel;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
 import org.eclipse.leshan.core.node.LwM2mChildNode;
@@ -39,8 +40,11 @@ public interface NotificationStrategy {
      * @param path The path of the LWM2M node to observe
      * @param attributes The whole {@link NotificationAttributeTree} currently attached to the object targeted by the
      *        given path.
+     *
+     * @throws InvalidAttributesException if current attributes configuration is inconsistent.
      */
-    NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path, NotificationAttributeTree attributes);
+    NotificationAttributeTree selectNotificationsAttributes(LwM2mPath path, NotificationAttributeTree attributes)
+            throws InvalidAttributesException;
 
     /**
      * @param attributes The attributes returned by

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification.checker;
+
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+
+public interface CriteriaBasedOnValueChecker {
+    boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
+            Object newValue);
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
@@ -15,9 +15,20 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification.checker;
 
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 
+/**
+ * A {@link CriteriaBasedOnValueChecker} MUST evaluate new value based on Notification {@link LwM2mAttribute} and
+ * previous value sent to determine if new notification should be sent.
+ */
 public interface CriteriaBasedOnValueChecker {
+    /**
+     * @param attributes {@link LwM2mAttributeSet} attached to the node.
+     * @param lastSentValue value sent in previous notification.
+     * @param newValue value for which it should be decided if a notification should be sent.
+     * @return <code>true</code> if new notification should be sent.
+     */
     boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
             Object newValue);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/CriteriaBasedOnValueChecker.java
@@ -21,6 +21,9 @@ import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 /**
  * A {@link CriteriaBasedOnValueChecker} MUST evaluate new value based on Notification {@link LwM2mAttribute} and
  * previous value sent to determine if new notification should be sent.
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/draft-ietf-core-dynlink-07#section-4.7">Attribute Interactions
+ *      </a>
  */
 public interface CriteriaBasedOnValueChecker {
     /**

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification.checker;
+
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+
+public class FloatChecker implements CriteriaBasedOnValueChecker {
+
+    @Override
+    public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
+            Object newValue) {
+        Double lastSentDouble = (Double) lastSentValue;
+        Double newDouble = (Double) newValue;
+
+        if (attributes.contains(LwM2mAttributes.STEP)) {
+            return Math.abs(lastSentDouble - newDouble) >= attributes.get(LwM2mAttributes.STEP).getValue();
+        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            return lastSentDouble >= lessThan && newDouble < lessThan;
+        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            Double greaterThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            return lastSentDouble <= greaterThan && newDouble < greaterThan;
+        }
+        return true;
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
@@ -17,7 +17,12 @@ package org.eclipse.leshan.client.notification.checker;
 
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
 
+/**
+ * A {@link CriteriaBasedOnValueChecker} for {@link LwM2mResource} of {@link Type#FLOAT}
+ */
 public class FloatChecker implements CriteriaBasedOnValueChecker {
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
@@ -30,16 +30,35 @@ public class FloatChecker implements CriteriaBasedOnValueChecker {
             Object newValue) {
         Double lastSentDouble = (Double) lastSentValue;
         Double newDouble = (Double) newValue;
+        boolean hasNumericalAttributes = false;
 
         if (attributes.contains(LwM2mAttributes.STEP)) {
-            return Math.abs(lastSentDouble - newDouble) >= attributes.get(LwM2mAttributes.STEP).getValue();
-        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
-            Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
-            return lastSentDouble >= lessThan && newDouble < lessThan;
-        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
-            Double greaterThan = attributes.get(LwM2mAttributes.GREATER_THAN).getValue();
-            return lastSentDouble <= greaterThan && newDouble > greaterThan;
+            hasNumericalAttributes = true;
+
+            if (Math.abs(lastSentDouble - newDouble) >= attributes.get(LwM2mAttributes.STEP).getValue()) {
+                return true;
+            }
         }
-        return true;
+
+        if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            hasNumericalAttributes = true;
+
+            Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            if (lastSentDouble >= lessThan && newDouble < lessThan) {
+                return true;
+            }
+        }
+
+        if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            hasNumericalAttributes = true;
+
+            Double greaterThan = attributes.get(LwM2mAttributes.GREATER_THAN).getValue();
+            if (lastSentDouble <= greaterThan && newDouble > greaterThan) {
+                return true;
+            }
+        }
+
+        // if we have numerical attribute we can send notification else if one condition matches we already return true;
+        return !hasNumericalAttributes;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/FloatChecker.java
@@ -32,8 +32,8 @@ public class FloatChecker implements CriteriaBasedOnValueChecker {
             Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
             return lastSentDouble >= lessThan && newDouble < lessThan;
         } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
-            Double greaterThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
-            return lastSentDouble <= greaterThan && newDouble < greaterThan;
+            Double greaterThan = attributes.get(LwM2mAttributes.GREATER_THAN).getValue();
+            return lastSentDouble <= greaterThan && newDouble > greaterThan;
         }
         return true;
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification.checker;
+
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+
+public class IntegerChecker implements CriteriaBasedOnValueChecker {
+
+    @Override
+    public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
+            Object newValue) {
+        Long lastSentLong = (Long) lastSentValue;
+        Long newLong = (Long) newValue;
+
+        if (attributes.contains(LwM2mAttributes.STEP)) {
+            return Math.abs(lastSentLong - newLong) >= attributes.get(LwM2mAttributes.STEP).getValue();
+        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            return lastSentLong >= lessThan && newLong < lessThan;
+        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            Double greaterThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            return lastSentLong <= greaterThan && newLong < greaterThan;
+        }
+        return true;
+    }
+
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
@@ -32,8 +32,8 @@ public class IntegerChecker implements CriteriaBasedOnValueChecker {
             Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
             return lastSentLong >= lessThan && newLong < lessThan;
         } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
-            Double greaterThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
-            return lastSentLong <= greaterThan && newLong < greaterThan;
+            Double greaterThan = attributes.get(LwM2mAttributes.GREATER_THAN).getValue();
+            return lastSentLong <= greaterThan && newLong > greaterThan;
         }
         return true;
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
@@ -29,10 +29,10 @@ public class IntegerChecker implements CriteriaBasedOnValueChecker {
         if (attributes.contains(LwM2mAttributes.STEP)) {
             return Math.abs(lastSentLong - newLong) >= attributes.get(LwM2mAttributes.STEP).getValue();
         } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
-            Double lessThan = attributes.get(LwM2mAttributes.LESSER_THAN).getValue();
+            long lessThan = (long) Math.ceil(attributes.get(LwM2mAttributes.LESSER_THAN).getValue());
             return lastSentLong >= lessThan && newLong < lessThan;
         } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
-            Double greaterThan = attributes.get(LwM2mAttributes.GREATER_THAN).getValue();
+            long greaterThan = (long) Math.floor(attributes.get(LwM2mAttributes.GREATER_THAN).getValue());
             return lastSentLong <= greaterThan && newLong > greaterThan;
         }
         return true;

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
@@ -17,7 +17,12 @@ package org.eclipse.leshan.client.notification.checker;
 
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
 
+/**
+ * A {@link CriteriaBasedOnValueChecker} for {@link LwM2mResource} of {@link Type#INTEGER}
+ */
 public class IntegerChecker implements CriteriaBasedOnValueChecker {
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/IntegerChecker.java
@@ -30,17 +30,35 @@ public class IntegerChecker implements CriteriaBasedOnValueChecker {
             Object newValue) {
         Long lastSentLong = (Long) lastSentValue;
         Long newLong = (Long) newValue;
+        boolean hasNumericalAttributes = false;
 
         if (attributes.contains(LwM2mAttributes.STEP)) {
-            return Math.abs(lastSentLong - newLong) >= attributes.get(LwM2mAttributes.STEP).getValue();
-        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
-            long lessThan = (long) Math.ceil(attributes.get(LwM2mAttributes.LESSER_THAN).getValue());
-            return lastSentLong >= lessThan && newLong < lessThan;
-        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
-            long greaterThan = (long) Math.floor(attributes.get(LwM2mAttributes.GREATER_THAN).getValue());
-            return lastSentLong <= greaterThan && newLong > greaterThan;
+            hasNumericalAttributes = true;
+
+            if (Math.abs(lastSentLong - newLong) >= attributes.get(LwM2mAttributes.STEP).getValue()) {
+                return true;
+            }
         }
-        return true;
+
+        if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            hasNumericalAttributes = true;
+
+            long lessThan = (long) Math.ceil(attributes.get(LwM2mAttributes.LESSER_THAN).getValue());
+            if (lastSentLong >= lessThan && newLong < lessThan) {
+                return true;
+            }
+        }
+
+        if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            hasNumericalAttributes = true;
+
+            long greaterThan = (long) Math.floor(attributes.get(LwM2mAttributes.GREATER_THAN).getValue());
+            if (lastSentLong <= greaterThan && newLong > greaterThan) {
+                return true;
+            }
+        }
+        // if we have numerical attribute we can send notification else if one condition matches we already return true;
+        return !hasNumericalAttributes;
     }
 
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.notification.checker;
+
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+
+public class UnsignedIntegerChecker implements CriteriaBasedOnValueChecker {
+
+    @Override
+    public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
+            Object newValue) {
+//        ULong lastSentULong = (ULong) lastSentValue;
+//        ULong newULong = (ULong) newValue;
+
+        throw new IllegalStateException("Not implemented yet");
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
@@ -21,8 +21,13 @@ import java.math.RoundingMode;
 
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.util.datatype.ULong;
 
+/**
+ * A {@link CriteriaBasedOnValueChecker} for {@link LwM2mResource} of {@link Type#UNSIGNED_INTEGER}
+ */
 public class UnsignedIntegerChecker implements CriteriaBasedOnValueChecker {
 
     @Override

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
@@ -35,23 +35,42 @@ public class UnsignedIntegerChecker implements CriteriaBasedOnValueChecker {
             Object newValue) {
         BigInteger lastSentULong = ((ULong) lastSentValue).toBigInteger();
         BigInteger newULong = ((ULong) newValue).toBigInteger();
+        boolean hasNumericalAttributes = false;
 
         if (attributes.contains(LwM2mAttributes.STEP)) {
+            hasNumericalAttributes = true;
+
             // Handle Step
             BigInteger step = new BigDecimal(attributes.get(LwM2mAttributes.STEP).getValue())
                     .setScale(0, RoundingMode.CEILING).toBigIntegerExact();
-            return lastSentULong.subtract(newULong).abs().subtract(step).signum() >= 0;
-        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            if (lastSentULong.subtract(newULong).abs().subtract(step).signum() >= 0) {
+                return true;
+            }
+        }
+
+        if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            hasNumericalAttributes = true;
+
             // Handle LESSER_THAN
             BigDecimal lessThan = new BigDecimal(attributes.get(LwM2mAttributes.LESSER_THAN).getValue());
             BigInteger lessThanRounded = lessThan.setScale(0, RoundingMode.CEILING).toBigIntegerExact();
-            return lastSentULong.compareTo(lessThanRounded) >= 0 && newULong.compareTo(lessThanRounded) < 0;
-        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            if (lastSentULong.compareTo(lessThanRounded) >= 0 && newULong.compareTo(lessThanRounded) < 0) {
+                return true;
+            }
+        }
+
+        if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            hasNumericalAttributes = true;
+
             // Handle LESSER_THAN
             BigDecimal lessThan = new BigDecimal(attributes.get(LwM2mAttributes.GREATER_THAN).getValue());
             BigInteger lessThanRounded = lessThan.setScale(0, RoundingMode.FLOOR).toBigIntegerExact();
-            return lastSentULong.compareTo(lessThanRounded) <= 0 && newULong.compareTo(lessThanRounded) > 0;
+            if (lastSentULong.compareTo(lessThanRounded) <= 0 && newULong.compareTo(lessThanRounded) > 0) {
+                return true;
+            }
         }
-        return true;
+
+        // if we have numerical attribute we can send notification else if one condition matches we already return true;
+        return !hasNumericalAttributes;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/notification/checker/UnsignedIntegerChecker.java
@@ -15,16 +15,38 @@
  *******************************************************************************/
 package org.eclipse.leshan.client.notification.checker;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.util.datatype.ULong;
 
 public class UnsignedIntegerChecker implements CriteriaBasedOnValueChecker {
 
     @Override
     public boolean shouldTriggerNotificationBasedOnValueChange(LwM2mAttributeSet attributes, Object lastSentValue,
             Object newValue) {
-//        ULong lastSentULong = (ULong) lastSentValue;
-//        ULong newULong = (ULong) newValue;
+        BigInteger lastSentULong = ((ULong) lastSentValue).toBigInteger();
+        BigInteger newULong = ((ULong) newValue).toBigInteger();
 
-        throw new IllegalStateException("Not implemented yet");
+        if (attributes.contains(LwM2mAttributes.STEP)) {
+            // Handle Step
+            BigInteger step = new BigDecimal(attributes.get(LwM2mAttributes.STEP).getValue())
+                    .setScale(0, RoundingMode.CEILING).toBigIntegerExact();
+            return lastSentULong.subtract(newULong).abs().subtract(step).signum() >= 0;
+        } else if (attributes.contains(LwM2mAttributes.LESSER_THAN)) {
+            // Handle LESSER_THAN
+            BigDecimal lessThan = new BigDecimal(attributes.get(LwM2mAttributes.LESSER_THAN).getValue());
+            BigInteger lessThanRounded = lessThan.setScale(0, RoundingMode.CEILING).toBigIntegerExact();
+            return lastSentULong.compareTo(lessThanRounded) >= 0 && newULong.compareTo(lessThanRounded) < 0;
+        } else if (attributes.contains(LwM2mAttributes.GREATER_THAN)) {
+            // Handle LESSER_THAN
+            BigDecimal lessThan = new BigDecimal(attributes.get(LwM2mAttributes.GREATER_THAN).getValue());
+            BigInteger lessThanRounded = lessThan.setScale(0, RoundingMode.FLOOR).toBigIntegerExact();
+            return lastSentULong.compareTo(lessThanRounded) <= 0 && newULong.compareTo(lessThanRounded) > 0;
+        }
+        return true;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -582,12 +582,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
     }
 
     @Override
-    public NotificationAttributeTree getAttributesFor(LwM2mPath path) {
-        // check we ask for supported path
-        if (!path.startWith(new LwM2mPath(id))) {
-            throw new IllegalStateException("Path doesn't concern object " + getId());
-        }
-
+    public NotificationAttributeTree getAttributesFor(LwM2mServer server) {
         return assignedAttributes;
     }
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -93,6 +93,8 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
             @Override
             public void resourceChanged(LwM2mPath... paths) {
                 synchronized (BaseObjectEnabler.this) {
+                    // Assigned attributes housekeeping : if resource instance is removed we removed attached
+                    // attributes.
                     for (LwM2mPath p : paths) {
                         if (p.isResource()) {
                             ResourceModel resourceModel = objectModel.resources.get(p.getResourceId());
@@ -121,6 +123,8 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
             @Override
             public void objectInstancesRemoved(LwM2mObjectEnabler object, int... instanceIds) {
                 synchronized (BaseObjectEnabler.this) {
+                    // Assigned attributes housekeeping : if object instance is removed we removed attached
+                    // attributes.
                     for (int instanceId : instanceIds) {
                         assignedAttributes.removeAllUnder(new LwM2mPath(getId(), instanceId));
                     }
@@ -437,12 +441,13 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
         // apply new attribute values
         LwM2mAttributeSet currentAttributes = assignedAttributes.get(request.getPath());
         LwM2mAttributeSet newValue;
-        if (currentAttributes != null)
+        if (currentAttributes != null) {
             newValue = currentAttributes.apply(request.getAttributes());
-        else
+        } else {
             newValue = request.getAttributes();
+        }
 
-        // TODO validate new value based on model.
+        // TODO write attributes : validate new value based on model.
         if (newValue.isEmpty()) {
             assignedAttributes.remove(request.getPath());
         } else {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/BaseObjectEnabler.java
@@ -35,6 +35,7 @@ import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
 import org.eclipse.leshan.core.LwM2mId;
 import org.eclipse.leshan.core.link.lwm2m.LwM2mLink;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -82,6 +83,7 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
 
     private LwM2mClient lwm2mClient;
     private LinkFormatHelper linkFormatHelper;
+
     private final NotificationAttributeTree assignedAttributes = new NotificationAttributeTree();
 
     public BaseObjectEnabler(int id, ObjectModel objectModel) {
@@ -446,8 +448,12 @@ public abstract class BaseObjectEnabler implements LwM2mObjectEnabler {
         } else {
             newValue = request.getAttributes();
         }
+        try {
+            newValue.validate(request.getPath(), getObjectModel());
+        } catch (InvalidAttributesException e) {
+            return WriteAttributesResponse.badRequest(e.getMessage());
+        }
 
-        // TODO write attributes : validate new value based on model.
         if (newValue.isEmpty()) {
             assignedAttributes.remove(request.getPath());
         } else {

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
@@ -25,7 +25,9 @@ import org.eclipse.leshan.client.util.LinkFormatHelper;
 import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.Startable;
 import org.eclipse.leshan.core.Stoppable;
+import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
 import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.BootstrapReadRequest;
@@ -115,4 +117,6 @@ public interface LwM2mObjectEnabler {
     void endTransaction(byte level);
 
     ContentFormat getDefaultEncodingFormat(DownlinkRequest<?> request);
+
+    NotificationAttributeTree getAttributesFor(LwM2mPath path);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/LwM2mObjectEnabler.java
@@ -27,7 +27,6 @@ import org.eclipse.leshan.core.Startable;
 import org.eclipse.leshan.core.Stoppable;
 import org.eclipse.leshan.core.link.lwm2m.attributes.NotificationAttributeTree;
 import org.eclipse.leshan.core.model.ObjectModel;
-import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.BootstrapDeleteRequest;
 import org.eclipse.leshan.core.request.BootstrapDiscoverRequest;
 import org.eclipse.leshan.core.request.BootstrapReadRequest;
@@ -118,5 +117,5 @@ public interface LwM2mObjectEnabler {
 
     ContentFormat getDefaultEncodingFormat(DownlinkRequest<?> request);
 
-    NotificationAttributeTree getAttributesFor(LwM2mPath path);
+    NotificationAttributeTree getAttributesFor(LwM2mServer server);
 }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/NotificationSender.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/resource/NotificationSender.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.resource;
+
+import org.eclipse.leshan.core.response.ObserveResponse;
+
+public interface NotificationSender {
+    /**
+     * Send notification, return false if there is no more observe relation.
+     */
+    boolean sendNotification(ObserveResponse response);
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/DefaultLwM2mLinkParser.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/DefaultLwM2mLinkParser.java
@@ -28,6 +28,7 @@ import org.eclipse.leshan.core.link.attributes.AttributeModel;
 import org.eclipse.leshan.core.link.attributes.Attributes;
 import org.eclipse.leshan.core.link.attributes.DefaultAttributeParser;
 import org.eclipse.leshan.core.link.attributes.ResourceTypeAttribute;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
@@ -103,7 +104,7 @@ public class DefaultLwM2mLinkParser implements LwM2mLinkParser {
 
                 // create link and replace it
                 lwm2mLinks[i] = new LwM2mLink(rootpath, new LwM2mPath(path), lwm2mAttrSet);
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalArgumentException | InvalidAttributesException e) {
                 String strLink = new String(bytes, StandardCharsets.UTF_8);
                 throw new LinkParseException(e, "Unable to parse link %s in %s", links[i], strLink);
             }
@@ -150,7 +151,7 @@ public class DefaultLwM2mLinkParser implements LwM2mLinkParser {
 
                     // create link and replace it
                     links[i] = new MixedLwM2mLink(rootPath, lwm2mPath, attributes);
-                } catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException | InvalidAttributesException e) {
                     String strLink = new String(bytes, StandardCharsets.UTF_8);
                     throw new LinkParseException(e, "Unable to parse link %s in %s", links[i], strLink);
                 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/InvalidAttributesException.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/InvalidAttributesException.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.link.lwm2m.attributes;
+
+/**
+ * Exception raised when a collection of Attribute are not valid.
+ */
+public class InvalidAttributesException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public InvalidAttributesException(String message) {
+        super(message);
+    }
+
+    public InvalidAttributesException(String message, Object... args) {
+        super(String.format(message, args));
+    }
+
+    public InvalidAttributesException(Exception e, String message, Object... args) {
+        super(String.format(message, args), e);
+    }
+
+    public InvalidAttributesException(String message, Exception e) {
+        super(message, e);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeModel.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeModel.java
@@ -18,7 +18,7 @@ package org.eclipse.leshan.core.link.lwm2m.attributes;
 import java.util.Set;
 
 import org.eclipse.leshan.core.link.attributes.AttributeModel;
-import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mPath;
 
 /**
@@ -97,7 +97,7 @@ public abstract class LwM2mAttributeModel<T> extends AttributeModel<LwM2mAttribu
      * @param model the LWM2M model used, if this model is null checks which need model will be ignored.
      * @return null is the attribute can be applied to the LWM2M node identified by the given path.
      */
-    public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+    public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
         if (!canBeAttachedTo(Attachment.fromPath(path))) {
             return String.format("%s attribute is only applicable to %s, and so can not be attached to %s", getName(),
                     getAttachment(), path);

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributes.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributes.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.LwM2mId;
-import org.eclipse.leshan.core.model.LwM2mModel;
+import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.node.LwM2mPath;
 
@@ -44,14 +44,14 @@ public final class LwM2mAttributes {
         };
 
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
 
             if (model != null) {
                 // here the path should be a resource path one.
-                ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                ResourceModel resourceModel = model.resources.get(path.getResourceId());
                 if (resourceModel != null && !resourceModel.multiple) {
                     return "'Dimension' attribute is only applicable to multi-Instance resource";
                 }
@@ -74,7 +74,7 @@ public final class LwM2mAttributes {
         };
 
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -101,7 +101,7 @@ public final class LwM2mAttributes {
             AttributeClass.PROPERTIES) {
 
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -126,7 +126,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -135,7 +135,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null && !resourceModel.operations.isReadable()) {
                         return "'pmin' attribute  can not be applied to not readable resource";
                     }
@@ -153,7 +153,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -162,7 +162,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null && !resourceModel.operations.isReadable()) {
                         return "'pmax' attribute can not be applied to not readable resource";
                     }
@@ -180,7 +180,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -189,7 +189,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null) {
                         if (!resourceModel.operations.isReadable()) {
                             return "'gt' attribute is can not be applied to not readable resource";
@@ -212,7 +212,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -221,7 +221,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null) {
                         if (!resourceModel.operations.isReadable()) {
                             return "'lt' attribute is can not be applied to not readable resource";
@@ -242,7 +242,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -251,7 +251,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null) {
                         if (!resourceModel.operations.isReadable()) {
                             return "'st' attribute is can not be applied to not readable resource";
@@ -274,7 +274,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -283,7 +283,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null && !resourceModel.operations.isReadable()) {
                         return "'epmin' attribute is can not be applied to not readable resource";
                     }
@@ -301,7 +301,7 @@ public final class LwM2mAttributes {
             AccessMode.RW, //
             AttributeClass.NOTIFICATION) {
         @Override
-        public String getApplicabilityError(LwM2mPath path, LwM2mModel model) {
+        public String getApplicabilityError(LwM2mPath path, ObjectModel model) {
             String error = super.getApplicabilityError(path, model);
             if (error != null)
                 return error;
@@ -310,7 +310,7 @@ public final class LwM2mAttributes {
                 Integer resourceId = path.getResourceId();
                 if (resourceId != null) {
                     // if assigned to at least resource level.
-                    ResourceModel resourceModel = model.getResourceModel(path.getObjectId(), path.getResourceId());
+                    ResourceModel resourceModel = model.resources.get(path.getResourceId());
                     if (resourceModel != null && !resourceModel.operations.isReadable()) {
                         return "'epmax' attribute is can not be applied to not readable resource";
                     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
@@ -126,10 +126,26 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         }
         if (attributes != null) {
             for (LwM2mAttribute<?> attr : attributes.getLwM2mAttributes()) {
-                merged.put(attr.getName(), attr);
+                if (attr.hasValue()) {
+                    merged.put(attr.getName(), attr);
+                } else {
+                    merged.remove(attr.getName());
+                }
             }
         }
         return new LwM2mAttributeSet(merged.values());
+    }
+
+    /**
+     * Creates a new AttributeSet by merging given attributes.
+     *
+     * @param attributes the array that should be merged onto this instance. Attributes in this array will overwrite
+     *        existing attribute values, if present. If this is null, the new attribute set will effectively be a clone
+     *        of the existing one
+     * @return the merged AttributeSet
+     */
+    public LwM2mAttributeSet merge(LwM2mAttribute<?>... attributes) {
+        return this.merge(new LwM2mAttributeSet(attributes));
     }
 
     /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
@@ -133,6 +133,27 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
     }
 
     /**
+     * Like {@link #merge(LwM2mAttributeSet)} except if a given {@link LwM2mAttribute} has no value, it will remove this
+     * attribute from final result.
+     */
+    public LwM2mAttributeSet apply(LwM2mAttributeSet attributes) {
+        Map<String, LwM2mAttribute<?>> merged = new LinkedHashMap<>();
+        for (LwM2mAttribute<?> attr : getLwM2mAttributes()) {
+            merged.put(attr.getName(), attr);
+        }
+        if (attributes != null) {
+            for (LwM2mAttribute<?> attr : attributes.getLwM2mAttributes()) {
+                if (attr.hasValue()) {
+                    merged.put(attr.getName(), attr);
+                } else {
+                    merged.remove(attr.getName());
+                }
+            }
+        }
+        return new LwM2mAttributeSet(merged.values());
+    }
+
+    /**
      * Returns the attributes as a map with the CoRELinkParam as key and the attribute value as map value.
      *
      * @return the attributes map

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
@@ -99,8 +99,8 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         LwM2mAttribute<Long> pmax = this.getLwM2mAttribute(LwM2mAttributes.MAXIMUM_PERIOD);
         if ((pmin != null) && (pmax != null) //
                 && pmin.hasValue() && pmax.hasValue() //
-                && pmin.getValue() > pmax.getValue()) {
-            throw new InvalidAttributesException("Cannot write attributes where '%s' > '%s'", pmin.getName(),
+                && !(pmin.getValue() <= pmax.getValue())) {
+            throw new InvalidAttributesException("Attributes doesn't fulfill '%s'<= '%s' condition", pmin.getName(),
                     pmax.getName());
         }
 
@@ -110,8 +110,8 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         LwM2mAttribute<Long> epmax = this.getLwM2mAttribute(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD);
         if ((epmin != null) && (epmax != null) //
                 && epmin.hasValue() && epmax.hasValue() //
-                && epmin.getValue() > epmax.getValue()) {
-            throw new InvalidAttributesException("Cannot write attributes where '%s' > '%s'", epmin.getName(),
+                && !(epmin.getValue() <= epmax.getValue())) {
+            throw new InvalidAttributesException("Attributes doesn't fulfill '%s'<= '%s' condition", epmin.getName(),
                     epmax.getName());
         }
 
@@ -122,7 +122,7 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         if ((lt != null) && (gt != null) //
                 && lt.hasValue() && gt.hasValue() //
                 && !(lt.getValue() < gt.getValue())) {
-            throw new InvalidAttributesException("Cannot write attributes where '%s' >= '%s'", lt.getName(),
+            throw new InvalidAttributesException("Attributes doesn't fulfill '%s'< '%s' condition", lt.getName(),
                     gt.getName());
         }
 
@@ -132,8 +132,8 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         if ((lt != null) && (gt != null) && (st != null) ///
                 && lt.hasValue() && gt.hasValue() && st.hasValue() //
                 && !(lt.getValue() + 2 * st.getValue() < gt.getValue())) {
-            throw new InvalidAttributesException("Cannot write attributes where '%s' >= '%s'", lt.getName(),
-                    gt.getName());
+            throw new InvalidAttributesException(
+                    "Attributes doesn't fulfill  (\"lt\" value + 2*\"st\" values) <\"gt\") condition");
         }
     }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/MixedLwM2mAttributeSet.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.link.attributes.AttributeSet;
+import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.node.LwM2mPath;
 
 /**
@@ -90,25 +91,65 @@ public class MixedLwM2mAttributeSet extends AttributeSet {
         };
     }
 
-    public void validate(LwM2mPath path) {
-        // Can all attributes be assigned to this path
-        for (LwM2mAttribute<?> attr : getLwM2mAttributes()) {
-            String errorMessage = attr.getModel().getApplicabilityError(path, null);
-            if (errorMessage != null) {
-                throw new IllegalArgumentException(errorMessage);
-            }
+    public void validate() throws InvalidAttributesException {
+        // check some consistency about attribute set
+        // pmin SHOULD BE LESSER or EQUAL TO pmax
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-dynlink-07#section-4.2
+        LwM2mAttribute<Long> pmin = this.getLwM2mAttribute(LwM2mAttributes.MINIMUM_PERIOD);
+        LwM2mAttribute<Long> pmax = this.getLwM2mAttribute(LwM2mAttributes.MAXIMUM_PERIOD);
+        if ((pmin != null) && (pmax != null) //
+                && pmin.hasValue() && pmax.hasValue() //
+                && pmin.getValue() > pmax.getValue()) {
+            throw new InvalidAttributesException("Cannot write attributes where '%s' > '%s'", pmin.getName(),
+                    pmax.getName());
+        }
+
+        // epmin SHOULD BE LESSER or EQUAL TO epmax
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-conditional-attributes-06#section-3.2.4
+        LwM2mAttribute<Long> epmin = this.getLwM2mAttribute(LwM2mAttributes.EVALUATE_MINIMUM_PERIOD);
+        LwM2mAttribute<Long> epmax = this.getLwM2mAttribute(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD);
+        if ((epmin != null) && (epmax != null) //
+                && epmin.hasValue() && epmax.hasValue() //
+                && epmin.getValue() > epmax.getValue()) {
+            throw new InvalidAttributesException("Cannot write attributes where '%s' > '%s'", epmin.getName(),
+                    epmax.getName());
+        }
+
+        // "lt" value < "gt" value MUST BE TRUE
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-0-73-Attributes
+        LwM2mAttribute<Double> lt = this.getLwM2mAttribute(LwM2mAttributes.LESSER_THAN);
+        LwM2mAttribute<Double> gt = this.getLwM2mAttribute(LwM2mAttributes.GREATER_THAN);
+        if ((lt != null) && (gt != null) //
+                && lt.hasValue() && gt.hasValue() //
+                && !(lt.getValue() < gt.getValue())) {
+            throw new InvalidAttributesException("Cannot write attributes where '%s' >= '%s'", lt.getName(),
+                    gt.getName());
+        }
+
+        // ("lt" value + 2*"st" values) <"gt" value MUST BE TRUE
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-0-73-Attributes
+        LwM2mAttribute<Double> st = this.getLwM2mAttribute(LwM2mAttributes.STEP);
+        if ((lt != null) && (gt != null) && (st != null) ///
+                && lt.hasValue() && gt.hasValue() && st.hasValue() //
+                && !(lt.getValue() + 2 * st.getValue() < gt.getValue())) {
+            throw new InvalidAttributesException("Cannot write attributes where '%s' >= '%s'", lt.getName(),
+                    gt.getName());
         }
     }
 
-    // TODO not sure we still need this function
-    public void validate(Attachment attachment) {
-        // Can all attributes be assigned to this level?
+    public void validate(LwM2mPath path) throws InvalidAttributesException {
+        validate(path, null);
+    }
+
+    public void validate(LwM2mPath path, ObjectModel objectModel) throws InvalidAttributesException {
+        // Can all attributes be assigned to this path
         for (LwM2mAttribute<?> attr : getLwM2mAttributes()) {
-            if (!attr.canBeAttachedTo(attachment)) {
-                throw new IllegalArgumentException(String.format("Attribute '%s' cannot be attached to level %s",
-                        attr.getName(), attachment.name()));
+            String errorMessage = attr.getModel().getApplicabilityError(path, objectModel);
+            if (errorMessage != null) {
+                throw new InvalidAttributesException(errorMessage);
             }
         }
+        validate();
     }
 
     /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.link.lwm2m.attributes;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import org.eclipse.leshan.core.node.LwM2mPath;
+
+public class NotificationAttributeTree {
+
+    NavigableMap<LwM2mPath, LwM2mAttributeSet> internalTree = new TreeMap<>();
+
+    public void put(LwM2mPath path, LwM2mAttributeSet newValue) {
+        internalTree.put(path, newValue);
+    }
+
+    public void remove(LwM2mPath path) {
+        internalTree.remove(path);
+
+    }
+
+    public LwM2mAttributeSet get(LwM2mPath path) {
+        return internalTree.get(path);
+    }
+}

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
@@ -36,4 +36,29 @@ public class NotificationAttributeTree {
     public LwM2mAttributeSet get(LwM2mPath path) {
         return internalTree.get(path);
     }
+
+    /**
+     * @return {@link LwM2mAttributeSet} attached to given level merged with value inherited from higher level.
+     *
+     * @See https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-2-0-732-lessNOTIFICATIONgreater-Class-Attributes
+     */
+    public LwM2mAttributeSet getWithInheritance(LwM2mPath path) {
+        // For Root Path no need to "flatten" hierarchy
+        if (path.isRoot()) {
+            return get(path);
+        }
+
+        // For not root path
+        // Create Attribute Set taking inherited value into account.
+        LwM2mAttributeSet result = get(path);
+        LwM2mPath parentPath = path.toParenPath();
+        while (!parentPath.isRoot()) {
+            LwM2mAttributeSet parentAttributes = get(parentPath);
+            if (parentAttributes != null) {
+                result = parentAttributes.merge(result);
+            }
+            parentPath = parentPath.toParenPath();
+        }
+        return result;
+    }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
@@ -52,7 +52,9 @@ public class NotificationAttributeTree {
     /**
      * @return {@link LwM2mAttributeSet} attached to given level merged with value inherited from higher level.
      *
-     * @See https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-2-0-732-lessNOTIFICATIONgreater-Class-Attributes
+     * @see <a href=
+     *      "https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-2-0-732-lessNOTIFICATIONgreater-Class-Attributes">LWM2M-v1.2.1@core7.3.2.
+     *      NOTIFICATION Class Attributes</a>
      */
     public LwM2mAttributeSet getWithInheritance(LwM2mPath path) {
         // For Root Path no need to "flatten" hierarchy

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
@@ -21,18 +21,28 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.eclipse.leshan.core.node.LwM2mPath;
 
+/**
+ * A kind of tree structure which stores {@link LwM2mAttributeSet} by {@link LwM2mPath}.
+ */
 public class NotificationAttributeTree {
 
     private final ConcurrentNavigableMap<LwM2mPath, LwM2mAttributeSet> internalTree = new ConcurrentSkipListMap<>();
 
     public void put(LwM2mPath path, LwM2mAttributeSet newValue) {
-        internalTree.put(path, newValue);
+        if (newValue.isEmpty()) {
+            internalTree.remove(path);
+        } else {
+            internalTree.put(path, newValue);
+        }
     }
 
     public void remove(LwM2mPath path) {
         internalTree.remove(path);
     }
 
+    /**
+     * Remove all attribute for the given {@link LwM2mPath} and all its children.
+     */
     public void removeAllUnder(LwM2mPath parentPath) {
         internalTree.subMap(parentPath, true, parentPath.toMaxDescendant(), true).clear();
     }
@@ -45,6 +55,10 @@ public class NotificationAttributeTree {
         return internalTree.get(path);
     }
 
+    /**
+     * @return all children {@link LwM2mPath} of given parent {@link LwM2mPath} which have attached
+     *         {@link LwM2mAttributeSet}
+     */
     public Set<LwM2mPath> getChildren(LwM2mPath parentPath) {
         return internalTree.subMap(parentPath, false, parentPath.toMaxDescendant(), true).keySet();
     }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/NotificationAttributeTree.java
@@ -15,14 +15,15 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.lwm2m.attributes;
 
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.Set;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.eclipse.leshan.core.node.LwM2mPath;
 
 public class NotificationAttributeTree {
 
-    NavigableMap<LwM2mPath, LwM2mAttributeSet> internalTree = new TreeMap<>();
+    private final ConcurrentNavigableMap<LwM2mPath, LwM2mAttributeSet> internalTree = new ConcurrentSkipListMap<>();
 
     public void put(LwM2mPath path, LwM2mAttributeSet newValue) {
         internalTree.put(path, newValue);
@@ -30,11 +31,22 @@ public class NotificationAttributeTree {
 
     public void remove(LwM2mPath path) {
         internalTree.remove(path);
+    }
 
+    public void removeAllUnder(LwM2mPath parentPath) {
+        internalTree.subMap(parentPath, true, parentPath.toMaxDescendant(), true).clear();
+    }
+
+    public boolean isEmpty() {
+        return internalTree.isEmpty();
     }
 
     public LwM2mAttributeSet get(LwM2mPath path) {
         return internalTree.get(path);
+    }
+
+    public Set<LwM2mPath> getChildren(LwM2mPath parentPath) {
+        return internalTree.subMap(parentPath, false, parentPath.toMaxDescendant(), true).keySet();
     }
 
     /**

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
@@ -16,9 +16,9 @@
 package org.eclipse.leshan.core.request;
 
 import org.eclipse.leshan.core.link.lwm2m.attributes.AttributeClass;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
-import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
@@ -84,28 +84,9 @@ public class WriteAttributesRequest extends AbstractSimpleDownlinkRequest<WriteA
         }
         try {
             attributes.validate(path);
-
-        } catch (IllegalArgumentException e) {
+        } catch (InvalidAttributesException e) {
             throw new InvalidRequestException(e, "Some attributes are not valid for the path %s.", path);
         }
-
-        // check some consistency about attribute set
-        LwM2mAttribute<Long> pmin = attributes.getLwM2mAttribute(LwM2mAttributes.MINIMUM_PERIOD);
-        LwM2mAttribute<Long> pmax = attributes.getLwM2mAttribute(LwM2mAttributes.MAXIMUM_PERIOD);
-        if ((pmin != null) && (pmax != null) && pmin.hasValue() && pmax.hasValue()
-                && pmin.getValue() > pmax.getValue()) {
-            throw new InvalidRequestException("Cannot write attributes where '%s' > '%s'", pmin.getName(),
-                    pmax.getName());
-        }
-
-        LwM2mAttribute<Long> epmin = attributes.getLwM2mAttribute(LwM2mAttributes.EVALUATE_MINIMUM_PERIOD);
-        LwM2mAttribute<Long> epmax = attributes.getLwM2mAttribute(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD);
-        if ((epmin != null) && (epmax != null) && epmin.hasValue() && epmax.hasValue()
-                && epmin.getValue() > epmax.getValue()) {
-            throw new InvalidRequestException("Cannot write attributes where '%s' > '%s'", epmin.getName(),
-                    epmax.getName());
-        }
-
     }
 
     @Override

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
@@ -23,11 +23,13 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.eclipse.leshan.core.LwM2m.Version;
-import org.eclipse.leshan.core.link.lwm2m.attributes.Attachment;
 import org.eclipse.leshan.core.link.lwm2m.attributes.DefaultLwM2mAttributeParser;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeParser;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
 
 public class AttributeSetTest {
@@ -134,24 +136,24 @@ public class AttributeSetTest {
     }
 
     @Test
-    public void should_validate_assignation() {
+    public void should_validate_assignation() throws InvalidLwM2mPathException, InvalidAttributesException {
         LwM2mAttributeSet sut = new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 5L),
                 LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 60L));
         Collection<Attribute> attributes = sut.asCollection();
         assertEquals(2, attributes.size());
-        sut.validate(Attachment.RESOURCE);
+        sut.validate(new LwM2mPath("/3/0/9"));
     }
 
     @Test
     public void should_throw_on_invalid_assignation_level() {
-        assertThrowsExactly(IllegalArgumentException.class, () -> {
+        assertThrowsExactly(InvalidAttributesException.class, () -> {
             LwM2mAttributeSet sut = new LwM2mAttributeSet(
                     LwM2mAttributes.create(LwM2mAttributes.OBJECT_VERSION, new Version("1.1")),
                     LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 5L),
                     LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 60L));
 
             // OBJECT_VERSION cannot be assigned on resource level
-            sut.validate(Attachment.RESOURCE);
+            sut.validate(new LwM2mPath("/3/0/9"));
         });
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeTest.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.core.link.attributes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.leshan.core.LwM2m.Version;
@@ -35,5 +36,51 @@ public class AttributeTest {
         assertEquals(new Version("1.0"), verAttribute.getValue());
         assertTrue(verAttribute.canBeAttachedTo(Attachment.OBJECT));
         assertFalse(verAttribute.isWritable());
+    }
+
+    @Test
+    public void should_throw_on_pmin_lesser_than_zero() {
+        // The minimum period MUST be greater than zero
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-dynlink-07#section-4.1
+
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, -1L);
+        });
+    }
+
+    @Test
+    public void should_throw_on_pmax_lesser_than_zero() {
+        // The maximum period MUST be greater than zero
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-dynlink-07#section-4.2
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, -1L);
+        });
+    }
+
+    @Test
+    public void should_throw_on_epmin_lesser_than_zero() {
+        // The Minimum Evaluation Period MUST be greater than zero
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-conditional-attributes-06#section-3.2.3
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MINIMUM_PERIOD, -1L);
+        });
+    }
+
+    @Test
+    public void should_throw_on_epmax_lesser_than_zero() {
+        // The Maximum Evaluation Period MUST be greater than zero
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-conditional-attributes-06#section-3.2.4
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD, -1L);
+        });
+    }
+
+    @Test
+    public void should_throw_on_step_lesser_than_zero() {
+        // The Maximum Evaluation Period MUST be greater than zero
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-conditional-attributes-06#section-3.2.4
+        assertThrowsExactly(IllegalArgumentException.class, () -> {
+            LwM2mAttributes.create(LwM2mAttributes.STEP, -1D);
+        });
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
@@ -24,9 +24,13 @@ import org.junit.jupiter.api.Test;
 
 public class WriteAttributesRequestTest {
 
-    @Test()
-    public void should_throw_on_invalid_pmin_pmax() {
-        LwM2mAttributeSet sut = new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 50L),
+    @Test
+    public void should_throw_on_pmin_greater_than_pmax() {
+        // The maximum period MUST be greater than the minimum period parameter
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-dynlink-07#section-4.2
+
+        LwM2mAttributeSet sut = new LwM2mAttributeSet( //
+                LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 50L), //
                 LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 49L));
 
         // pmin cannot be greater then pmax
@@ -36,10 +40,13 @@ public class WriteAttributesRequestTest {
     }
 
     @Test
-    public void should_throw_on_invalid_epmin_epmax() {
-        LwM2mAttributeSet sut = new LwM2mAttributeSet(
-                LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MINIMUM_PERIOD, 50L),
-                LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD, 49L));
+    public void should_throw_on_epmin_greater_than_pmax() {
+        // The Maximum Evaluation Period MUST be greater than the Minimum Evaluation Period parameter
+        // https://datatracker.ietf.org/doc/html/draft-ietf-core-conditional-attributes-06#section-3.2.4
+
+        LwM2mAttributeSet sut = new LwM2mAttributeSet( //
+                LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 50L), //
+                LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 49L));
 
         // pmin cannot be greater then pmax
         assertThrowsExactly(InvalidRequestException.class, () -> {
@@ -47,4 +54,49 @@ public class WriteAttributesRequestTest {
         });
     }
 
+    @Test
+    public void should_throw_on_lt_greater_than_gt() {
+        // "lt" value < "gt" value
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-0-73-Attributes
+
+        LwM2mAttributeSet sut = new LwM2mAttributeSet(//
+                LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 50d), //
+                LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 49d));
+
+        // pmin cannot be greater then pmax
+        assertThrowsExactly(InvalidRequestException.class, () -> {
+            new WriteAttributesRequest(3, 0, 9, sut);
+        });
+    }
+
+    @Test
+    public void should_throw_on_gt_equals_lt() {
+        // "lt" value < "gt" value
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-0-73-Attributes
+
+        LwM2mAttributeSet sut = new LwM2mAttributeSet(//
+                LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 50d), //
+                LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 50d));
+
+        // pmin cannot be greater then pmax
+        assertThrowsExactly(InvalidRequestException.class, () -> {
+            new WriteAttributesRequest(3, 0, 9, sut);
+        });
+    }
+
+    @Test
+    public void should_throw_on_invalid_lt_gt_st_combination() {
+        // ("lt" value + 2*"st" values) <"gt" value
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#7-3-0-73-Attributes
+
+        LwM2mAttributeSet sut = new LwM2mAttributeSet(//
+                LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 10d), //
+                LwM2mAttributes.create(LwM2mAttributes.STEP, 2d), //
+                LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 12d));
+
+        // pmin cannot be greater then pmax
+        assertThrowsExactly(InvalidRequestException.class, () -> {
+            new WriteAttributesRequest(3, 0, 9, sut);
+        });
+    }
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeBootstrapTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeBootstrapTest.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *     Michał Wadowski (Orange) - Improved compliance with rfc6690
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.attributes;
+
+import static org.eclipse.leshan.core.util.TestLwM2mId.MULTIPLE_INTEGER_VALUE;
+import static org.eclipse.leshan.core.util.TestLwM2mId.TEST_OBJECT;
+import static org.eclipse.leshan.integration.tests.BootstrapConfigTestBuilder.givenBootstrapConfig;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestBootstrapServerBuilder.givenBootstrapServerUsing;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder.givenServerUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.request.WriteAttributesRequest;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.integration.tests.util.LeshanTestBootstrapServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestBootstrapServerBuilder;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.bootstrap.InvalidConfigurationException;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class WriteAttributeBootstrapTest {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2}- BS Server using {3}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllTransportLayer {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider - BS Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap", "Californium"), //
+                arguments(Protocol.COAP, "java-coap", "Californium", "Californium"), //
+                arguments(Protocol.COAP, "java-coap", "java-coap", "Californium"));
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+    LeshanTestBootstrapServerBuilder givenBootstrapServer;
+    LeshanTestBootstrapServer bootstrapServer;
+    LeshanTestServerBuilder givenServer;
+    LeshanTestServer server;
+    LeshanTestClientBuilder givenClient;
+    LeshanTestClient client;
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String givenBootstrapServerEndpointProvider) {
+        givenServer = givenServerUsing(givenProtocol).with(givenServerEndpointProvider);
+        givenBootstrapServer = givenBootstrapServerUsing(givenProtocol).with(givenBootstrapServerEndpointProvider);
+        givenClient = givenClientUsing(givenProtocol).with(givenClientEndpointProvider);
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+        if (bootstrapServer != null)
+            bootstrapServer.destroy();
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_then_bootstrap_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String givenBootstrapServerEndpointProvider)
+            throws InterruptedException, InvalidLwM2mPathException, InvalidConfigurationException {
+
+        write_attribute_then_observe_then_bootstrap_then_check_no_more_notification_data(givenProtocol,
+                new LwM2mPath(TEST_OBJECT));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_instance_then_bootstrap_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String givenBootstrapServerEndpointProvider)
+            throws InterruptedException, InvalidLwM2mPathException, InvalidConfigurationException {
+
+        write_attribute_then_observe_then_bootstrap_then_check_no_more_notification_data(givenProtocol,
+                new LwM2mPath(TEST_OBJECT, 0));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_then_bootstrap_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String givenBootstrapServerEndpointProvider)
+            throws InterruptedException, InvalidLwM2mPathException, InvalidConfigurationException {
+
+        write_attribute_then_observe_then_bootstrap_then_check_no_more_notification_data(givenProtocol,
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_instance_then_bootstrap_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String givenBootstrapServerEndpointProvider)
+            throws InterruptedException, InvalidLwM2mPathException, InvalidConfigurationException {
+
+        write_attribute_then_observe_then_bootstrap_then_check_no_more_notification_data(givenProtocol,
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
+    }
+
+    public void write_attribute_then_observe_then_bootstrap_then_check_no_more_notification_data(Protocol givenProtocol,
+            LwM2mPath targetedPath) throws InterruptedException, InvalidConfigurationException {
+
+        // Create DM Server without security & start it
+        server = givenServer.build();
+        server.start();
+
+        // Create and start bootstrap server
+        bootstrapServer = givenBootstrapServer.build();
+        bootstrapServer.start();
+
+        // Create Client and check it is not already registered
+        client = givenClient.connectingTo(bootstrapServer).build();
+        assertThat(client).isNotRegisteredAt(server);
+
+        // Add config for this client
+        bootstrapServer.getConfigStore().add(client.getEndpointName(), //
+                givenBootstrapConfig() //
+                        .adding(givenProtocol, bootstrapServer) //
+                        .adding(givenProtocol, server) //
+                        .build());
+
+        // Start it and wait for registration
+        client.start();
+        client.waitForBootstrapSuccess(bootstrapServer, 1, TimeUnit.SECONDS);
+        server.waitForNewRegistrationOf(client);
+        Registration currentRegistration = server.getRegistrationFor(client);
+
+        // check the client is registered
+        assertThat(client).isRegisteredAt(server);
+
+        // Add Attribute pmin=1seconds to targeted node
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration, new WriteAttributesRequest(
+                targetedPath, new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 1l))));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Check there is no notification data
+        assertThat(client).hasNoNotificationData();
+
+        // Observe targeted node
+        ObserveResponse response = server.send(currentRegistration, new ObserveRequest(targetedPath));
+        assertThat(response).isSuccess();
+
+        // Check that we have new NotificationData
+        Thread.sleep(100); // wait to be sure client handle observation : TODO We should do better.
+        assertThat(client).hasNotificationData();
+
+        // Force Bootstrap
+        client.triggerClientInitiatedBootstrap(false);
+
+        // then assert the is no more notification data
+        client.waitForBootstrapSuccess(bootstrapServer, 1, TimeUnit.SECONDS);
+        assertThat(client).hasNoNotificationData();
+    }
+
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
@@ -1,0 +1,408 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.attributes;
+
+import static org.eclipse.leshan.core.ResponseCode.CHANGED;
+import static org.eclipse.leshan.core.ResponseCode.CONTENT;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder.givenServerUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.client.object.Device;
+import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.model.ObjectModel;
+import org.eclipse.leshan.core.request.DiscoverRequest;
+import org.eclipse.leshan.core.request.WriteAttributesRequest;
+import org.eclipse.leshan.core.response.DiscoverResponse;
+import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class WriteAttributeDiscoverTest {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllTransportLayer {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium") // , //
+        // arguments(Protocol.COAP, "Californium", "java-coap"), //
+        // arguments(Protocol.COAP, "java-coap", "Californium"), //
+        // arguments(Protocol.COAP, "java-coap", "java-coap"))
+        );
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClient client;
+    Registration currentRegistration;
+
+    private static class WriteAttributeTestDevice extends Device {
+
+        private static final List<Integer> supportedResources = Arrays.asList(0, 7, 9, 16);
+
+        public WriteAttributeTestDevice() {
+            super("test_manufacturer", "model_number", "serial");
+        }
+
+        @Override
+        public List<Integer> getAvailableResourceIds(ObjectModel model) {
+            return supportedResources;
+        }
+    }
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        client = givenClientUsing(givenProtocol)
+                // we create client with a custom device to have pretty small discover response (making test readable)
+                .withInstancesForObject(LwM2mId.DEVICE, new WriteAttributeTestDevice())
+                .with(givenClientEndpointProvider).connectingTo(server).build();
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        currentRegistration = server.getRegistrationFor(client);
+
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @TestAllTransportLayer
+    public void write_attribute_on_object_then_discover(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        // Check there is no attribute already set
+        DiscoverResponse response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // Write some attributes
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 100l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 200l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check those attributes are now visible when discovering at object level
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>;pmin=100;pmax=200,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // override attribute
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 150l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check it
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>;pmin=150;pmax=200,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // remove attribute
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check it
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>;pmin=150,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // add + override attribute
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 300l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 600l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check it
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>;pmin=300;pmax=600,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_on_object_instance_then_discover(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        // Check there is no attribute already set
+        DiscoverResponse response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE, 0));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // Write some attributes
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, 0, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 100l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 200l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check those attributes are now visible when discovering at object level
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>,</3/0>;pmin=100;pmax=200,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // Check those attributes are now visible when discovering at object instance level
+        response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE, 0));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0>;pmin=100;pmax=200,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_on_single_resource_then_discover(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        // Check there is no attribute already set
+        DiscoverResponse response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE, 0, 9));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0/9>");
+
+        // Write some attributes
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(3, 0, 9, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 100l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 200l), //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, 1d), //
+                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 20d), //
+                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 50d) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check those attributes are now visible when discovering at object level
+        response = server.send(currentRegistration, new DiscoverRequest(3));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike(
+                        "</3>,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>;pmin=100;pmax=200;st=1;lt=20;gt=50,</3/0/16>");
+
+        // Check those attributes are now visible when discovering at object instance level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0>,</3/0/0>,</3/0/7>,</3/0/9>;pmin=100;pmax=200;st=1;lt=20;gt=50,</3/0/16>");
+
+        // Check those attributes are now visible when discovering at resource level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0, 9));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0/9>;pmin=100;pmax=200;st=1;lt=20;gt=50");
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_on_resource_instance_then_discover(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        // Check there is no attribute already set
+        DiscoverResponse response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE, 0, 7));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0/7>;dim=2,</3/0/7/0>,</3/0/7/1>");
+
+        // Write some attributes
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(3, 0, 7, 0, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 100l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 200l), //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, 1d), //
+                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 20d), //
+                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 50d) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check those attributes are now visible when discovering at object level
+        response = server.send(currentRegistration, new DiscoverRequest(3));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // Check those attributes are now visible when discovering at object instance level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0>,</3/0/0>,</3/0/7>,</3/0/9></3/0/16>");
+
+        // Check those attributes are now visible when discovering at resource level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0, 7));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3/0/7>;dim=2,</3/0/7/0>;pmin=100;pmax=200;st=1;lt=20;gt=50,</3/0/7/1>");
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_at_all_level_then_discover(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        // Check there is no attribute already set
+        DiscoverResponse response = server.send(currentRegistration, new DiscoverRequest(LwM2mId.DEVICE));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike("</3>,</3/0>,</3/0/0>,</3/0/7>,</3/0/9>,</3/0/16>");
+
+        // Write some attributes at object level
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 1000l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 2000l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        // Write some attributes at object install level
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(LwM2mId.DEVICE, 0, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 100l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 200l) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        // Write some attributes at resource level
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(3, 0, 7, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 10l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 20l), //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, 10d), //
+                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 200d), //
+                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 500d) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        // Write some attributes at resource instance level
+        writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(3, 0, 7, 0, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 1l), //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 2l), //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, 1d), //
+                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 20d), //
+                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 50d) //
+                )));
+        assertThat(writeAttributesResponse) //
+                .hasCode(CHANGED) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+        // Check those attributes are now visible when discovering at object level
+        response = server.send(currentRegistration, new DiscoverRequest(3));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike(
+                        "</3>;pmin=1000;pmax=2000,</3/0>;pmin=100;pmax=200,</3/0/0>,</3/0/7>;dim=2;pmin=10;pmax=20;st=10;lt=200;gt=500,</3/0/9></3/0/16>");
+
+        // Check those attributes are now visible when discovering at object instance level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike(
+                        "</3/0>;pmin=100;pmax=200,</3/0/0>,</3/0/7>;dim=2;pmin=10;pmax=20;st=10;lt=200;gt=500,</3/0/9></3/0/16>");
+
+        // Check those attributes are now visible when discovering at resource level
+        response = server.send(currentRegistration, new DiscoverRequest(3, 0, 7));
+        assertThat(response) //
+                .hasCode(CONTENT) //
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider) //
+                .hasObjectLinksLike(
+                        "</3/0/7>;dim=2;pmin=10;pmax=20;st=10;lt=200;gt=500,</3/0/7/0>;pmin=1;pmax=2;st=1;lt=20;gt=50,</3/0/7/1>");
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
@@ -67,11 +67,10 @@ public class WriteAttributeDiscoverTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAP, "Californium", "Californium") // , //
-        // arguments(Protocol.COAP, "Californium", "java-coap"), //
-        // arguments(Protocol.COAP, "java-coap", "Californium"), //
-        // arguments(Protocol.COAP, "java-coap", "java-coap"))
-        );
+                arguments(Protocol.COAP, "Californium", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap"), //
+                arguments(Protocol.COAP, "java-coap", "Californium"), //
+                arguments(Protocol.COAP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeFailedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeFailedTest.java
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.attributes;
+
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder.givenServerUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.core.ResponseCode;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.WriteAttributesRequest;
+import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.ArgumentsUtil;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class WriteAttributeFailedTest {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2} - {3} - {4},{5}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllCases {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+
+        Object[][] transports = new Object[][] {
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                { Protocol.COAP, "Californium", "Californium" }, //
+                { Protocol.COAP, "Californium", "java-coap" }, //
+                { Protocol.COAP, "java-coap", "Californium" }, //
+                { Protocol.COAP, "java-coap", "java-coap" } };
+
+        Object[][] testCases = new Object[][] { //
+                // targeted path - initial state - invalid attributes to write
+
+                { // test pmin > pmax
+                        "/3", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 300l)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 200l)) //
+                }, //
+                { // test epmin > epmax
+                        "/3", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MINIMUM_PERIOD, 300l)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.EVALUATE_MAXIMUM_PERIOD, 200l)) //
+                }, //
+                { // test gt < lt
+                        "/3/0/9", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 100d)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 200d)) //
+                }, //
+                { // test gt == lt
+                        "/3/0/9", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 200d)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 200d)) //
+                }, //
+                { // test lt - 2*st > gt
+                        "/3/0/9", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 11d)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create( //
+                                LwM2mAttributes.LESSER_THAN, 10d), //
+                                LwM2mAttributes.create(LwM2mAttributes.STEP, 2d)) //
+                }, //
+                { // test lt - 2*st == gt
+                        "/3/0/9", //
+                        new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 14d)), //
+                        new LwM2mAttributeSet(LwM2mAttributes.create( //
+                                LwM2mAttributes.LESSER_THAN, 10d), //
+                                LwM2mAttributes.create(LwM2mAttributes.STEP, 2d)) //
+                } };
+
+        // for each transport, create 1 test by format.
+        return Stream.of(ArgumentsUtil.combine(transports, testCases));
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClient client;
+    Registration currentRegistration;
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider,
+            String targetedPath, LwM2mAttributeSet initialState, LwM2mAttributeSet invalidAttributes) {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        client = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server).build();
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        currentRegistration = server.getRegistrationFor(client);
+
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @TestAllCases
+    public void test_failing(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider, String targetedPath, LwM2mAttributeSet initialState,
+            LwM2mAttributeSet invalidAttributes) throws InterruptedException {
+
+        LwM2mPath path = new LwM2mPath(targetedPath);
+
+        // Set initial state if needed
+        if (initialState != null) {
+            WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                    new WriteAttributesRequest(path, initialState));
+            assertThat(writeAttributesResponse).isSuccess();
+        }
+
+        // Write failing attributes
+        WriteAttributesResponse writeAttributesResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(path, invalidAttributes));
+        assertThat(writeAttributesResponse).hasCode(ResponseCode.BAD_REQUEST)
+                .hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
@@ -257,7 +257,7 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
-        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+        write_attribute_then_observe_then_active_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT));
     }
 
@@ -266,7 +266,7 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
-        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+        write_attribute_then_observe_then_active_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0));
     }
 
@@ -275,16 +275,16 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
-        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+        write_attribute_then_observe_then_active_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
     }
 
     @TestAllTransportLayer
-    public void write_attribute_then_observe_resource_active_then_passive_cancel_then_check_no_more_notification_data(
+    public void write_attribute_then_observe_resource_instance_then_active_cancel_then_check_no_more_notification_data(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
-        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+        write_attribute_then_observe_then_active_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
     }
 
@@ -316,4 +316,67 @@ public class WriteAttributeHouseKeepingTest {
         // then assert the is no more notification data
         assertThat(client).hasNoNotificationData();
     }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_then_remove_object_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_remove_object_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_instance_then_remove_object_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_remove_object_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_then_remove_object_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_remove_object_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_instance_then_remove_object_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_remove_object_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
+    }
+
+    public void write_attribute_then_observe_then_remove_object_then_check_no_more_notification_data(
+            LwM2mPath targetedPath) throws InterruptedException {
+
+        // Add Attribute pmin=1seconds to targeted node
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration, new WriteAttributesRequest(
+                targetedPath, new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 2l))));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Check there is no notification data
+        assertThat(client).hasNoNotificationData();
+
+        // Observe targeted node
+        ObserveResponse response = server.send(currentRegistration, new ObserveRequest(targetedPath));
+        assertThat(response).isSuccess();
+
+        // Check that we have new NotificationData
+        Thread.sleep(100); // wait to be sure client handle observation : TODO We should do better.
+        assertThat(client).hasNotificationData();
+
+        // Disable object
+        client.getObjectTree().removeObjectEnabler(targetedPath.getObjectId());
+
+        // then assert the is no more notification data
+        assertThat(client).hasNoNotificationData();
+    }
+
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
@@ -1,0 +1,319 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.integration.tests.attributes;
+
+import static org.eclipse.leshan.core.util.TestLwM2mId.MULTIPLE_INTEGER_VALUE;
+import static org.eclipse.leshan.core.util.TestLwM2mId.TEST_OBJECT;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.model.ResourceModel.Type;
+import org.eclipse.leshan.core.node.LwM2mMultipleResource;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.LwM2mResourceInstance;
+import org.eclipse.leshan.core.observation.SingleObservation;
+import org.eclipse.leshan.core.request.CancelObservationRequest;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.request.DeleteRequest;
+import org.eclipse.leshan.core.request.DownlinkRequest;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.request.WriteAttributesRequest;
+import org.eclipse.leshan.core.request.WriteRequest;
+import org.eclipse.leshan.core.request.WriteRequest.Mode;
+import org.eclipse.leshan.core.response.CancelObservationResponse;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class WriteAttributeHouseKeepingTest {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllTransportLayer {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium"), //
+                arguments(Protocol.COAP, "java-coap", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap"), //
+                arguments(Protocol.COAP, "java-coap", "java-coap"));
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClient client;
+    Registration currentRegistration;
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        client = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server).build();
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        currentRegistration = server.getRegistrationFor(client);
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        return new LeshanTestServerBuilder(givenProtocol);
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+
+    @TestAllTransportLayer
+    public void write_attribute_on_tree_then_remove_object_instance(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        // For each of this path,
+        LwM2mPath instancePath = new LwM2mPath(TEST_OBJECT, 0);
+        LwM2mPath resourcePath = new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE);
+        LwM2mPath resourceInstancePath = new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0);
+        List<LwM2mPath> path = Arrays.asList(instancePath, resourcePath, resourceInstancePath);
+
+        // this attribute set will be written,
+        LwM2mAttributeSet attributeSet = new LwM2mAttributeSet(
+                LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 10l));
+
+        // Then this request will be executed (to delete node)
+        DeleteRequest deleteRequest = new DeleteRequest(instancePath);
+
+        // Then ensure there is no more attribute for those path.
+        write_attribute_on_tree_then_remove_node_then_check_attributes_are_removed(path, attributeSet, deleteRequest);
+
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_on_tree_then_remove_resource_instance(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        // For each of this path,
+        LwM2mPath resourceInstancePath = new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0);
+        List<LwM2mPath> path = Arrays.asList(resourceInstancePath);
+
+        // this attribute set will be written,
+        LwM2mAttributeSet attributeSet = new LwM2mAttributeSet(
+                LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, 10l));
+
+        // Then this request will be executed (to delete node : we will replace resource instance with id 0 by resource
+        // instance with id 1)
+        LwM2mPath resourcePath = new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE);
+        WriteRequest writeRequest = new WriteRequest(Mode.REPLACE, ContentFormat.TLV, resourcePath, //
+                new LwM2mMultipleResource(MULTIPLE_INTEGER_VALUE, Type.INTEGER,
+                        LwM2mResourceInstance.newIntegerInstance(1, 10)));
+
+        // Then ensure there is no more attribute for those path.
+        write_attribute_on_tree_then_remove_node_then_check_attributes_are_removed(path, attributeSet, writeRequest);
+    }
+
+    private void write_attribute_on_tree_then_remove_node_then_check_attributes_are_removed(List<LwM2mPath> pathToCheck,
+            LwM2mAttributeSet attributeSet, DownlinkRequest<?> deleteRequest) throws InterruptedException {
+
+        // For each of this path, be sure there is no attributes
+        LwM2mServer lwServer = client.getServerIdForRegistrationId(currentRegistration.getId());
+        for (LwM2mPath path : pathToCheck) {
+            assertThat(client).hasNoAttributeSetFor(lwServer, path);
+        }
+
+        // For each of this path, Write Attribute and check it is present.
+        for (LwM2mPath path : pathToCheck) {
+            WriteAttributesResponse response = server.send(currentRegistration,
+                    new WriteAttributesRequest(path, attributeSet));
+
+            assertThat(response).isSuccess();
+            assertThat(client).hasAttributesFor(lwServer, path, attributeSet);
+        }
+
+        // Delete given node
+        LwM2mResponse response = server.send(currentRegistration, deleteRequest);
+        assertThat(response).isSuccess();
+
+        // assert there is no attributes for those path after node deletion
+        for (LwM2mPath path : pathToCheck) {
+            assertThat(client).hasNoAttributeSetFor(lwServer, path);
+        }
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_then_passive_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_instance_then_passive_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_then_passive_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_instance_then_passive_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
+    }
+
+    public void write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+            LwM2mPath targetedPath) throws InterruptedException {
+
+        // Add Attribute pmin=1seconds to targeted node
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration, new WriteAttributesRequest(
+                targetedPath, new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 1l))));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Check there is no notification data
+        assertThat(client).hasNoNotificationData();
+
+        // Observe targeted node
+        ObserveResponse response = server.send(currentRegistration, new ObserveRequest(targetedPath));
+        SingleObservation observation = (SingleObservation) server.waitForNewObservation(client);
+        assertThat(response).isSuccess();
+
+        // Check that we have new NotificationData
+        Thread.sleep(100); // wait to be sure client handle observation : TODO We should do better.
+        assertThat(client).hasNotificationData();
+
+        // Remove observation at server side : Passive Cancel observation
+        server.getObservationService().cancelObservation(observation);
+
+        // wait for notification, then assert the is no more notification data
+        Thread.sleep(1200); // wait to be sure client handle RST (passive cancel)
+        assertThat(client).hasNoNotificationData();
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_then_active_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_object_instance_then_active_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_then_active_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
+    }
+
+    @TestAllTransportLayer
+    public void write_attribute_then_observe_resource_active_then_passive_cancel_then_check_no_more_notification_data(
+            Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
+                new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
+    }
+
+    public void write_attribute_then_observe_then_active_cancel_then_check_no_more_notification_data(
+            LwM2mPath targetedPath) throws InterruptedException {
+
+        // Add Attribute pmin=1seconds to targeted node
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration, new WriteAttributesRequest(
+                targetedPath, new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, 1l))));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Check there is no notification data
+        assertThat(client).hasNoNotificationData();
+
+        // Observe targeted node
+        ObserveResponse response = server.send(currentRegistration, new ObserveRequest(targetedPath));
+        SingleObservation observation = (SingleObservation) server.waitForNewObservation(client);
+        assertThat(response).isSuccess();
+
+        // Check that we have new NotificationData
+        Thread.sleep(100); // wait to be sure client handle observation : TODO We should do better.
+        assertThat(client).hasNotificationData();
+
+        // Do active cancel
+        CancelObservationResponse cancelObservationResponse = server.send(currentRegistration,
+                new CancelObservationRequest(observation));
+        assertThat(cancelObservationResponse).isSuccess();
+
+        // then assert the is no more notification data
+        assertThat(client).hasNoNotificationData();
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ *******************************************************************************/
+
+package org.eclipse.leshan.integration.tests.attributes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.core.util.TestLwM2mId.INTEGER_VALUE;
+import static org.eclipse.leshan.core.util.TestLwM2mId.TEST_OBJECT;
+import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
+import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.LwM2mSingleResource;
+import org.eclipse.leshan.core.observation.SingleObservation;
+import org.eclipse.leshan.core.request.ObserveRequest;
+import org.eclipse.leshan.core.request.WriteAttributesRequest;
+import org.eclipse.leshan.core.request.WriteRequest;
+import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.core.response.ObserveResponse;
+import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
+import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
+import org.eclipse.leshan.integration.tests.util.junit5.extensions.BeforeEachParameterizedResolver;
+import org.eclipse.leshan.server.registration.Registration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(BeforeEachParameterizedResolver.class)
+public class WriteAttributeObserveTest {
+
+    /*---------------------------------/
+     *  Parameterized Tests
+     * -------------------------------*/
+    @ParameterizedTest(name = "{0} - Client using {1} - Server using {2}")
+    @MethodSource("transports")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllTransportLayer {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
+        return Stream.of(//
+                // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
+                arguments(Protocol.COAP, "Californium", "Californium") // , //
+//                arguments(Protocol.COAP, "java-coap", "Californium"), //
+//                arguments(Protocol.COAP, "Californium", "java-coap"), //
+//                arguments(Protocol.COAP, "java-coap", "java-coap")
+        );
+    }
+
+    /*---------------------------------/
+     *  Set-up and Tear-down Tests
+     * -------------------------------*/
+
+    LeshanTestServer server;
+    LeshanTestClient client;
+    Registration currentRegistration;
+
+    @BeforeEach
+    public void start(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider) {
+        server = givenServerUsing(givenProtocol).with(givenServerEndpointProvider).build();
+        server.start();
+        client = givenClientUsing(givenProtocol).with(givenClientEndpointProvider).connectingTo(server).build();
+        client.start();
+        server.waitForNewRegistrationOf(client);
+        client.waitForRegistrationTo(server);
+
+        currentRegistration = server.getRegistrationFor(client);
+
+    }
+
+    @AfterEach
+    public void stop() throws InterruptedException {
+        if (client != null)
+            client.destroy(false);
+        if (server != null)
+            server.destroy();
+    }
+
+    protected LeshanTestServerBuilder givenServerUsing(Protocol givenProtocol) {
+        return new LeshanTestServerBuilder(givenProtocol);
+    }
+
+    /*---------------------------------/
+     *  Tests
+     * -------------------------------*/
+    @TestAllTransportLayer
+    public void test_pmin(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        Long pmin = 1l; // seconds
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MINIMUM_PERIOD, pmin) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Trigger new notification (changing value using Write Request)
+        LwM2mResponse writeResponse = server.send(currentRegistration,
+                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 50l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.8),
+                TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationOf(observation,
+                (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 50l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+    }
+
+    @TestAllTransportLayer
+    public void test_pmax(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        Long pmax = 1l; // seconds
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.MAXIMUM_PERIOD, pmax) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Do nothing to trigger notification
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.8),
+                TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationOf(observation,
+                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1024l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+
+    }
+
+    @TestAllTransportLayer
+    public void test_lt(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        Double lt = 500d;
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, lt) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Change value which doesn't cross the less_than limit (initial value 1024)
+        LwM2mResponse writeResponse = server.send(currentRegistration,
+                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 800l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+        // Change value which crosses the less_than limit
+        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 450l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        ObserveResponse response = server.waitForNotificationOf(observation);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 450l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+    }
+
+    @TestAllTransportLayer
+    public void test_gt(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
+            throws InterruptedException {
+
+        Double gt = 2000d;
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, gt) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Change value which doesn't cross the greater_than limit (initial value 1024)
+        LwM2mResponse writeResponse = server.send(currentRegistration,
+                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1500l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+        // Change value which crosses the greater_than limit
+        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 3000l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        ObserveResponse response = server.waitForNotificationOf(observation);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 3000l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+    }
+
+    @TestAllTransportLayer
+    public void test_st_with_positive_gap(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        Double st = 200d;
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, st) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Change value which isn't a big enough step (initial value 1024)
+        LwM2mResponse writeResponse = server.send(currentRegistration,
+                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1124l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+        // Change value which crosses the less_than limit
+        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1225l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        ObserveResponse response = server.waitForNotificationOf(observation);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1225l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+    }
+
+    @TestAllTransportLayer
+    public void test_st_with_negative_gap(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        Double st = 200d;
+
+        // Set attribute
+        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
+                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
+                        LwM2mAttributes.create(LwM2mAttributes.STEP, st) //
+                )));
+        assertThat(writeAttributeResponse).isSuccess();
+
+        // Set observe relation
+        ObserveResponse observeResponse = server.send(currentRegistration,
+                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observeResponse).isSuccess();
+        SingleObservation observation = observeResponse.getObservation();
+        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        server.waitForNewObservation(observation);
+
+        // Change value which isn't a big enough step (initial value 1024)
+        LwM2mResponse writeResponse = server.send(currentRegistration,
+                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 924l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+        // Change value which crosses the less_than limit
+        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 823l));
+        assertThat(writeResponse).isSuccess();
+
+        // Verify Behavior
+        ObserveResponse response = server.waitForNotificationOf(observation);
+        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 823l));
+        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
+        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+
+    }
+}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Sierra Wireless and others.
+ * Copyright (c) 2024 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -10,6 +10,8 @@
  * and the Eclipse Distribution License is available at
  *    http://www.eclipse.org/org/documents/edl-v10.html.
  *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
  *******************************************************************************/
 
 package org.eclipse.leshan.integration.tests.attributes;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -66,11 +66,10 @@ public class WriteAttributeObserveTest {
     static Stream<org.junit.jupiter.params.provider.Arguments> transports() {
         return Stream.of(//
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
-                arguments(Protocol.COAP, "Californium", "Californium") // , //
-//                arguments(Protocol.COAP, "java-coap", "Californium"), //
-//                arguments(Protocol.COAP, "Californium", "java-coap"), //
-//                arguments(Protocol.COAP, "java-coap", "java-coap")
-        );
+                arguments(Protocol.COAP, "Californium", "Californium"), //
+                arguments(Protocol.COAP, "java-coap", "Californium"), //
+                arguments(Protocol.COAP, "Californium", "java-coap"), //
+                arguments(Protocol.COAP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -17,8 +17,10 @@
 package org.eclipse.leshan.integration.tests.attributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.leshan.core.util.TestLwM2mId.FLOAT_VALUE;
 import static org.eclipse.leshan.core.util.TestLwM2mId.INTEGER_VALUE;
 import static org.eclipse.leshan.core.util.TestLwM2mId.TEST_OBJECT;
+import static org.eclipse.leshan.core.util.TestLwM2mId.UNSIGNED_INTEGER_VALUE;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
@@ -31,15 +33,19 @@ import java.util.stream.Stream;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.observation.SingleObservation;
+import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.ObserveRequest;
 import org.eclipse.leshan.core.request.WriteAttributesRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
+import org.eclipse.leshan.core.request.WriteRequest.Mode;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
+import org.eclipse.leshan.core.util.datatype.ULong;
 import org.eclipse.leshan.integration.tests.util.LeshanTestClient;
 import org.eclipse.leshan.integration.tests.util.LeshanTestServer;
 import org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder;
@@ -177,163 +183,224 @@ public class WriteAttributeObserveTest {
     }
 
     @TestAllTransportLayer
-    public void test_lt(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws InterruptedException {
-
-        Double lt = 500d;
-
-        // Set attribute
-        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
-                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
-                        LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, lt) //
-                )));
-        assertThat(writeAttributeResponse).isSuccess();
-
-        // Set observe relation
-        ObserveResponse observeResponse = server.send(currentRegistration,
-                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
-        assertThat(observeResponse).isSuccess();
-        SingleObservation observation = observeResponse.getObservation();
-        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
-        server.waitForNewObservation(observation);
-
-        // Change value which doesn't cross the less_than limit (initial value 1024)
-        LwM2mResponse writeResponse = server.send(currentRegistration,
-                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 800l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-
-        // Change value which crosses the less_than limit
-        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 450l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        ObserveResponse response = server.waitForNotificationOf(observation);
-        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 450l));
-        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-
-    }
-
-    @TestAllTransportLayer
-    public void test_gt(Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
-            throws InterruptedException {
-
-        Double gt = 2000d;
-
-        // Set attribute
-        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
-                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
-                        LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, gt) //
-                )));
-        assertThat(writeAttributeResponse).isSuccess();
-
-        // Set observe relation
-        ObserveResponse observeResponse = server.send(currentRegistration,
-                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
-        assertThat(observeResponse).isSuccess();
-        SingleObservation observation = observeResponse.getObservation();
-        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
-        server.waitForNewObservation(observation);
-
-        // Change value which doesn't cross the greater_than limit (initial value 1024)
-        LwM2mResponse writeResponse = server.send(currentRegistration,
-                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1500l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-
-        // Change value which crosses the greater_than limit
-        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 3000l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        ObserveResponse response = server.waitForNotificationOf(observation);
-        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 3000l));
-        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-    }
-
-    @TestAllTransportLayer
-    public void test_st_with_positive_gap(Protocol givenProtocol, String givenClientEndpointProvider,
+    public void test_lt_integer_resource(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws InterruptedException {
 
-        Double st = 200d;
-
-        // Set attribute
-        WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
-                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
-                        LwM2mAttributes.create(LwM2mAttributes.STEP, st) //
-                )));
-        assertThat(writeAttributeResponse).isSuccess();
-
-        // Set observe relation
-        ObserveResponse observeResponse = server.send(currentRegistration,
-                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
-        assertThat(observeResponse).isSuccess();
-        SingleObservation observation = observeResponse.getObservation();
-        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
-        server.waitForNewObservation(observation);
-
-        // Change value which isn't a big enough step (initial value 1024)
-        LwM2mResponse writeResponse = server.send(currentRegistration,
-                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1124l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-
-        // Change value which crosses the less_than limit
-        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 1225l));
-        assertThat(writeResponse).isSuccess();
-
-        // Verify Behavior
-        ObserveResponse response = server.waitForNotificationOf(observation);
-        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1225l));
-        assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
-
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 1024
+                new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE),
+                // "LESSER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 500d)),
+                // value which doesn't cross the less_than limit
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 800l),
+                // value which crosses the less_than limit
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 450l));
     }
 
     @TestAllTransportLayer
-    public void test_st_with_negative_gap(Protocol givenProtocol, String givenClientEndpointProvider,
+    public void test_lt_float_resource(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws InterruptedException {
 
-        Double st = 200d;
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 3.14159
+                new LwM2mPath(TEST_OBJECT, 0, FLOAT_VALUE),
+                // "LESSER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 2.5d)),
+                // value which doesn't cross the less_than limit
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 4.3d),
+                // value which crosses the less_than limit
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 2.1d));
+    }
+
+    @TestAllTransportLayer
+    public void test_lt_unsigned_integer_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 9223372036854775808
+                new LwM2mPath(TEST_OBJECT, 0, UNSIGNED_INTEGER_VALUE),
+                // "LESSER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.LESSER_THAN, 500d)),
+                // value which doesn't cross the less_than limit
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE, ULong.valueOf(800l)),
+                // value which crosses the less_than limit
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE, ULong.valueOf(450l)));
+    }
+
+    @TestAllTransportLayer
+    public void test_gt_integer_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 1024
+                new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE),
+                // "GREATER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 2000d)),
+                // value which doesn't cross the greater_than limit
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1500l),
+                // value which crosses the greater_than limit
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 3000l));
+    }
+
+    @TestAllTransportLayer
+    public void test_gt_float_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 3.14159
+                new LwM2mPath(TEST_OBJECT, 0, FLOAT_VALUE),
+                // "GREATER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 5.5d)),
+                // value which doesn't cross the greater_than limit
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 4.3d),
+                // value which crosses the greater_than limit
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 5.6d));
+    }
+
+    @TestAllTransportLayer
+    public void test_gt_unsigned_integer_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 9223372036854775808
+                new LwM2mPath(TEST_OBJECT, 0, UNSIGNED_INTEGER_VALUE),
+                // "GREATER THAN" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 9999999999999999900d)),
+                // value which doesn't cross the greater_than limit
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9999999999999990000")),
+                // value which crosses the greater_than limit
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9999999999999999999")));
+    }
+
+    @TestAllTransportLayer
+    public void test_st_with_positive_gap_on_integer_resource(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 1024
+                new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 200d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1124l),
+                // Second change value which is big enough
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1225l));
+    }
+
+    @TestAllTransportLayer
+    public void test_with_positive_gap_on_float_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 3.14159
+                new LwM2mPath(TEST_OBJECT, 0, FLOAT_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 200d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 103.14159d),
+                // Second change value which is big enough
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, 204.14159d));
+    }
+
+    @TestAllTransportLayer
+    public void test_with_positive_gap_on_unsigned_integer_resource(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 9223372036854775808
+                new LwM2mPath(TEST_OBJECT, 0, UNSIGNED_INTEGER_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 20d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9223372036854775818")),
+                // Second change value which is big enough
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9223372036854775828")));
+    }
+
+    @TestAllTransportLayer
+    public void test_st_with_negative_gap_on_integer_resource(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 1024
+                new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 200d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 924l),
+                // Second change value which is big enough
+                LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 823l));
+    }
+
+    @TestAllTransportLayer
+    public void test_with_negative_gap_on_float_resource(Protocol givenProtocol, String givenClientEndpointProvider,
+            String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 3.14159
+                new LwM2mPath(TEST_OBJECT, 0, FLOAT_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 200d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, -103.14159d),
+                // Second change value which is big enough
+                LwM2mSingleResource.newFloatResource(FLOAT_VALUE, -203.14159d));
+    }
+
+    @TestAllTransportLayer
+    public void test_with_negative_gap_on_unsigned_integer_resource(Protocol givenProtocol,
+            String givenClientEndpointProvider, String givenServerEndpointProvider) throws InterruptedException {
+
+        test_first_change_didnt_trigger_then_second_did(givenServerEndpointProvider, //
+                // target LWM2M node : initial value is 9223372036854775808
+                new LwM2mPath(TEST_OBJECT, 0, UNSIGNED_INTEGER_VALUE),
+                // "STEP" attribute value
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.STEP, 20d)),
+                // First change value which isn't a big enough step
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9223372036854775800")),
+                // Second change value which is big enough
+                LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
+                        ULong.valueOf("9223372036854775758")));
+    }
+
+    protected void test_first_change_didnt_trigger_then_second_did(String givenServerEndpointProvider,
+            LwM2mPath targetedResource, LwM2mAttributeSet attributesToWrite,
+            LwM2mNode valueWhichDidntTriggerNotification, LwM2mNode valueWhichTriggerNotification)
+            throws InterruptedException {
 
         // Set attribute
         WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
-                new WriteAttributesRequest(TEST_OBJECT, 0, INTEGER_VALUE, new LwM2mAttributeSet( //
-                        LwM2mAttributes.create(LwM2mAttributes.STEP, st) //
-                )));
+                new WriteAttributesRequest(targetedResource, attributesToWrite));
         assertThat(writeAttributeResponse).isSuccess();
 
         // Set observe relation
-        ObserveResponse observeResponse = server.send(currentRegistration,
-                new ObserveRequest(TEST_OBJECT, 0, INTEGER_VALUE));
+        ObserveResponse observeResponse = server.send(currentRegistration, new ObserveRequest(targetedResource));
         assertThat(observeResponse).isSuccess();
         SingleObservation observation = observeResponse.getObservation();
-        assertThat(observation.getPath()).isEqualTo(new LwM2mPath(TEST_OBJECT, 0, INTEGER_VALUE));
+        assertThat(observation.getPath()).isEqualTo(targetedResource);
         server.waitForNewObservation(observation);
 
-        // Change value which isn't a big enough step (initial value 1024)
-        LwM2mResponse writeResponse = server.send(currentRegistration,
-                new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 924l));
+        // Change value which should NOT trigger notification
+        LwM2mResponse writeResponse = server.send(currentRegistration, new WriteRequest(Mode.REPLACE, ContentFormat.TLV,
+                targetedResource, valueWhichDidntTriggerNotification));
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
         server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
 
-        // Change value which crosses the less_than limit
-        writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 823l));
+        // Change value which should trigger notification
+        writeResponse = server.send(currentRegistration,
+                new WriteRequest(Mode.REPLACE, ContentFormat.TLV, targetedResource, valueWhichTriggerNotification));
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
         ObserveResponse response = server.waitForNotificationOf(observation);
-        assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 823l));
+        assertThat(response.getContent()).isEqualTo(valueWhichTriggerNotification);
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
         server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -265,13 +265,13 @@ public class WriteAttributeObserveTest {
                 // target LWM2M node : initial value is 9223372036854775808
                 new LwM2mPath(TEST_OBJECT, 0, UNSIGNED_INTEGER_VALUE),
                 // "GREATER THAN" attribute value
-                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 9999999999999999900d)),
+                new LwM2mAttributeSet(LwM2mAttributes.create(LwM2mAttributes.GREATER_THAN, 10000000000000000000d)),
                 // value which doesn't cross the greater_than limit
                 LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
                         ULong.valueOf("9999999999999990000")),
                 // value which crosses the greater_than limit
                 LwM2mSingleResource.newUnsignedIntegerResource(UNSIGNED_INTEGER_VALUE,
-                        ULong.valueOf("9999999999999999999")));
+                        ULong.valueOf("10000000000000010000")));
     }
 
     @TestAllTransportLayer

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -123,7 +123,7 @@ public class WriteAttributeObserveTest {
     public void test_pmin(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws InterruptedException {
 
-        Long pmin = 1l; // seconds
+        long pmin = 1l; // seconds
 
         // Set attribute
         WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
@@ -146,10 +146,7 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        ObserveResponse response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationExactlyIn(observation, (int) pmin, TimeUnit.SECONDS, 0.2);
         assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 50l));
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
     }
@@ -158,7 +155,7 @@ public class WriteAttributeObserveTest {
     public void test_pmax(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws InterruptedException {
 
-        Long pmax = 1l; // seconds
+        long pmax = 1l; // seconds
 
         // Set attribute
         WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
@@ -178,10 +175,7 @@ public class WriteAttributeObserveTest {
         // Do nothing to trigger notification
 
         // Verify Behavior
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        ObserveResponse response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationExactlyIn(observation, (int) pmax, TimeUnit.SECONDS, 0.2);
         assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 1024l));
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
     }
@@ -225,18 +219,12 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        ObserveResponse response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmin, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationExactlyIn(observation, (int) pmin, TimeUnit.SECONDS, 0.2);
         assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 30));
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
 
         // Wait pmax seconds more and check again
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        response = server.waitForNotificationExactlyIn(observation, (int) pmax, TimeUnit.SECONDS, 0.2);
         assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 30));
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
     }
@@ -450,7 +438,7 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+        server.ensureNoNotification(observation, 200, TimeUnit.MILLISECONDS);
 
         // Change value which should trigger notification
         writeResponse = server.send(currentRegistration,
@@ -458,10 +446,10 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        ObserveResponse response = server.waitForNotificationOf(observation);
+        ObserveResponse response = server.waitForNotificationOf(observation, 100, TimeUnit.MILLISECONDS);
         assertThat(response.getContent()).isEqualTo(valueWhichTriggerNotification);
         assertThat(response).hasValidUnderlyingResponseFor(givenServerEndpointProvider);
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+        server.ensureNoNotification(observation, 100, TimeUnit.MILLISECONDS);
     }
 
     @TestAllTransportLayer
@@ -469,7 +457,7 @@ public class WriteAttributeObserveTest {
             String givenServerEndpointProvider) throws InterruptedException {
 
         Double lt = 500d;
-        Long pmax = 1l;
+        long pmax = 1l;
 
         // Setting attribute
         WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
@@ -492,22 +480,19 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+        server.ensureNoNotification(observation, 200, TimeUnit.MILLISECONDS);
 
         // Changing value which crosses the lt limit
         writeResponse = server.send(currentRegistration, new WriteRequest(TEST_OBJECT, 0, INTEGER_VALUE, 400));
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        ObserveResponse response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationOf(observation, 100, TimeUnit.MILLISECONDS);
         assertThat(response.getContent()).isEqualTo(LwM2mSingleResource.newIntegerResource(INTEGER_VALUE, 400));
 
         // Wait for pmax and ensure new notification is raised
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        response = server.waitForNotificationExactlyIn(observation, (int) pmax, TimeUnit.SECONDS, 0.2);
+
     }
 
     @TestAllTransportLayer
@@ -614,7 +599,7 @@ public class WriteAttributeObserveTest {
         assertThat(writeResponse).isSuccess();
 
         // Verify Behavior
-        server.ensureNoNotification(observation, 500, TimeUnit.MILLISECONDS);
+        server.ensureNoNotification(observation, 300, TimeUnit.MILLISECONDS);
 
         // Changing value which crosses the lt limit but NOT fulfill step condition
         writeResponse = server.send(currentRegistration,
@@ -675,7 +660,7 @@ public class WriteAttributeObserveTest {
     private void write_pmax_then_observe_then_wait_for_notification(String givenServerEndpointProvider,
             LwM2mPath pathToWriteAttribute, LwM2mPath pathToObserve) throws InterruptedException {
 
-        Long pmax = 1l; // seconds
+        long pmax = 1l; // seconds
 
         // Set attribute
         WriteAttributesResponse writeAttributeResponse = server.send(currentRegistration,
@@ -694,10 +679,7 @@ public class WriteAttributeObserveTest {
         // Do nothing to trigger notification
 
         // Verify Behavior
-        server.ensureNoNotification(observation, (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.8),
-                TimeUnit.MILLISECONDS);
-        ObserveResponse response = server.waitForNotificationOf(observation,
-                (int) (TimeUnit.MILLISECONDS.convert(pmax, TimeUnit.SECONDS) * 0.3), TimeUnit.MILLISECONDS);
+        ObserveResponse response = server.waitForNotificationExactlyIn(observation, (int) pmax, TimeUnit.SECONDS, 0.2);
         assertThat(response).isSuccess();
     }
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
@@ -41,8 +41,12 @@ import org.eclipse.leshan.client.californium.endpoint.CaliforniumClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
+import org.eclipse.leshan.client.notification.NotificationDataStore;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.observer.LwM2mClientObserver;
+import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
+import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.send.DataSender;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
@@ -63,6 +67,7 @@ public class LeshanTestClient extends LeshanClient {
     private final String endpointName;
     private final InOrder inOrder;
     private final ReverseProxy proxy;
+    private NotificationDataStore notificationDataStore;
 
     public LeshanTestClient(String endpoint, List<? extends LwM2mObjectEnabler> objectEnablers,
             List<DataSender> dataSenders, List<Certificate> trustStore, RegistrationEngineFactory engineFactory,
@@ -84,6 +89,17 @@ public class LeshanTestClient extends LeshanClient {
         addObserver(clientObserver);
         inOrder = inOrder(clientObserver);
     }
+
+    @Override
+    protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
+            DownlinkRequestReceiver requestReceiver) {
+        notificationDataStore = new NotificationDataStore();
+        return new NotificationManager(objectTree, requestReceiver, notificationDataStore);
+    }
+
+    public NotificationDataStore getNotificationDataStore() {
+        return notificationDataStore;
+    };
 
     public String getEndpointName() {
         return endpointName;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
@@ -42,11 +42,8 @@ import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.RegistrationEngineFactory;
 import org.eclipse.leshan.client.notification.NotificationDataStore;
-import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.observer.LwM2mClientObserver;
-import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectEnabler;
-import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.send.DataSender;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
@@ -91,10 +88,9 @@ public class LeshanTestClient extends LeshanClient {
     }
 
     @Override
-    protected NotificationManager createNotificationManager(LwM2mObjectTree objectTree,
-            DownlinkRequestReceiver requestReceiver) {
-        notificationDataStore = new NotificationDataStore();
-        return new NotificationManager(objectTree, requestReceiver, notificationDataStore);
+    protected NotificationDataStore createNotificationStore() {
+        notificationDataStore = super.createNotificationStore();
+        return notificationDataStore;
     }
 
     public NotificationDataStore getNotificationDataStore() {
@@ -207,6 +203,11 @@ public class LeshanTestClient extends LeshanClient {
         // ...
     }
 
+    public void waitForBootstrapStarted() {
+        // TODO Auto-generated method stub
+
+    }
+
     public void waitForBootstrapSuccess(LeshanBootstrapServer server, long timeout, TimeUnit unit) {
         inOrder.verify(clientObserver, timeout(unit.toMillis(timeout)).times(1)).onBootstrapStarted(assertArg( //
                 s -> assertThat(server.getEndpoints()) //
@@ -258,4 +259,5 @@ public class LeshanTestClient extends LeshanClient {
         }
         return false;
     }
+
 }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClient.java
@@ -99,7 +99,7 @@ public class LeshanTestClient extends LeshanClient {
 
     public NotificationDataStore getNotificationDataStore() {
         return notificationDataStore;
-    };
+    }
 
     public String getEndpointName() {
         return endpointName;

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServer.java
@@ -316,6 +316,15 @@ public class LeshanTestServer extends LeshanServer {
         return c.getValue();
     }
 
+    public ObserveResponse waitForNotificationExactlyIn(SingleObservation observation, int timeout, TimeUnit unit,
+            double percentOfError) {
+        SingleObservation singleObservation = observation;
+        ensureNoNotification(singleObservation,
+                (int) (TimeUnit.MILLISECONDS.convert(timeout, unit) * (1d - percentOfError)), TimeUnit.MILLISECONDS);
+        return waitForNotificationOf(singleObservation,
+                (int) (TimeUnit.MILLISECONDS.convert(timeout, unit) * percentOfError * 2d), TimeUnit.MILLISECONDS);
+    }
+
     public ObserveResponse waitForNotificationThenCancelled(SingleObservation obs) {
         return waitForNotificationThenCancelled(obs, 1, TimeUnit.SECONDS);
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/AbstractLwM2mResponseAssert.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/AbstractLwM2mResponseAssert.java
@@ -36,6 +36,16 @@ public abstract class AbstractLwM2mResponseAssert<SELF extends AbstractLwM2mResp
         return (SELF) this;
     }
 
+    public SELF isSuccess() {
+        isNotNull();
+
+        if (!actual.isSuccess()) {
+            failWithMessage("Expected successful Response");
+        }
+
+        return mySelf();
+    }
+
     public SELF hasCode(ResponseCode expectedCode) {
         isNotNull();
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/AbstractLwM2mResponseAssert.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/assertion/AbstractLwM2mResponseAssert.java
@@ -40,7 +40,7 @@ public abstract class AbstractLwM2mResponseAssert<SELF extends AbstractLwM2mResp
         isNotNull();
 
         if (!actual.isSuccess()) {
-            failWithMessage("Expected successful Response");
+            failWithMessage("Expected successful Response but was %s %s", actual.getCode(), actual.getErrorMessage());
         }
 
         return mySelf();

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
 import org.eclipse.leshan.client.resource.LwM2mObjectTree;
 import org.eclipse.leshan.client.servers.LwM2mServer;
@@ -73,7 +74,7 @@ public class JavaCoapClientEndpointsProvider implements LwM2mClientEndpointsProv
 
     @Override
     public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
-            ClientEndpointToolbox toolbox) {
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox) {
         this.objectTree = objectTree;
         this.toolbox = toolbox;
 

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
@@ -17,8 +17,10 @@ package org.eclipse.leshan.transport.javacoap.client.observe;
 
 import java.net.InetSocketAddress;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.Opaque;
@@ -26,6 +28,7 @@ import com.mbed.coap.packet.Opaque;
 public class HashMapObserversStore implements ObserversStore {
 
     private final ConcurrentHashMap<Object, CoapRequest> store = new ConcurrentHashMap<>();
+    private final List<ObserversListener> listeners = new CopyOnWriteArrayList<>();
 
     @Override
     public Iterator<CoapRequest> iterator() {
@@ -34,17 +37,45 @@ public class HashMapObserversStore implements ObserversStore {
 
     @Override
     public void add(CoapRequest observeRequest) {
-        store.put(toKey(observeRequest), observeRequest);
+        CoapRequest previous = store.put(toKey(observeRequest), observeRequest);
+        if (previous != null)
+            fireObserversRemoved(previous);
+        fireObserversAdded(observeRequest);
     }
 
     @Override
     public void remove(CoapRequest observeRequest) {
-        store.remove(toKey(observeRequest));
+        CoapRequest previous = store.remove(toKey(observeRequest));
+        if (previous != null) {
+            fireObserversRemoved(previous);
+        }
     }
 
     @Override
     public boolean contains(CoapRequest observeRequest) {
         return store.containsKey(toKey(observeRequest));
+    }
+
+    @Override
+    public void addListener(ObserversListener listener) {
+        listeners.add(listener);
+    }
+
+    private void fireObserversAdded(CoapRequest observeRequest) {
+        for (ObserversListener listener : listeners) {
+            listener.observersAdded(observeRequest);
+        }
+    }
+
+    @Override
+    public void removeListener(ObserversListener listener) {
+        listeners.remove(listener);
+    }
+
+    private void fireObserversRemoved(CoapRequest observeRequest) {
+        for (ObserversListener listener : listeners) {
+            listener.observersRemoved(observeRequest);
+        }
     }
 
     protected Object toKey(CoapRequest observeRequest) {

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
@@ -42,6 +42,11 @@ public class HashMapObserversStore implements ObserversStore {
         store.remove(toKey(observeRequest));
     }
 
+    @Override
+    public boolean contains(CoapRequest observeRequest) {
+        return store.containsKey(toKey(observeRequest));
+    }
+
     protected Object toKey(CoapRequest observeRequest) {
         return new ObserverKey(observeRequest.getToken(), observeRequest.getPeerAddress());
     }
@@ -71,6 +76,12 @@ public class HashMapObserversStore implements ObserversStore {
                 return false;
             ObserverKey other = (ObserverKey) obj;
             return Objects.equals(peerAddress, other.peerAddress) && Objects.equals(token, other.token);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("ObserverKey [token=%s, peerAddress=%s]", token != null ? token.toHex() : "null",
+                    peerAddress);
         }
     }
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/LwM2mKeys.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/LwM2mKeys.java
@@ -25,4 +25,5 @@ public class LwM2mKeys {
 
     // Keys for Observe Request
     public static final Key<List<LwM2mPath>> LESHAN_OBSERVED_PATHS = new Key<>(null);
+    public static final Key<Boolean> LESHAN_NOTIFICATION = new Key<>(null);
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversListener.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 Sierra Wireless and others.
+ * Copyright (c) 2024 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -17,15 +17,9 @@ package org.eclipse.leshan.transport.javacoap.client.observe;
 
 import com.mbed.coap.packet.CoapRequest;
 
-public interface ObserversStore extends Iterable<CoapRequest> {
+public interface ObserversListener {
 
-    void add(CoapRequest observeRequest);
+    void observersAdded(CoapRequest request);
 
-    void remove(CoapRequest observeRequest);
-
-    boolean contains(CoapRequest observeRequest);
-
-    void addListener(ObserversListener listener);
-
-    void removeListener(ObserversListener listener);
+    void observersRemoved(CoapRequest request);
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversManager.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversManager.java
@@ -63,7 +63,14 @@ public class ObserversManager implements Filter.SimpleFilter<CoapRequest, CoapRe
 
     @Override
     public CompletableFuture<CoapResponse> apply(CoapRequest request, Service<CoapRequest, CoapResponse> service) {
-        return service.apply(request).thenApply(resp -> subscribe(request, resp));
+        CompletableFuture<CoapResponse> coapResponse = service.apply(request);
+        if (coapResponse != null)
+            return coapResponse.thenApply(resp -> subscribe(request, resp));
+        return null;
+    }
+
+    public boolean contains(CoapRequest req) {
+        return observersStore.contains(req);
     }
 
     private CoapResponse subscribe(CoapRequest req, CoapResponse resp) {
@@ -90,9 +97,15 @@ public class ObserversManager implements Filter.SimpleFilter<CoapRequest, CoapRe
     }
 
     private void sendObservation(CoapRequest observeRequest, Service<CoapRequest, CoapResponse> responseBuilder) {
+        CompletableFuture<CoapResponse> coapResponse = responseBuilder.apply(observeRequest);
+        if (coapResponse != null) {
+            sendObservation(observeRequest, coapResponse);
+        }
+    }
+
+    public void sendObservation(CoapRequest observeRequest, CompletableFuture<CoapResponse> response) {
         int currentObserveSequence = observeSeq.incrementAndGet();
-        responseBuilder.apply(observeRequest)
-                .thenApply(obsResponse -> toSeparateResponse(obsResponse, currentObserveSequence, observeRequest))
+        response.thenApply(obsResponse -> toSeparateResponse(obsResponse, currentObserveSequence, observeRequest))
                 .thenAccept(separateResponse -> sendObservation(observeRequest, separateResponse));
     }
 

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversManager.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversManager.java
@@ -73,6 +73,14 @@ public class ObserversManager implements Filter.SimpleFilter<CoapRequest, CoapRe
         return observersStore.contains(req);
     }
 
+    public void addListener(ObserversListener listener) {
+        observersStore.addListener(listener);
+    }
+
+    public void removeListener(ObserversListener listener) {
+        observersStore.removeListener(listener);
+    }
+
     private CoapResponse subscribe(CoapRequest req, CoapResponse resp) {
         if (req.getMethod() != Method.GET && req.getMethod() != Method.FETCH) {
             return resp;

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversStore.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/ObserversStore.java
@@ -22,4 +22,6 @@ public interface ObserversStore extends Iterable<CoapRequest> {
     void add(CoapRequest observeRequest);
 
     void remove(CoapRequest observeRequest);
+
+    boolean contains(CoapRequest observeRequest);
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
@@ -20,7 +20,9 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
+import org.eclipse.leshan.client.notification.NotificationManager;
 import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
+import org.eclipse.leshan.client.resource.NotificationSender;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.link.attributes.InvalidAttributeException;
@@ -60,7 +62,11 @@ import org.eclipse.leshan.core.response.ObserveResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
 import org.eclipse.leshan.core.response.WriteResponse;
+import org.eclipse.leshan.transport.javacoap.client.observe.LwM2mKeys;
+import org.eclipse.leshan.transport.javacoap.client.observe.ObserversManager;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
@@ -69,14 +75,21 @@ import com.mbed.coap.packet.Opaque;
 
 public class ObjectResource extends LwM2mClientCoapResource {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ObjectResource.class);
+
     protected DownlinkRequestReceiver requestReceiver;
     protected ClientEndpointToolbox toolbox;
+    protected NotificationManager notificationManager;
+    protected ObserversManager observersManager;
 
     public ObjectResource(DownlinkRequestReceiver requestReceiver, String uri, ClientEndpointToolbox toolbox,
-            ServerIdentityExtractor serverIdentityExtractor) {
+            ServerIdentityExtractor serverIdentityExtractor, NotificationManager notificationManager,
+            ObserversManager observersManager) {
         super(uri, serverIdentityExtractor);
         this.requestReceiver = requestReceiver;
         this.toolbox = toolbox;
+        this.notificationManager = notificationManager;
+        this.observersManager = observersManager;
     }
 
     @Override
@@ -139,14 +152,28 @@ public class ObjectResource extends LwM2mClientCoapResource {
                 ObserveResponse response = requestReceiver.requestReceived(identity, observeRequest).getResponse();
                 if (response.getCode() == ResponseCode.CONTENT) {
                     ContentFormat format = getContentFormat(observeRequest, requestedContentFormat);
-                    return responseWithPayload( //
+                    CompletableFuture<CoapResponse> coapResponse = responseWithPayload( //
                             response.getCode(), //
                             format, //
                             toolbox.getEncoder().encode(response.getContent(), format, getPath(URI),
                                     toolbox.getModel()));
+
+                    // store observation relation
+                    notificationManager.initRelation(identity, observeRequest, response.getContent(),
+                            createNotificationSender(coapRequest, identity, observeRequest, requestedContentFormat));
+                    return coapResponse;
                 } else {
-                    return errorMessage(response.getCode(), response.getErrorMessage());
+                    CompletableFuture<CoapResponse> errorMessage = errorMessage(response.getCode(),
+                            response.getErrorMessage());
+                    notificationManager.clear(identity, observeRequest);
+                    return errorMessage;
                 }
+            } else if (coapRequest.getTransContext(LwM2mKeys.LESHAN_NOTIFICATION, false)) {
+                // Manage Notifications
+                ObserveRequest observeRequest = new ObserveRequest(requestedContentFormat, URI, coapRequest);
+                notificationManager.notificationTriggered(identity, observeRequest,
+                        createNotificationSender(coapRequest, identity, observeRequest, requestedContentFormat));
+                return null;
             } else {
                 if (identity.isLwm2mBootstrapServer()) {
                     // Manage Bootstrap Read Request
@@ -424,5 +451,42 @@ public class ObjectResource extends LwM2mClientCoapResource {
                 return emptyResponse(response.getCode());
             }
         }
+    }
+
+    protected NotificationSender createNotificationSender(CoapRequest coapRequest, LwM2mServer server,
+            ObserveRequest observeRequest, ContentFormat requestedContentFormat) {
+        return new NotificationSender() {
+            @Override
+            public boolean sendNotification(ObserveResponse response) {
+                try {
+                    if (observersManager.contains(coapRequest))
+                        if (response.getCode() == ResponseCode.CONTENT) {
+                            ContentFormat format = getContentFormat(observeRequest, requestedContentFormat);
+                            CompletableFuture<CoapResponse> coapResponse = responseWithPayload( //
+                                    response.getCode(), //
+                                    format, //
+                                    toolbox.getEncoder().encode(response.getContent(), format,
+                                            getPath(coapRequest.options().getUriPath()), toolbox.getModel()));
+
+                            // store observation relation
+                            observersManager.sendObservation(coapRequest, coapResponse);
+                            return true;
+                        } else {
+                            CompletableFuture<CoapResponse> errorMessage = errorMessage(response.getCode(),
+                                    response.getErrorMessage());
+                            observersManager.sendObservation(coapRequest, errorMessage);
+                            return false;
+                        }
+                    else {
+                        return false;
+                    }
+                } catch (Exception e) {
+                    LOG.error("Exception while sending notification [{}] for [{}] to {}", response, observeRequest,
+                            server, e);
+                    errorMessage(ResponseCode.INTERNAL_SERVER_ERROR, "failure sending notification");
+                    return false;
+                }
+            }
+        };
     }
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.client.resource.NotificationSender;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.link.attributes.InvalidAttributeException;
+import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
 import org.eclipse.leshan.core.node.LwM2mNode;
@@ -192,9 +193,14 @@ public class ObjectResource extends LwM2mClientCoapResource {
 
                     // store observation relation if this is not a active observe cancellation
                     if (coapRequest.options().getObserve() != 1) {
-                        notificationManager.initRelation(identity, observeRequest, response.getContent(),
-                                createNotificationSender(coapRequest, identity, observeRequest,
-                                        requestedContentFormat));
+                        try {
+                            notificationManager.initRelation(identity, observeRequest, response.getContent(),
+                                    createNotificationSender(coapRequest, identity, observeRequest,
+                                            requestedContentFormat));
+                        } catch (InvalidAttributesException e) {
+                            return errorMessage(ResponseCode.INTERNAL_SERVER_ERROR,
+                                    "Invalid Attributes state : " + e.getMessage());
+                        }
                     }
                     return coapResponse;
                 } else {
@@ -243,6 +249,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
                 }
             }
         }
+
     }
 
     protected ContentFormat getContentFormat(DownlinkRequest<?> request, ContentFormat requestedContentFormat) {


### PR DESCRIPTION
This is experimental work to try to implement #534.

I tried to find solution to manage how to skip or delay notification. This a maybe a bit twisted but until now I can not find a simple way... :grimacing: 

We can not really do that at `ObjectListener` of `LwM2mObjectEnabler` because : 
 - this will affect all listeners (not only listeners related to observation)
 - this will affect all observe relation but attribute are attached by server. (and even [by request in LWM2M v1.2.x](https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Core-V1_2_1-20221209-A.html#6-4-1-0-641-Observe-Operation) )

Note that  : 
- I didn't test if this will fit with `java-coap`
- I didn't think about Observe-Composite
- the code is not complete but this is more a proof of concept which can be used as base for more development about that. 
