### PR TITLE
Add ErrorHandler to XML Parser in DDFFileParser

### DIFF
--- a/leshan-core/src/test/java/org/eclipse/leshan/core/model/DDFFileParserTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/model/DDFFileParserTest.java
@@ -25,8 +25,14 @@ public class DDFFileParserTest {
 
     @Test
     public void test_xxe_injection_failed() throws IOException, InvalidModelException, InvalidDDFFileException {
+        // check with validation
         assertThrows(InvalidDDFFileException.class, () -> {
             ObjectLoader.loadDdfResources("/models/", new String[] { "xxe_injection.xml" }, true);
+        });
+
+        // check without validation
+        assertThrows(InvalidDDFFileException.class, () -> {
+            ObjectLoader.loadDdfResources("/models/", new String[] { "xxe_injection.xml" }, false);
         });
     }
 }


### PR DESCRIPTION
This aims to fix #1521.

Some XML parser implementation print error on standard output (sysout) which sounds not a good behavior, so we replace this by : 
- logging message with `TRACE` level,
- raising exception (only when `DDFFileParser` is built with Validator). 

I wanted to add test about warning and error XML exception but I was not able to find a way to trigger it. (even by looking at XML parser source code)

I also decide to raise exception in `fatalError()` medthod, even if default implementaiton seems to do it anyway. I think the code is clearer like this. (I guess someone who don't know about this default behavior could be confused that `fataError()` doesn't raise any exception ...)