### PR TITLE
Add support of several endpoint providers

### DIFF
--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/LeshanBootstrapServerDemo.java
@@ -199,7 +199,7 @@ public class LeshanBootstrapServerDemo {
         endpointsBuilder.addEndpoint(coapsAddr, Protocol.COAPS);
 
         // Create LWM2M server
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         return builder.build();
     }
 

--- a/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/servlet/ServerServlet.java
+++ b/leshan-bsserver-demo/src/main/java/org/eclipse/leshan/server/bootstrap/demo/servlet/ServerServlet.java
@@ -27,12 +27,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.server.bootstrap.LeshanBootstrapServer;
 import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpoint;
 import org.eclipse.leshan.server.core.demo.json.PublicKeySerDes;
 import org.eclipse.leshan.server.core.demo.json.X509CertificateSerDes;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -86,22 +86,22 @@ public class ServerServlet extends HttpServlet {
         }
 
         // search coap and coaps port
-        Integer coapPort = null;
-        Integer coapsPort = null;
-        for (LwM2mBootstrapServerEndpoint endpoint : server.getEndpoints()) {
-            if (endpoint.getProtocol().equals(Protocol.COAP)) {
-                coapPort = endpoint.getURI().getPort();
-            } else if (endpoint.getProtocol().equals(Protocol.COAPS)) {
-                coapsPort = endpoint.getURI().getPort();
-            }
-        }
-
         if ("endpoint".equals(path[0])) {
-            resp.setStatus(HttpServletResponse.SC_OK);
+            ArrayNode endpoints = JsonNodeFactory.instance.arrayNode();
+            for (LwM2mBootstrapServerEndpoint endpoint : server.getEndpoints()) {
+                ObjectNode ep = JsonNodeFactory.instance.objectNode();
+                ObjectNode uri = JsonNodeFactory.instance.objectNode();
+                ep.set("uri", uri);
+                uri.put("full", endpoint.getURI().toString());
+                uri.put("scheme", endpoint.getURI().getScheme());
+                uri.put("host", endpoint.getURI().getHost());
+                uri.put("port", endpoint.getURI().getPort());
+                ep.put("description", endpoint.getDescription());
+                endpoints.add(ep);
+            }
             resp.setContentType("application/json");
-            resp.getOutputStream().write(String
-                    .format("{ \"securedEndpointPort\":\"%s\", \"unsecuredEndpointPort\":\"%s\"}", coapsPort, coapPort)
-                    .getBytes(StandardCharsets.UTF_8));
+            resp.getOutputStream().write(endpoints.toString().getBytes(StandardCharsets.UTF_8));
+            resp.setStatus(HttpServletResponse.SC_OK);
             return;
         }
 

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpoint.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpoint.java
@@ -48,6 +48,7 @@ public class CaliforniumClientEndpoint implements LwM2mClientEndpoint {
     private final Logger LOG = LoggerFactory.getLogger(CaliforniumClientEndpoint.class);
 
     private final Protocol protocol;
+    private final String description;
     private final ScheduledExecutorService executor;
     private final CoapEndpoint endpoint;
     private final ClientEndpointToolbox toolbox;
@@ -57,11 +58,12 @@ public class CaliforniumClientEndpoint implements LwM2mClientEndpoint {
     private final LwM2mModel model;
     private final ExceptionTranslator exceptionTranslator;
 
-    public CaliforniumClientEndpoint(Protocol protocol, CoapEndpoint endpoint, ClientCoapMessageTranslator translator,
-            ClientEndpointToolbox toolbox, IdentityHandler identityHandler,
+    public CaliforniumClientEndpoint(Protocol protocol, String description, CoapEndpoint endpoint,
+            ClientCoapMessageTranslator translator, ClientEndpointToolbox toolbox, IdentityHandler identityHandler,
             CaliforniumConnectionController connectionController, LwM2mModel model,
             ExceptionTranslator exceptionTranslator, ScheduledExecutorService executor) {
         this.protocol = protocol;
+        this.description = description;
         this.translator = translator;
         this.toolbox = toolbox;
         this.endpoint = endpoint;
@@ -84,9 +86,13 @@ public class CaliforniumClientEndpoint implements LwM2mClientEndpoint {
                     getCoapEndpoint().getAddress().getPort(), null, null, null);
         } catch (URISyntaxException e) {
             // TODO TL : handle this properly
-            e.printStackTrace();
             throw new IllegalStateException(e);
         }
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
     @Override

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointFactory.java
@@ -32,6 +32,8 @@ public interface CaliforniumClientEndpointFactory {
 
     Protocol getProtocol();
 
+    String getEndpointDescription();
+
     CoapEndpoint createCoapEndpoint(InetAddress clientAddress, Configuration defaultConfiguration,
             ServerInfo serverInfo, boolean clientInitiatedOnly, List<Certificate> trustStore,
             ClientEndpointToolbox toolbox);
@@ -41,5 +43,4 @@ public interface CaliforniumClientEndpointFactory {
     IdentityHandler createIdentityHandler();
 
     ExceptionTranslator createExceptionTranslator();
-
 }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
@@ -182,9 +182,10 @@ public class CaliforniumClientEndpointsProvider implements LwM2mClientEndpointsP
                     identityHandlerProvider.addIdentityHandler(coapEndpoint, identityHandler);
 
                     // create LWM2M endpoint
-                    endpoint = new CaliforniumClientEndpoint(endpointFactory.getProtocol(), coapEndpoint,
-                            messagetranslator, toolbox, identityHandler, endpointFactory.createConnectionController(),
-                            objectTree.getModel(), endpointFactory.createExceptionTranslator(), executor);
+                    endpoint = new CaliforniumClientEndpoint(endpointFactory.getProtocol(),
+                            endpointFactory.getEndpointDescription(), coapEndpoint, messagetranslator, toolbox,
+                            identityHandler, endpointFactory.createConnectionController(), objectTree.getModel(),
+                            endpointFactory.createExceptionTranslator(), executor);
 
                     // add Californium endpoint to coap server
                     coapServer.addEndpoint(coapEndpoint);
@@ -194,8 +195,8 @@ public class CaliforniumClientEndpointsProvider implements LwM2mClientEndpointsP
                         coapServer.start();
                         try {
                             coapEndpoint.start();
-                            LOG.info("New endpoint created for server {} at {}", currentServer.getUri(),
-                                    coapEndpoint.getUri());
+                            LOG.info("New {} created, \n for server {} at {}.", endpoint.getDescription(),
+                                    currentServer.getUri(), coapEndpoint.getUri());
                         } catch (IOException e) {
                             throw new RuntimeException("Unable to start endpoint", e);
                         }

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/CaliforniumClientEndpointsProvider.java
@@ -261,7 +261,7 @@ public class CaliforniumClientEndpointsProvider implements LwM2mClientEndpointsP
 
     @Override
     public LwM2mClientEndpoint getEndpoint(LwM2mServer server) {
-        if (currentServer.equals(server)) {
+        if (currentServer != null && currentServer.equals(server)) {
             return endpoint;
         }
         return null;

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapClientEndpointFactory.java
@@ -56,6 +56,11 @@ public class CoapClientEndpointFactory implements CaliforniumClientEndpointFacto
         return Protocol.COAP;
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return "CoAP over UDP endpoint based on Californium library";
+    }
+
     protected String getLoggingTag(URI uri) {
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, uri);

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapOscoreClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coap/CoapOscoreClientEndpointFactory.java
@@ -51,6 +51,11 @@ public class CoapOscoreClientEndpointFactory extends CoapClientEndpointFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(CoapOscoreClientEndpointFactory.class);
 
+    @Override
+    public String getEndpointDescription() {
+        return super.getEndpointDescription() + " with very experimental support of OSCORE";
+    }
+
     /**
      * This method is intended to be overridden.
      *

--- a/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coaps/CoapsClientEndpointFactory.java
+++ b/leshan-client-cf/src/main/java/org/eclipse/leshan/client/californium/endpoint/coaps/CoapsClientEndpointFactory.java
@@ -93,6 +93,11 @@ public class CoapsClientEndpointFactory extends CoapClientEndpointFactory {
         this("LWM2M Client");
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return "CoAP over DTLS endpoint based on Californium/Scandium library";
+    }
+
     public CoapsClientEndpointFactory(String loggingTagPrefix) {
         this.loggingTagPrefix = loggingTagPrefix;
     }

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClientBuilder.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClientBuilder.java
@@ -19,6 +19,7 @@ package org.eclipse.leshan.client;
 import java.security.cert.Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.eclipse.leshan.client.bootstrap.BootstrapConsistencyChecker;
 import org.eclipse.leshan.client.bootstrap.DefaultBootstrapConsistencyChecker;
+import org.eclipse.leshan.client.endpoint.DefaultCompositeClientEndpointsProvider;
 import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
 import org.eclipse.leshan.client.engine.DefaultRegistrationEngineFactory;
 import org.eclipse.leshan.client.engine.RegistrationEngine;
@@ -266,10 +268,28 @@ public class LeshanClientBuilder {
     }
 
     /**
-     * @return the builder for fluent client creation.
+     * By default LeshanClient doesn't support any protocol. Users need to provide 1 or several
+     * {@link LwM2mClientEndpointsProvider} implementation.
+     * <p>
+     * Leshan project provides {@code coap} and {@code coaps} support based on Californium/Scandium in
+     * <strong>leshan-client-cf</strong>.
      */
-    public LeshanClientBuilder setEndpointsProvider(LwM2mClientEndpointsProvider endpointsProvider) {
-        this.endpointsProvider = endpointsProvider;
+    public LeshanClientBuilder setEndpointsProviders(LwM2mClientEndpointsProvider... endpointsProvider) {
+        return setEndpointsProviders(Arrays.asList(endpointsProvider));
+    }
+
+    /**
+     * @see #setEndpointsProviders(LwM2mClientEndpointsProvider...)
+     */
+    public LeshanClientBuilder setEndpointsProviders(Collection<LwM2mClientEndpointsProvider> providers) {
+        if (providers == null || providers.isEmpty()) {
+            throw new IllegalStateException("At least one endpoint provider should be set");
+        }
+        if (providers.size() == 1) {
+            endpointsProvider = providers.iterator().next();
+        } else {
+            endpointsProvider = new DefaultCompositeClientEndpointsProvider(providers);
+        }
         return this;
     }
 

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/CompositeClientEndpointsProvider.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/CompositeClientEndpointsProvider.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.endpoint;
+
+import java.util.Collection;
+
+/**
+ * A {@link LwM2mClientEndpointsProvider} composed of several internal {@link LwM2mClientEndpointsProvider}.
+ * <p>
+ * Implementation should allow to use several {@link LwM2mClientEndpointsProvider}.
+ *
+ * @see DefaultCompositeClientEndpointsProvider
+ */
+public interface CompositeClientEndpointsProvider extends LwM2mClientEndpointsProvider {
+    Collection<LwM2mClientEndpointsProvider> getProviders();
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/DefaultCompositeClientEndpointsProvider.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/DefaultCompositeClientEndpointsProvider.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.client.endpoint;
+
+import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
+import org.eclipse.leshan.client.resource.LwM2mObjectTree;
+import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.client.servers.ServerInfo;
+
+/**
+ * Default implementation of {@link CompositeClientEndpointsProvider}.
+ * <p>
+ * It allows to use several {@link LwM2mClientEndpointsProvider} on same Leshan server.
+ */
+public class DefaultCompositeClientEndpointsProvider implements CompositeClientEndpointsProvider {
+
+    private final List<LwM2mClientEndpointsProvider> providers;
+
+    public DefaultCompositeClientEndpointsProvider(LwM2mClientEndpointsProvider... providers) {
+        this(Arrays.asList(providers));
+    }
+
+    public DefaultCompositeClientEndpointsProvider(Collection<LwM2mClientEndpointsProvider> providers) {
+        this.providers = Collections.unmodifiableList(new ArrayList<>(providers));
+    }
+
+    @Override
+    public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
+            ClientEndpointToolbox toolbox) {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            provider.init(objectTree, requestReceiver, toolbox);
+        }
+    }
+
+    @Override
+    public LwM2mServer createEndpoint(ServerInfo serverInfo, boolean clientInitiatedOnly, List<Certificate> trustStore,
+            ClientEndpointToolbox toolbox) {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            LwM2mServer server = provider.createEndpoint(serverInfo, clientInitiatedOnly, trustStore, toolbox);
+            if (server != null) {
+                return server;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<LwM2mServer> createEndpoints(Collection<? extends ServerInfo> serverInfo,
+            boolean clientInitiatedOnly, List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
+        // not implemented yet ...
+        return null;
+    }
+
+    @Override
+    public void destroyEndpoints() {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            provider.destroyEndpoints();
+        }
+    }
+
+    @Override
+    public void start() {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            provider.start();
+        }
+    }
+
+    @Override
+    public List<LwM2mClientEndpoint> getEndpoints() {
+        List<LwM2mClientEndpoint> endpoints = new ArrayList<>();
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            endpoints.addAll(provider.getEndpoints());
+        }
+        return endpoints;
+    }
+
+    @Override
+    public LwM2mClientEndpoint getEndpoint(LwM2mServer server) {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            LwM2mClientEndpoint endpoint = provider.getEndpoint(server);
+            if (endpoint != null) {
+                return endpoint;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void stop() {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            provider.stop();
+        }
+
+    }
+
+    @Override
+    public void destroy() {
+        for (LwM2mClientEndpointsProvider provider : providers) {
+            provider.destroy();
+        }
+    }
+
+    @Override
+    public Collection<LwM2mClientEndpointsProvider> getProviders() {
+        return providers;
+    }
+}

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/LwM2mClientEndpoint.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/endpoint/LwM2mClientEndpoint.java
@@ -30,6 +30,8 @@ public interface LwM2mClientEndpoint {
 
     URI getURI();
 
+    String getDescription();
+
     void forceReconnection(LwM2mServer server, boolean resume);
 
     long getMaxCommunicationPeriodFor(long lifetimeInMs);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -291,7 +291,7 @@ public class LeshanClientDemo {
         // Create client
         LeshanClientBuilder builder = new LeshanClientBuilder(cli.main.endpoint);
         builder.setObjects(enablers);
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         builder.setDataSenders(new ManualDataSender());
         if (cli.identity.isx509())
             builder.setTrustStore(cli.identity.getX509().trustStore);

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ServerOnlySecurityTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ServerOnlySecurityTest.java
@@ -147,7 +147,7 @@ public class ServerOnlySecurityTest {
         };
         CaliforniumClientEndpointsProvider endpointsProvider = new CaliforniumClientEndpointsProvider.Builder(
                 coapsProtocolProvider).build();
-        givenClient.setEndpointsProvider(endpointsProvider);
+        givenClient.setEndpointsProviders(endpointsProvider);
     }
 
     @AfterEach

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
@@ -248,17 +248,17 @@ public class LeshanTestClientBuilder extends LeshanClientBuilder {
     }
 
     public LeshanTestClientBuilder with(LwM2mClientEndpointsProvider endpointsProvider) {
-        setEndpointsProvider(endpointsProvider);
+        setEndpointsProviders(endpointsProvider);
         return this;
     }
 
     public LeshanTestClientBuilder with(String endpointProvider) {
         if (endpointProvider.equals("Californium")) {
-            setEndpointsProvider(
+            setEndpointsProviders(
                     new CaliforniumClientEndpointsProvider.Builder(getCaliforniumProtocolProvider(protocolToUse))
                             .build());
         } else if (endpointProvider.equals("Californium-OSCORE")) {
-            setEndpointsProvider(new CaliforniumClientEndpointsProvider.Builder(
+            setEndpointsProviders(new CaliforniumClientEndpointsProvider.Builder(
                     getCaliforniumProtocolProviderSupportingOscore(protocolToUse)).build());
         }
         return this;

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpoint.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpoint.java
@@ -45,6 +45,7 @@ import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpoint
 public class CaliforniumBootstrapServerEndpoint implements LwM2mBootstrapServerEndpoint {
 
     private final Protocol protocol;
+    private final String description;
     private final ScheduledExecutorService executor;
     private final CoapEndpoint endpoint;
     private final BootstrapServerEndpointToolbox toolbox;
@@ -56,11 +57,12 @@ public class CaliforniumBootstrapServerEndpoint implements LwM2mBootstrapServerE
     // This is used to be able to cancel request
     private final ConcurrentNavigableMap<String/* sessionId#requestId */, Request /* ongoing coap Request */> ongoingRequests = new ConcurrentSkipListMap<>();
 
-    public CaliforniumBootstrapServerEndpoint(Protocol protocol, CoapEndpoint endpoint,
+    public CaliforniumBootstrapServerEndpoint(Protocol protocol, String description, CoapEndpoint endpoint,
             BootstrapServerCoapMessageTranslator translator, BootstrapServerEndpointToolbox toolbox,
             IdentityHandler identityHandler, ExceptionTranslator exceptionTranslator,
             ScheduledExecutorService executor) {
         this.protocol = protocol;
+        this.description = description;
         this.translator = translator;
         this.toolbox = toolbox;
         this.endpoint = endpoint;
@@ -77,6 +79,11 @@ public class CaliforniumBootstrapServerEndpoint implements LwM2mBootstrapServerE
     @Override
     public URI getURI() {
         return EndpointUriUtil.createUri(protocol.getUriScheme(), endpoint.getAddress());
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
     public CoapEndpoint getCoapEndpoint() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpointFactory.java
@@ -31,6 +31,8 @@ public interface CaliforniumBootstrapServerEndpointFactory {
 
     URI getUri();
 
+    String getEndpointDescription();
+
     CoapEndpoint createCoapEndpoint(Configuration defaultCaliforniumConfiguration,
             ServerSecurityInfo serverSecurityInfo, LeshanBootstrapServer server);
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpointsProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/CaliforniumBootstrapServerEndpointsProvider.java
@@ -124,8 +124,8 @@ public class CaliforniumBootstrapServerEndpointsProvider implements LwM2mBootstr
 
                 // create LWM2M endpoint
                 CaliforniumBootstrapServerEndpoint lwm2mEndpoint = new CaliforniumBootstrapServerEndpoint(
-                        endpointFactory.getProtocol(), coapEndpoint, messagetranslator, toolbox, identityHandler,
-                        exceptionTranslator, executor);
+                        endpointFactory.getProtocol(), endpointFactory.getEndpointDescription(), coapEndpoint,
+                        messagetranslator, toolbox, identityHandler, exceptionTranslator, executor);
                 endpoints.add(lwm2mEndpoint);
 
                 // add Californium endpoint to coap server

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapBootstrapServerEndpointFactory.java
@@ -85,6 +85,11 @@ public class CoapBootstrapServerEndpointFactory implements CaliforniumBootstrapS
         return endpointUri;
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return "CoAP over UDP endpoint based on Californium library";
+    }
+
     protected String getLoggingTag() {
         if (loggingTagPrefix != null) {
             return String.format("[%s-%s]", loggingTagPrefix, getUri().toString());

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapOscoreBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coap/CoapOscoreBootstrapServerEndpointFactory.java
@@ -49,6 +49,11 @@ public class CoapOscoreBootstrapServerEndpointFactory extends CoapBootstrapServe
         super(uri);
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return super.getEndpointDescription() + " with very experimental support of OSCORE";
+    }
+
     /**
      * This method is intended to be overridden.
      *

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/bootstrap/endpoint/coaps/CoapsBootstrapServerEndpointFactory.java
@@ -84,6 +84,11 @@ public class CoapsBootstrapServerEndpointFactory implements CaliforniumBootstrap
         return Protocol.COAPS;
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return "CoAP over DTLS endpoint based on Californium/Scandium library";
+    }
+
     public static void applyDefaultValue(Configuration configuration) {
         configuration.set(CoapConfig.MID_TRACKER, TrackerMode.NULL);
         configuration.set(DtlsConfig.DTLS_ROLE, DtlsRole.SERVER_ONLY);

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpoint.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpoint.java
@@ -51,6 +51,7 @@ import org.eclipse.leshan.server.request.LowerLayerConfig;
 public class CaliforniumServerEndpoint implements LwM2mServerEndpoint {
 
     private final Protocol protocol;
+    private final String description;
     private final ScheduledExecutorService executor;
     private final CoapEndpoint endpoint;
     private final ServerEndpointToolbox toolbox;
@@ -63,11 +64,12 @@ public class CaliforniumServerEndpoint implements LwM2mServerEndpoint {
     // This is used to be able to cancel request
     private final ConcurrentNavigableMap<String/* sessionId#requestId */, Request /* ongoing coap Request */> ongoingRequests = new ConcurrentSkipListMap<>();
 
-    public CaliforniumServerEndpoint(Protocol protocol, CoapEndpoint endpoint, ServerCoapMessageTranslator translator,
-            ServerEndpointToolbox toolbox, LwM2mNotificationReceiver notificationReceiver,
-            IdentityHandler identityHandler, ExceptionTranslator exceptionTranslator,
-            ScheduledExecutorService executor) {
+    public CaliforniumServerEndpoint(Protocol protocol, String description, CoapEndpoint endpoint,
+            ServerCoapMessageTranslator translator, ServerEndpointToolbox toolbox,
+            LwM2mNotificationReceiver notificationReceiver, IdentityHandler identityHandler,
+            ExceptionTranslator exceptionTranslator, ScheduledExecutorService executor) {
         this.protocol = protocol;
+        this.description = description;
         this.translator = translator;
         this.toolbox = toolbox;
         this.endpoint = endpoint;
@@ -85,6 +87,11 @@ public class CaliforniumServerEndpoint implements LwM2mServerEndpoint {
     @Override
     public URI getURI() {
         return EndpointUriUtil.createUri(protocol.getUriScheme(), endpoint.getAddress());
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
     }
 
     public CoapEndpoint getCoapEndpoint() {

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointFactory.java
@@ -32,6 +32,8 @@ public interface CaliforniumServerEndpointFactory {
 
     URI getUri();
 
+    String getEndpointDescription();
+
     CoapEndpoint createCoapEndpoint(Configuration defaultCaliforniumConfiguration,
             ServerSecurityInfo serverSecurityInfo, LwM2mNotificationReceiver notificationReceiver, LeshanServer server);
 

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointsProvider.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/CaliforniumServerEndpointsProvider.java
@@ -138,8 +138,8 @@ public class CaliforniumServerEndpointsProvider implements LwM2mServerEndpointsP
 
                 // create LWM2M endpoint
                 CaliforniumServerEndpoint lwm2mEndpoint = new CaliforniumServerEndpoint(endpointFactory.getProtocol(),
-                        coapEndpoint, messagetranslator, toolbox, notificatonReceiver, identityHandler,
-                        exceptionTranslator, executor);
+                        endpointFactory.getEndpointDescription(), coapEndpoint, messagetranslator, toolbox,
+                        notificatonReceiver, identityHandler, exceptionTranslator, executor);
                 endpoints.add(lwm2mEndpoint);
 
                 // add Californium endpoint to coap server

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapOscoreServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapOscoreServerEndpointFactory.java
@@ -49,6 +49,11 @@ public class CoapOscoreServerEndpointFactory extends CoapServerEndpointFactory {
         super(uri);
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return super.getEndpointDescription() + " with very experimental support of OSCORE";
+    }
+
     /**
      * This method is intended to be overridden.
      *

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coap/CoapServerEndpointFactory.java
@@ -85,6 +85,11 @@ public class CoapServerEndpointFactory implements CaliforniumServerEndpointFacto
     }
 
     @Override
+    public String getEndpointDescription() {
+        return "CoAP over UDP endpoint based on Californium library";
+    }
+
+    @Override
     public URI getUri() {
         return endpointUri;
     }

--- a/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactory.java
+++ b/leshan-server-cf/src/main/java/org/eclipse/leshan/server/californium/endpoint/coaps/CoapsServerEndpointFactory.java
@@ -94,6 +94,11 @@ public class CoapsServerEndpointFactory implements CaliforniumServerEndpointFact
         return Protocol.COAPS;
     }
 
+    @Override
+    public String getEndpointDescription() {
+        return "CoAP over DTLS endpoint based on Californium/Scandium library";
+    }
+
     public static void applyDefaultValue(Configuration configuration) {
         configuration.set(CoapConfig.MID_TRACKER, TrackerMode.NULL);
         // Do no allow Server to initiated Handshake by default, for U device request will be allowed to initiate

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerBuilderTest.java
@@ -90,7 +90,7 @@ public class LeshanServerBuilderTest {
 
     @Test
     public void create_server_with_default_californiumEndpointsProvider() {
-        builder.setEndpointsProvider(new CaliforniumServerEndpointsProvider());
+        builder.setEndpointsProviders(new CaliforniumServerEndpointsProvider());
         server = builder.build();
 
         assertEquals(1, server.getEndpoints().size());
@@ -101,7 +101,7 @@ public class LeshanServerBuilderTest {
     public void create_server_without_securityStore() {
         Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(new CoapServerProtocolProvider(),
                 new CoapsServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         server = builder.build();
 
         assertEquals(1, server.getEndpoints().size());
@@ -113,7 +113,7 @@ public class LeshanServerBuilderTest {
     public void create_server_with_securityStore() {
         Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(new CoapServerProtocolProvider(),
                 new CoapsServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         builder.setSecurityStore(new InMemorySecurityStore());
         server = builder.build();
 
@@ -126,7 +126,7 @@ public class LeshanServerBuilderTest {
     @Test
     public void create_server_with_coaps_only() {
         Builder endpointsBuilder = new CaliforniumServerEndpointsProvider.Builder(new CoapsServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         builder.setSecurityStore(new InMemorySecurityStore());
         server = builder.build();
 
@@ -146,7 +146,7 @@ public class LeshanServerBuilderTest {
         builder.setPrivateKey(privateKey);
         builder.setPublicKey(publicKey);
         builder.setSecurityStore(new InMemorySecurityStore());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
 
         server = builder.build();
 

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/LeshanServerTest.java
@@ -41,7 +41,7 @@ public class LeshanServerTest {
     public void testStartStopStart() throws InterruptedException {
         Builder EndpointProviderbuilder = new CaliforniumServerEndpointsProvider.Builder();
         EndpointProviderbuilder.addEndpoint(new InetSocketAddress(0), Protocol.COAP);
-        LeshanServer server = new LeshanServerBuilder().setEndpointsProvider(EndpointProviderbuilder.build()).build();
+        LeshanServer server = new LeshanServerBuilder().setEndpointsProviders(EndpointProviderbuilder.build()).build();
 
         server.start();
         Thread.sleep(100);
@@ -57,7 +57,7 @@ public class LeshanServerTest {
 
         Builder EndpointProviderbuilder = new CaliforniumServerEndpointsProvider.Builder();
         EndpointProviderbuilder.addEndpoint(new InetSocketAddress(0), Protocol.COAP);
-        LeshanServer server = new LeshanServerBuilder().setEndpointsProvider(EndpointProviderbuilder.build()).build();
+        LeshanServer server = new LeshanServerBuilder().setEndpointsProviders(EndpointProviderbuilder.build()).build();
 
         server.start();
         Thread.sleep(100);
@@ -78,7 +78,7 @@ public class LeshanServerTest {
 
         Builder EndpointProviderbuilder = new CaliforniumServerEndpointsProvider.Builder();
         EndpointProviderbuilder.addEndpoint(new InetSocketAddress(0), Protocol.COAP);
-        LeshanServer server = new LeshanServerBuilder().setEndpointsProvider(EndpointProviderbuilder.build()).build();
+        LeshanServer server = new LeshanServerBuilder().setEndpointsProviders(EndpointProviderbuilder.build()).build();
 
         server.start();
         Thread.sleep(100);
@@ -101,7 +101,7 @@ public class LeshanServerTest {
 
         Builder EndpointProviderbuilder = new CaliforniumServerEndpointsProvider.Builder();
         EndpointProviderbuilder.addEndpoint(new InetSocketAddress(0), Protocol.COAP);
-        LeshanServer server = new LeshanServerBuilder().setEndpointsProvider(EndpointProviderbuilder.build())
+        LeshanServer server = new LeshanServerBuilder().setEndpointsProviders(EndpointProviderbuilder.build())
                 .disableQueueModeSupport().build();
         server.start();
         Thread.sleep(100);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerBuilderTest.java
@@ -104,7 +104,7 @@ public class LeshanBootstrapServerBuilderTest {
 
     @Test
     public void create_server_with_default_californiumEndpointsProvider() {
-        builder.setEndpointsProvider(new CaliforniumBootstrapServerEndpointsProvider());
+        builder.setEndpointsProviders(new CaliforniumBootstrapServerEndpointsProvider());
         server = builder.build();
 
         assertEquals(1, server.getEndpoints().size());
@@ -115,7 +115,7 @@ public class LeshanBootstrapServerBuilderTest {
     public void create_server_without_securityStore() {
         Builder endpointsBuilder = new CaliforniumBootstrapServerEndpointsProvider.Builder(
                 new CoapBootstrapServerProtocolProvider(), new CoapsBootstrapServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         server = builder.build();
 
         assertEquals(1, server.getEndpoints().size());
@@ -127,7 +127,7 @@ public class LeshanBootstrapServerBuilderTest {
     public void create_server_with_securityStore() {
         Builder endpointsBuilder = new CaliforniumBootstrapServerEndpointsProvider.Builder(
                 new CoapBootstrapServerProtocolProvider(), new CoapsBootstrapServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         builder.setSecurityStore(new BootstrapSecurityStore() {
             @Override
             public SecurityInfo getByIdentity(String pskIdentity) {
@@ -156,7 +156,7 @@ public class LeshanBootstrapServerBuilderTest {
     public void create_server_with_coaps_only() {
         Builder endpointsBuilder = new CaliforniumBootstrapServerEndpointsProvider.Builder(
                 new CoapsBootstrapServerProtocolProvider());
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         builder.setSecurityStore(new BootstrapSecurityStore() {
             @Override
             public SecurityInfo getByIdentity(String pskIdentity) {
@@ -187,7 +187,7 @@ public class LeshanBootstrapServerBuilderTest {
         endpointsBuilder.setConfiguration(c -> {
             c.setAsList(DtlsConfig.DTLS_CIPHER_SUITES, CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8);
         });
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
 
         builder.setPrivateKey(privateKey);
         builder.setPublicKey(publicKey);

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/bootstrap/LeshanBootstrapServerTest.java
@@ -63,7 +63,7 @@ public class LeshanBootstrapServerTest {
                 return config;
             }
         });
-        builder.setEndpointsProvider(new CaliforniumBootstrapServerEndpointsProvider());
+        builder.setEndpointsProviders(new CaliforniumBootstrapServerEndpointsProvider());
         return builder.build();
 
     }

--- a/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
+++ b/leshan-server-cf/src/test/java/org/eclipse/leshan/server/californium/observation/ObservationServiceTest.java
@@ -214,6 +214,11 @@ public class ObservationServiceTest {
             }
 
             @Override
+            public String getDescription() {
+                return null;
+            }
+
+            @Override
             public Protocol getProtocol() {
                 return null;
             }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/LeshanServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/LeshanServer.java
@@ -261,7 +261,7 @@ public class LeshanServer {
         if (LOG.isInfoEnabled()) {
             LOG.info("LWM2M server started.");
             for (LwM2mServerEndpoint endpoint : endpointsProvider.getEndpoints()) {
-                LOG.info("{} endpoint available at {}.", endpoint.getProtocol().getName(), endpoint.getURI());
+                LOG.info("{} available at {}.", endpoint.getDescription(), endpoint.getURI());
             }
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/LeshanServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/LeshanServer.java
@@ -17,8 +17,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.server;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.leshan.core.Destroyable;
@@ -42,6 +42,7 @@ import org.eclipse.leshan.core.response.ErrorCallback;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.core.response.ResponseCallback;
 import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.endpoint.CompositeServerEndpointsProvider;
 import org.eclipse.leshan.server.endpoint.LwM2mServerEndpoint;
 import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
 import org.eclipse.leshan.server.endpoint.ServerEndpointToolbox;
@@ -376,9 +377,10 @@ public class LeshanServer {
     }
 
     public Collection<LwM2mServerEndpointsProvider> getEndpointsProvider() {
-        // TODO current we support only 1 endpoints provider but we will add support for multiple endpoints provider
-        // soon
-        return Arrays.asList(endpointsProvider);
+        if (endpointsProvider instanceof CompositeServerEndpointsProvider) {
+            return ((CompositeServerEndpointsProvider) endpointsProvider).getProviders();
+        }
+        return Collections.singleton(endpointsProvider);
     }
 
     public List<LwM2mServerEndpoint> getEndpoints() {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServer.java
@@ -104,7 +104,7 @@ public class LeshanBootstrapServer {
         if (LOG.isInfoEnabled()) {
             LOG.info("Bootstrap server started.");
             for (LwM2mBootstrapServerEndpoint endpoint : endpointsProvider.getEndpoints()) {
-                LOG.info("{} endpoint available at {}.", endpoint.getProtocol().getName(), endpoint.getURI());
+                LOG.info("{} available at {}.", endpoint.getDescription(), endpoint.getURI());
             }
         }
     }

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServer.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServer.java
@@ -16,8 +16,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.server.bootstrap;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.leshan.core.Destroyable;
@@ -29,11 +29,13 @@ import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
 import org.eclipse.leshan.core.util.Validate;
 import org.eclipse.leshan.server.bootstrap.endpoint.BootstrapServerEndpointToolbox;
+import org.eclipse.leshan.server.bootstrap.endpoint.CompositeBootstrapServerEndpointsProvider;
 import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpoint;
 import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpointsProvider;
 import org.eclipse.leshan.server.bootstrap.request.BootstrapDownlinkRequestSender;
 import org.eclipse.leshan.server.bootstrap.request.DefaultBootstrapDownlinkRequestSender;
 import org.eclipse.leshan.server.bootstrap.request.DefaultBootstrapUplinkRequestReceiver;
+import org.eclipse.leshan.server.endpoint.CompositeServerEndpointsProvider;
 import org.eclipse.leshan.server.security.BootstrapSecurityStore;
 import org.eclipse.leshan.server.security.ServerSecurityInfo;
 import org.slf4j.Logger;
@@ -148,9 +150,10 @@ public class LeshanBootstrapServer {
     }
 
     public Collection<LwM2mBootstrapServerEndpointsProvider> getEndpointsProvider() {
-        // TODO current we support only 1 endpoints provider but we will add support for multiple endpoints provider
-        // soon
-        return Arrays.asList(endpointsProvider);
+        if (endpointsProvider instanceof CompositeServerEndpointsProvider) {
+            return ((CompositeBootstrapServerEndpointsProvider) endpointsProvider).getProviders();
+        }
+        return Collections.singleton(endpointsProvider);
     }
 
     public LwM2mBootstrapServerEndpoint getEndpoint(Protocol protocol) {

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServerBuilder.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/LeshanBootstrapServerBuilder.java
@@ -21,6 +21,8 @@ import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collection;
 
 import org.eclipse.leshan.core.link.lwm2m.DefaultLwM2mLinkParser;
 import org.eclipse.leshan.core.link.lwm2m.LwM2mLinkParser;
@@ -29,6 +31,7 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
 import org.eclipse.leshan.core.node.codec.LwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.LwM2mEncoder;
+import org.eclipse.leshan.server.bootstrap.endpoint.DefaultCompositeBootstrapServerEndpointsProvider;
 import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpointsProvider;
 import org.eclipse.leshan.server.bootstrap.request.BootstrapDownlinkRequestSender;
 import org.eclipse.leshan.server.model.LwM2mBootstrapModelProvider;
@@ -255,8 +258,31 @@ public class LeshanBootstrapServerBuilder {
         return this;
     }
 
-    public LeshanBootstrapServerBuilder setEndpointsProvider(LwM2mBootstrapServerEndpointsProvider endpointsProvider) {
-        this.endpointsProvider = endpointsProvider;
+    /**
+     * By default LeshanBootstrapServer doesn't support any protocol. Users need to provide 1 or several
+     * {@link LwM2mBootstrapServerEndpointsProvider} implementation.
+     * <p>
+     * Leshan project provides {@code coap} and {@code coaps} support based on Californium/Scandium in
+     * <strong>leshan-server-cf</strong>.
+     */
+    public LeshanBootstrapServerBuilder setEndpointsProviders(
+            LwM2mBootstrapServerEndpointsProvider... endpointsProvider) {
+        return setEndpointsProviders(Arrays.asList(endpointsProvider));
+    }
+
+    /**
+     * @see #setEndpointsProviders(LwM2mBootstrapServerEndpointsProvider...)
+     */
+    public LeshanBootstrapServerBuilder setEndpointsProviders(
+            Collection<LwM2mBootstrapServerEndpointsProvider> providers) {
+        if (providers == null || providers.isEmpty()) {
+            throw new IllegalStateException("At least one endpoint provider should be set");
+        }
+        if (providers.size() == 1) {
+            this.endpointsProvider = providers.iterator().next();
+        } else {
+            this.endpointsProvider = new DefaultCompositeBootstrapServerEndpointsProvider(providers);
+        }
         return this;
     }
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/CompositeBootstrapServerEndpointsProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/CompositeBootstrapServerEndpointsProvider.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap.endpoint;
+
+import java.util.Collection;
+
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+
+/**
+ * A {@link LwM2mBootstrapServerEndpointsProvider} composed of several internal
+ * {@link LwM2mBootstrapServerEndpointsProvider}.
+ * <p>
+ * Implementation should allow to use several {@link LwM2mBootstrapServerEndpointsProvider}.
+ *
+ * @see DefaultCompositeBootstrapServerEndpointsProvider
+ */
+public interface CompositeBootstrapServerEndpointsProvider extends LwM2mBootstrapServerEndpointsProvider {
+
+    /**
+     * @return all internal {@link LwM2mServerEndpointsProvider}.
+     */
+    Collection<LwM2mBootstrapServerEndpointsProvider> getProviders();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/DefaultCompositeBootstrapServerEndpointsProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/DefaultCompositeBootstrapServerEndpointsProvider.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.bootstrap.endpoint;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.bootstrap.LeshanBootstrapServer;
+import org.eclipse.leshan.server.bootstrap.request.BootstrapUplinkRequestReceiver;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+
+/**
+ * Default implementation of {@link CompositeBootstrapServerEndpointsProvider}.
+ * <p>
+ * It allows to use several {@link LwM2mBootstrapServerEndpointsProvider} on same Leshan server.
+ */
+public class DefaultCompositeBootstrapServerEndpointsProvider implements CompositeBootstrapServerEndpointsProvider {
+
+    private final List<LwM2mBootstrapServerEndpointsProvider> providers;
+
+    public DefaultCompositeBootstrapServerEndpointsProvider(LwM2mBootstrapServerEndpointsProvider... providers) {
+        this(Arrays.asList(providers));
+    }
+
+    public DefaultCompositeBootstrapServerEndpointsProvider(
+            Collection<LwM2mBootstrapServerEndpointsProvider> providers) {
+        Validate.notEmpty(providers);
+        this.providers = Collections.unmodifiableList(new ArrayList<>(providers));
+    }
+
+    @Override
+    public List<LwM2mBootstrapServerEndpoint> getEndpoints() {
+        List<LwM2mBootstrapServerEndpoint> endpoints = new ArrayList<>();
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            endpoints.addAll(provider.getEndpoints());
+        }
+        return endpoints;
+    }
+
+    @Override
+    public LwM2mBootstrapServerEndpoint getEndpoint(URI uri) {
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            LwM2mBootstrapServerEndpoint endpoint = provider.getEndpoint(uri);
+            if (endpoint != null) {
+                return endpoint;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void createEndpoints(BootstrapUplinkRequestReceiver requestReceiver, BootstrapServerEndpointToolbox toolbox,
+            ServerSecurityInfo serverSecurityInfo, LeshanBootstrapServer server) {
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            provider.createEndpoints(requestReceiver, toolbox, serverSecurityInfo, server);
+        }
+    }
+
+    @Override
+    public void start() {
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            provider.start();
+        }
+    }
+
+    @Override
+    public void stop() {
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            provider.stop();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        for (LwM2mBootstrapServerEndpointsProvider provider : providers) {
+            provider.destroy();
+        }
+    }
+
+    @Override
+    public Collection<LwM2mBootstrapServerEndpointsProvider> getProviders() {
+        return providers;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/LwM2mBootstrapServerEndpoint.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/bootstrap/endpoint/LwM2mBootstrapServerEndpoint.java
@@ -30,6 +30,8 @@ public interface LwM2mBootstrapServerEndpoint {
 
     URI getURI();
 
+    String getDescription();
+
     <T extends LwM2mResponse> T send(BootstrapSession destination, BootstrapDownlinkRequest<T> request,
             long timeoutInMs) throws InterruptedException;
 

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/CompositeServerEndpointsProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/CompositeServerEndpointsProvider.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.endpoint;
+
+import java.util.Collection;
+
+/**
+ * A {@link LwM2mServerEndpointsProvider} composed of several internal {@link LwM2mServerEndpointsProvider}.
+ * <p>
+ * Implementation should allow to use several {@link LwM2mServerEndpointsProvider}.
+ *
+ * @see DefaultCompositeServerEndpointsProvider
+ */
+public interface CompositeServerEndpointsProvider extends LwM2mServerEndpointsProvider {
+
+    /**
+     * @return all internal {@link LwM2mServerEndpointsProvider}.
+     */
+    Collection<LwM2mServerEndpointsProvider> getProviders();
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/DefaultCompositeServerEndpointsProvider.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/DefaultCompositeServerEndpointsProvider.java
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.server.endpoint;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.leshan.core.util.Validate;
+import org.eclipse.leshan.server.LeshanServer;
+import org.eclipse.leshan.server.observation.LwM2mNotificationReceiver;
+import org.eclipse.leshan.server.request.UplinkRequestReceiver;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+
+/**
+ * Default implementation of {@link CompositeServerEndpointsProvider}.
+ * <p>
+ * It allows to use several {@link LwM2mServerEndpointsProvider} on same Leshan server.
+ */
+public class DefaultCompositeServerEndpointsProvider implements CompositeServerEndpointsProvider {
+
+    private final List<LwM2mServerEndpointsProvider> providers;
+
+    public DefaultCompositeServerEndpointsProvider(LwM2mServerEndpointsProvider... providers) {
+        this(Arrays.asList(providers));
+    }
+
+    public DefaultCompositeServerEndpointsProvider(Collection<LwM2mServerEndpointsProvider> providers) {
+        Validate.notEmpty(providers);
+        this.providers = Collections.unmodifiableList(new ArrayList<>(providers));
+    }
+
+    @Override
+    public List<LwM2mServerEndpoint> getEndpoints() {
+        List<LwM2mServerEndpoint> endpoints = new ArrayList<>();
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            endpoints.addAll(provider.getEndpoints());
+        }
+        return endpoints;
+    }
+
+    @Override
+    public LwM2mServerEndpoint getEndpoint(URI uri) {
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            LwM2mServerEndpoint endpoint = provider.getEndpoint(uri);
+            if (endpoint != null) {
+                return endpoint;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void createEndpoints(UplinkRequestReceiver requestReceiver, LwM2mNotificationReceiver observationService,
+            ServerEndpointToolbox toolbox, ServerSecurityInfo serverSecurityInfo, LeshanServer server) {
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            provider.createEndpoints(requestReceiver, observationService, toolbox, serverSecurityInfo, server);
+        }
+    }
+
+    @Override
+    public void start() {
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            provider.start();
+        }
+    }
+
+    @Override
+    public void stop() {
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            provider.stop();
+        }
+    }
+
+    @Override
+    public void destroy() {
+        for (LwM2mServerEndpointsProvider provider : providers) {
+            provider.destroy();
+        }
+    }
+
+    @Override
+    public Collection<LwM2mServerEndpointsProvider> getProviders() {
+        return providers;
+    }
+}

--- a/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/LwM2mServerEndpoint.java
+++ b/leshan-server-core/src/main/java/org/eclipse/leshan/server/endpoint/LwM2mServerEndpoint.java
@@ -32,6 +32,8 @@ public interface LwM2mServerEndpoint {
 
     URI getURI();
 
+    String getDescription();
+
     <T extends LwM2mResponse> T send(ClientProfile destination, DownlinkRequest<T> request,
             LowerLayerConfig lowerLayerConfig, long timeoutInMs) throws InterruptedException;
 

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -250,7 +250,7 @@ public class LeshanServerDemo {
         endpointsBuilder.addEndpoint(coapsAddr, Protocol.COAPS);
 
         // Create LWM2M server
-        builder.setEndpointsProvider(endpointsBuilder.build());
+        builder.setEndpointsProviders(endpointsBuilder.build());
         return builder.build();
     }
 


### PR DESCRIPTION
Before this PR, it was possible to provider only 1 endpoints providers by Leshan client/server/bootstrap server.
Now it's possible to use several at same time. 


~(I plan to also add new CLI command to demo to configure transport layer in this PR, inspired by  #1522)~
Finally, I dropped from this PR the addition of CLI command to configure transport layer because of https://github.com/eclipse-leshan/leshan/pull/1522#issuecomment-1759604768) 
I put my ongoing work in `transport_command2` branch just in case but I'm not sure it will be reusable. 
