### PR TITLE
Add coap+tcp support based on java-coap to client and server. 

### DIFF
--- a/build-config/lib-build-config/pom.xml
+++ b/build-config/lib-build-config/pom.xml
@@ -104,6 +104,13 @@ Contributors:
                     <matcher>java-package</matcher>
                     <match>/com\.mbed\.coap(\..*)?/</match>
                   </item>
+                  <item>
+                    <!-- HACK : we exclude com.mbed because of revapi bug. 
+                         See : https://github.com/revapi/revapi/issues/186
+                         This should be removed once it will be fixed in revapi. -->
+                    <matcher>java-package</matcher>
+                    <match>/io\.netty(\..*)?/</match>
+                  </item>
                 </exclude>
               </elements>
             </revapi.filter>

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClientBuilder.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/LeshanClientBuilder.java
@@ -41,6 +41,7 @@ import org.eclipse.leshan.client.send.DataSender;
 import org.eclipse.leshan.client.util.LinkFormatHelper;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2mId;
+import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.DefaultLinkSerializer;
 import org.eclipse.leshan.core.link.LinkSerializer;
 import org.eclipse.leshan.core.link.lwm2m.attributes.DefaultLwM2mAttributeParser;
@@ -299,11 +300,14 @@ public class LeshanClientBuilder {
     public LeshanClient build() {
         if (objectEnablers == null) {
             ObjectsInitializer initializer = new ObjectsInitializer();
-            initializer.setInstancesForObject(LwM2mId.SECURITY,
-                    Security.noSec("coap://leshan.eclipseprojects.io:5683", 12345));
-            initializer.setInstancesForObject(LwM2mId.SERVER, new Server(12345, 5 * 60));
+            String defaultServerUri = "coap://leshan.eclipseprojects.io:5683";
+            BindingMode serverBindingMode = BindingMode.fromProtocol(Protocol.fromUri(defaultServerUri));
+
+            initializer.setInstancesForObject(LwM2mId.SECURITY, Security.noSec(defaultServerUri, 12345));
+            initializer.setInstancesForObject(LwM2mId.SERVER,
+                    new Server(12345, 5 * 60, EnumSet.of(serverBindingMode), false, serverBindingMode));
             initializer.setInstancesForObject(LwM2mId.DEVICE,
-                    new Device("Eclipse Leshan", "model12345", "12345", EnumSet.of(BindingMode.U)));
+                    new Device("Eclipse Leshan", "model12345", "12345", EnumSet.of(serverBindingMode)));
             objectEnablers = initializer.createAll();
         }
         if (dataSenders == null)

--- a/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
+++ b/leshan-client-core/src/main/java/org/eclipse/leshan/client/servers/ServersInfoExtractor.java
@@ -281,8 +281,8 @@ public class ServersInfoExtractor {
         }
     }
 
-    public static EnumSet<BindingMode> getDeviceSupportedBindingMode(LwM2mObjectEnabler serverEnabler, int instanceId) {
-        ReadResponse response = serverEnabler.read(LwM2mServer.SYSTEM,
+    public static EnumSet<BindingMode> getDeviceSupportedBindingMode(LwM2mObjectEnabler deviceEnabler, int instanceId) {
+        ReadResponse response = deviceEnabler.read(LwM2mServer.SYSTEM,
                 new ReadRequest(DEVICE, instanceId, DVC_SUPPORTED_BINDING));
         if (response.isSuccess()) {
             return BindingMode.parse((String) ((LwM2mResource) response.getContent()).getValue());

--- a/leshan-client-demo/pom.xml
+++ b/leshan-client-demo/pom.xml
@@ -39,6 +39,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-client-coaptcp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-core-demo</artifactId>
     </dependency>
   </dependencies>

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -34,6 +34,7 @@ import static org.eclipse.leshan.core.LwM2mId.SERVER;
 import java.io.File;
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 
 import org.eclipse.californium.elements.config.Configuration;
@@ -64,6 +65,7 @@ import org.eclipse.leshan.core.californium.PrincipalMdcConnectionListener;
 import org.eclipse.leshan.core.demo.LwM2mDemoConstant;
 import org.eclipse.leshan.core.demo.cli.ShortErrorMessageHandler;
 import org.eclipse.leshan.core.demo.cli.interactive.InteractiveCLI;
+import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.model.LwM2mModelRepository;
 import org.eclipse.leshan.core.model.ObjectLoader;
 import org.eclipse.leshan.core.model.ObjectModel;
@@ -71,9 +73,11 @@ import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mDecoder;
 import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
 import org.eclipse.leshan.core.node.codec.text.LwM2mNodeTextDecoder;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.response.BootstrapWriteResponse;
+import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -201,31 +205,37 @@ public class LeshanClientDemo {
                 initializer.setClassForObject(SERVER, Server.class);
             }
         } else {
+            BindingMode serverBindingMode = BindingMode.fromProtocol(Protocol.fromUri(cli.main.url));
+
             if (cli.identity.isPSK()) {
                 // TODO OSCORE support OSCORE with DTLS/PSK
                 initializer.setInstancesForObject(SECURITY, psk(cli.main.url, 123,
                         cli.identity.getPsk().identity.getBytes(), cli.identity.getPsk().sharekey.getBytes()));
-                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec));
+                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec,
+                        EnumSet.of(serverBindingMode), false, serverBindingMode));
             } else if (cli.identity.isRPK()) {
                 // TODO OSCORE support OSCORE with DTLS/RPK
                 initializer.setInstancesForObject(SECURITY,
                         rpk(cli.main.url, 123, cli.identity.getRPK().cpubk.getEncoded(),
                                 cli.identity.getRPK().cprik.getEncoded(), cli.identity.getRPK().spubk.getEncoded()));
-                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec));
+                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec,
+                        EnumSet.of(serverBindingMode), false, serverBindingMode));
             } else if (cli.identity.isx509()) {
                 // TODO OSCORE support OSCORE with DTLS/X509
                 initializer.setInstancesForObject(SECURITY,
                         x509(cli.main.url, 123, cli.identity.getX509().ccert.getEncoded(),
                                 cli.identity.getX509().cprik.getEncoded(), cli.identity.getX509().scert.getEncoded(),
                                 cli.identity.getX509().certUsage.code));
-                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec));
+                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec,
+                        EnumSet.of(serverBindingMode), false, serverBindingMode));
             } else {
                 if (oscoreObjectInstanceId != null) {
                     initializer.setInstancesForObject(SECURITY, oscoreOnly(cli.main.url, 123, oscoreObjectInstanceId));
                 } else {
                     initializer.setInstancesForObject(SECURITY, noSec(cli.main.url, 123));
                 }
-                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec));
+                initializer.setInstancesForObject(SERVER, new Server(123, cli.main.lifetimeInSec,
+                        EnumSet.of(serverBindingMode), false, serverBindingMode));
             }
         }
         initializer.setInstancesForObject(DEVICE, new MyDevice());
@@ -308,6 +318,7 @@ public class LeshanClientDemo {
         if (cli.main.useJavaCoap) {
             endpointsProvider.add(new JavaCoapClientEndpointsProvider());
         }
+        endpointsProvider.add(new JavaCoapTcpClientEndpointsProvider());
 
         // Create client
         LeshanClientBuilder builder = new LeshanClientBuilder(cli.main.endpoint);

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/MyDevice.java
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import org.eclipse.leshan.core.Destroyable;
 import org.eclipse.leshan.core.model.ObjectModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
 import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.request.BindingMode;
 import org.eclipse.leshan.core.request.argument.Arguments;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 import org.eclipse.leshan.core.response.ReadResponse;
@@ -200,7 +202,7 @@ public class MyDevice extends BaseInstanceEnabler implements Destroyable {
     }
 
     private String getSupportedBinding() {
-        return "U";
+        return BindingMode.toString(EnumSet.of(BindingMode.U, BindingMode.T));
     }
 
     private String getDeviceType() {

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -317,11 +317,10 @@ public class LeshanClientDemoCLI implements Runnable {
         int indexOf = main.url.indexOf("://");
         String scheme = main.url.substring(0, indexOf);
         // we support only coap and coaps
-        if (!"coap".equals(scheme) && !"coaps".equals(scheme)) {
-            throw new MultiParameterException(spec.commandLine(),
-                    String.format("Invalid URL %s : unknown scheme '%s', we support only 'coap' or 'coaps' for now",
-                            main.url, scheme),
-                    "-u");
+        if (!"coap".equals(scheme) && !"coaps".equals(scheme) && !"coap+tcp".equals(scheme)) {
+            throw new MultiParameterException(spec.commandLine(), String.format(
+                    "Invalid URL %s : unknown scheme '%s', we support only 'coap' or 'coaps' or 'coap+tcp' for now",
+                    main.url, scheme), "-u");
         }
         // check scheme matches configuration
         if (identity.hasIdentity()) {
@@ -331,7 +330,7 @@ public class LeshanClientDemoCLI implements Runnable {
                         main.url, scheme), "-u");
             }
         } else {
-            if (!scheme.equals("coap")) {
+            if (!scheme.equals("coap") && !scheme.equals("coap+tcp")) {
                 throw new MultiParameterException(spec.commandLine(), String.format(
                         "Invalid URL %s : '%s' scheme must be used with PSK, RPK or x509 option. Do you mean 'coap' ? ",
                         main.url, scheme), "-u");

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
@@ -22,6 +22,9 @@ public class Protocol {
     public static final Protocol COAP_TCP = new Protocol("COAP_TCP", "coap+tcp");
     public static final Protocol COAPS_TCP = new Protocol("COAPS_TCP", "coaps+tcp");
 
+    private static final Protocol[] knownProtocols = new Protocol[] { Protocol.COAP, Protocol.COAPS, Protocol.COAP_TCP,
+            Protocol.COAPS_TCP };
+
     private final String name;
     private final String uriScheme;
 
@@ -66,5 +69,14 @@ public class Protocol {
     @Override
     public String toString() {
         return getName();
+    }
+
+    public static Protocol fromUri(String uri) {
+        for (Protocol protocol : knownProtocols) {
+            if (uri.startsWith(protocol.getUriScheme() + ":")) {
+                return protocol;
+            }
+        }
+        return null;
     }
 }

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/request/BindingMode.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.core.request;
 import java.util.EnumSet;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
+import org.eclipse.leshan.core.endpoint.Protocol;
 
 /**
  * Transport binding and Queue Mode
@@ -77,6 +78,15 @@ public enum BindingMode {
             throw new IllegalArgumentException("No enum constant " + c + ".");
 
         }
+    }
+
+    public static BindingMode fromProtocol(Protocol protocol) {
+        if (protocol.equals(Protocol.COAP) || protocol.equals(Protocol.COAPS)) {
+            return BindingMode.U;
+        } else if (protocol.equals(Protocol.COAP_TCP) || protocol.equals(Protocol.COAPS_TCP)) {
+            return BindingMode.T;
+        }
+        throw new IllegalArgumentException("Unknown Protocol " + protocol);
     }
 
     /**

--- a/leshan-integration-tests/pom.xml
+++ b/leshan-integration-tests/pom.xml
@@ -44,6 +44,10 @@ Contributors:
     </dependency>
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-server-coaptcp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-server-redis</artifactId>
     </dependency>
     <dependency>
@@ -53,6 +57,10 @@ Contributors:
     <dependency>
       <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-javacoap-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-client-coaptcp</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DeleteTest.java
@@ -65,7 +65,8 @@ public class DeleteTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DiscoverTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/DiscoverTest.java
@@ -65,7 +65,8 @@ public class DiscoverTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/ExecuteTest.java
@@ -62,7 +62,8 @@ public class ExecuteTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/QueueModeTest.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.integration.tests;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestServerBuilder.givenServerUsing;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
@@ -61,7 +62,8 @@ public class QueueModeTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/
@@ -182,6 +184,13 @@ public class QueueModeTest {
     @TestAllTransportLayer
     public void sleeping_if_timeout(Protocol givenProtocol, String givenClientEndpointProvider,
             String givenServerEndpointProvider) throws InterruptedException {
+
+        // TODO this test should be adapted to support COAP+TCP
+        // with coap with tcp we SHOULD get a UnconnectedPeerException instead of timeout
+        // leshan code based on javacoap for coap+tcp code should be adapted too.
+        // (currently it doesn't send an UnconnectedPeerException)
+        assumeTrue(Protocol.COAP.equals(givenProtocol));
+
         // Check client is not registered
         assertThat(client).isNotRegisteredAt(server);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/RegistrationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertArg;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -78,7 +79,8 @@ public class RegistrationTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/
@@ -144,6 +146,12 @@ public class RegistrationTest {
     @TestAllTransportLayer
     public void deregister_cancel_multiple_pending_request(Protocol protocol, String clientEndpointProvider,
             String serverEndpointProvider) throws InterruptedException, LinkParseException {
+        // This test written like this, can not work with coap+tcp
+        // because when we stop client, tcp connection is close
+        // and so when we send a request we get an exception instead of waiting until cancelation.
+        // TODO I don't know what we should do.
+        assumeFalse(Protocol.COAP_TCP.equals(protocol));
+
         // Check client is not registered
         client = givenClient.build();
         assertThat(client).isNotRegisteredAt(server);
@@ -189,7 +197,6 @@ public class RegistrationTest {
         for (int index = 0; index < numberOfRequests; ++index) {
             verify(responseCallbacks.get(index), never()).onResponse(any());
         }
-
     }
 
     @TestAllTransportLayer

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeDiscoverTest.java
@@ -70,7 +70,8 @@ public class WriteAttributeDiscoverTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeFailedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeFailedTest.java
@@ -60,7 +60,8 @@ public class WriteAttributeFailedTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[][] testCases = new Object[][] { //
                 // targeted path - initial state - invalid attributes to write

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeHouseKeepingTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.leshan.core.util.TestLwM2mId.MULTIPLE_INTEGER_VALUE;
 import static org.eclipse.leshan.core.util.TestLwM2mId.TEST_OBJECT;
 import static org.eclipse.leshan.integration.tests.util.LeshanTestClientBuilder.givenClientUsing;
 import static org.eclipse.leshan.integration.tests.util.assertion.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.lang.annotation.Retention;
@@ -77,7 +78,8 @@ public class WriteAttributeHouseKeepingTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/
@@ -193,6 +195,8 @@ public class WriteAttributeHouseKeepingTest {
     public void write_attribute_then_observe_object_then_passive_cancel_then_check_no_more_notification_data(
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
+
+        assumeFalse(givenProtocol.equals(Protocol.COAP_TCP)); // there is no passive cancel with CoAP TCP
         write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT));
     }
@@ -202,6 +206,7 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
+        assumeFalse(givenProtocol.equals(Protocol.COAP_TCP)); // there is no passive cancel with CoAP TCP
         write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0));
     }
@@ -211,6 +216,7 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
+        assumeFalse(givenProtocol.equals(Protocol.COAP_TCP)); // there is no passive cancel with CoAP TCP
         write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE));
     }
@@ -220,6 +226,7 @@ public class WriteAttributeHouseKeepingTest {
             Protocol givenProtocol, String givenClientEndpointProvider, String givenServerEndpointProvider)
             throws InterruptedException {
 
+        assumeFalse(givenProtocol.equals(Protocol.COAP_TCP)); // there is no passive cancel with CoAP TCP
         write_attribute_then_observe_then_passive_cancel_then_check_no_more_notification_data(
                 new LwM2mPath(TEST_OBJECT, 0, MULTIPLE_INTEGER_VALUE, 0));
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/attributes/WriteAttributeObserveTest.java
@@ -80,7 +80,8 @@ public class WriteAttributeObserveTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/create/CreateFailedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/create/CreateFailedTest.java
@@ -58,7 +58,8 @@ public class CreateFailedTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/create/CreateTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/create/CreateTest.java
@@ -75,7 +75,8 @@ public class CreateTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.TLV, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveCompositeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveCompositeTest.java
@@ -80,7 +80,8 @@ public class ObserveCompositeTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveTest.java
@@ -88,7 +88,8 @@ public class ObserveTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadCompositeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadCompositeTest.java
@@ -72,7 +72,8 @@ public class ReadCompositeTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[][] contentFormats = new Object[][] { //
                 // {request content format, response content format}

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadFailedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadFailedTest.java
@@ -57,7 +57,8 @@ public class ReadFailedTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadMultiValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadMultiValueTest.java
@@ -64,7 +64,8 @@ public class ReadMultiValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.TLV, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadOpaqueValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadOpaqueValueTest.java
@@ -65,7 +65,8 @@ public class ReadOpaqueValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.OPAQUE, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadSingleValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/read/ReadSingleValueTest.java
@@ -65,7 +65,8 @@ public class ReadSingleValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.TEXT, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTest.java
@@ -73,7 +73,8 @@ public class SendTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.SENML_JSON, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTimestampedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/send/SendTimestampedTest.java
@@ -70,7 +70,8 @@ public class SendTimestampedTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.SENML_JSON, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestClientBuilder.java
@@ -81,6 +81,7 @@ import org.eclipse.leshan.server.LeshanServer;
 import org.eclipse.leshan.server.bootstrap.LeshanBootstrapServer;
 import org.eclipse.leshan.server.bootstrap.endpoint.LwM2mBootstrapServerEndpoint;
 import org.eclipse.leshan.server.endpoint.LwM2mServerEndpoint;
+import org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint.JavaCoapTcpClientEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
 
 public class LeshanTestClientBuilder extends LeshanClientBuilder {
@@ -266,7 +267,7 @@ public class LeshanTestClientBuilder extends LeshanClientBuilder {
             setEndpointsProviders(new CaliforniumClientEndpointsProvider.Builder(
                     getCaliforniumProtocolProviderSupportingOscore(protocolToUse)).build());
         } else if (endpointProvider.equals("java-coap")) {
-            setEndpointsProviders(new JavaCoapClientEndpointsProvider());
+            setEndpointsProviders(getJavaCoapProtocolProvider(protocolToUse));
         }
         return this;
     }
@@ -293,6 +294,15 @@ public class LeshanTestClientBuilder extends LeshanClientBuilder {
         }
         throw new IllegalStateException(
                 String.format("No Californium Protocol Provider supporting OSCORE for protocol %s", protocol));
+    }
+
+    protected LwM2mClientEndpointsProvider getJavaCoapProtocolProvider(Protocol protocol) {
+        if (protocolToUse.equals(Protocol.COAP)) {
+            return new JavaCoapClientEndpointsProvider();
+        } else if (protocolToUse.equals(Protocol.COAP_TCP)) {
+            return new JavaCoapTcpClientEndpointsProvider();
+        }
+        throw new IllegalStateException(String.format("No Californium Protocol Provider for protocol %s", protocol));
     }
 
     public LeshanTestClientBuilder withAdditiontalAttributes(Map<String, String> attrs) {

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/util/LeshanTestServerBuilder.java
@@ -58,6 +58,7 @@ import org.eclipse.leshan.server.security.Authorizer;
 import org.eclipse.leshan.server.security.EditableSecurityStore;
 import org.eclipse.leshan.server.security.SecurityStore;
 import org.eclipse.leshan.server.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.JavaCoapServerEndpointsProvider;
 
 public class LeshanTestServerBuilder extends LeshanServerBuilder {
@@ -248,6 +249,8 @@ public class LeshanTestServerBuilder extends LeshanServerBuilder {
     protected LwM2mServerEndpointsProvider getJavaCoapProtocolProvider(Protocol protocol) {
         if (protocolToUse.equals(Protocol.COAP)) {
             return new JavaCoapServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        } else if (protocolToUse.equals(Protocol.COAP_TCP)) {
+            return new JavaCoapTcpServerEndpointsProvider(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         }
         throw new IllegalStateException(String.format("No Californium Protocol Provider for protocol %s", protocol));
     }

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
@@ -77,7 +77,8 @@ public class WriteCompositeTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.SENML_JSON, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteFailedTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteFailedTest.java
@@ -61,7 +61,8 @@ public class WriteFailedTest {
                 arguments(Protocol.COAP, "Californium", "Californium"), //
                 arguments(Protocol.COAP, "Californium", "java-coap"), //
                 arguments(Protocol.COAP, "java-coap", "Californium"), //
-                arguments(Protocol.COAP, "java-coap", "java-coap"));
+                arguments(Protocol.COAP, "java-coap", "java-coap"), //
+                arguments(Protocol.COAP_TCP, "java-coap", "java-coap"));
     }
 
     /*---------------------------------/

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteMultiValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteMultiValueTest.java
@@ -75,7 +75,8 @@ public class WriteMultiValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.TLV, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteOpaqueValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteOpaqueValueTest.java
@@ -68,7 +68,8 @@ public class WriteOpaqueValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.OPAQUE, //

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteSingleValueTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteSingleValueTest.java
@@ -80,7 +80,8 @@ public class WriteSingleValueTest {
                 { Protocol.COAP, "Californium", "Californium" }, //
                 { Protocol.COAP, "Californium", "java-coap" }, //
                 { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" } };
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
                 ContentFormat.TEXT, //

--- a/leshan-server-core-demo/webapp/src/views/Server.vue
+++ b/leshan-server-core-demo/webapp/src/views/Server.vue
@@ -183,10 +183,13 @@ export default {
         "CoAP",
         "UDP",
         "DTLS",
+        "TCP",
+        "TLS",
         "OSCORE",
         "Californium",
         "Scandium",
         "java-coap",
+        "netty",
       ];
       const strongKeywords = ["experimental"];
 

--- a/leshan-server-demo/pom.xml
+++ b/leshan-server-demo/pom.xml
@@ -54,6 +54,10 @@ Contributors:
       <artifactId>leshan-tl-javacoap-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-server-coaptcp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.californium</groupId>
       <artifactId>californium-core</artifactId>
     </dependency>

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/LeshanServerDemo.java
@@ -62,6 +62,7 @@ import org.eclipse.leshan.server.redis.RedisRegistrationStore;
 import org.eclipse.leshan.server.redis.RedisSecurityStore;
 import org.eclipse.leshan.server.security.EditableSecurityStore;
 import org.eclipse.leshan.server.security.FileSecurityStore;
+import org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint.JavaCoapTcpServerEndpointsProvider;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.JavaCoapServerEndpointsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -257,8 +258,16 @@ public class LeshanServerDemo {
                 : new InetSocketAddress(cli.main.jlocalAddress, jcoapPort);
         JavaCoapServerEndpointsProvider javacoapEndpointsProvider = new JavaCoapServerEndpointsProvider(jcoapAddr);
 
+        // Create CoAP over TCP endpoint based on java-coap
+        int coapTcpPort = cli.main.jTcpLocalPort;
+        InetSocketAddress coapTcpAddr = cli.main.jTcpLocalAddress == null ? new InetSocketAddress(coapTcpPort)
+                : new InetSocketAddress(cli.main.jTcpLocalAddress, coapTcpPort);
+        JavaCoapTcpServerEndpointsProvider javacoapTcpEndpointsProvider = new JavaCoapTcpServerEndpointsProvider(
+                coapTcpAddr);
+
         // Create LWM2M server
-        builder.setEndpointsProviders(endpointsBuilder.build(), javacoapEndpointsProvider);
+        builder.setEndpointsProviders(endpointsBuilder.build(), javacoapEndpointsProvider,
+                javacoapTcpEndpointsProvider);
         return builder.build();
     }
 

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/cli/LeshanServerDemoCLI.java
@@ -69,6 +69,19 @@ public class LeshanServerDemoCLI implements Runnable {
                 converter = PortConverter.class)
         public Integer jlocalPort = 5685;
 
+        @Option(names = { "-th", "--java-coap-tcp-host" },
+                description = { //
+                        "Set the local CoAP over TCP address of endpoint based on java-coap library.", //
+                        "Default: any local address." })
+        public String jTcpLocalAddress;
+
+        @Option(names = { "-tp", "--java-coap-tcp-port" },
+                description = { //
+                        "Set the local CoAP over TCP port of endpoint based on java-coap library.", //
+                        "Default: ${DEFAULT-VALUE}" },
+                converter = PortConverter.class)
+        public Integer jTcpLocalPort = 5683;
+
         @Option(names = { "-r", "--redis" },
                 description = { //
                         "Use redis to store registration and securityInfo.", //

--- a/leshan-tl-javacoap-client-coaptcp/pom.xml
+++ b/leshan-tl-javacoap-client-coaptcp/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2023 Sierra Wireless and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v20.html
+and the Eclipse Distribution License is available at
+   http://www.eclipse.org/org/documents/edl-v10.html.
+
+Contributors:
+    Sierra Wireless - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.leshan</groupId>
+    <artifactId>lib-build-config</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../build-config/lib-build-config/pom.xml</relativePath>
+  </parent>
+  <artifactId>leshan-tl-javacoap-client-coaptcp</artifactId>
+  <packaging>bundle</packaging>
+  <name>leshan - client java-coap</name>
+  <description>A transport implementation for leshan client based on Java CoAP</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-client-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.open-coap</groupId>
+      <artifactId>coap-tcp</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <excludes>org/eclipse/leshan/transport/javacoap/client/resource/RouterService.java</excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/leshan-tl-javacoap-client-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaptcp/endpoint/JavaCoapTcpClientEndpointsProvider.java
+++ b/leshan-tl-javacoap-client-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/client/coaptcp/endpoint/JavaCoapTcpClientEndpointsProvider.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.coaptcp.endpoint;
+
+import java.security.cert.Certificate;
+import java.util.List;
+
+import javax.net.SocketFactory;
+
+import org.eclipse.leshan.client.servers.ServerInfo;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.transport.javacoap.client.endpoint.AbstractJavaCoapClientEndpointsProvider;
+import org.eclipse.leshan.transport.javacoap.identity.DefaultCoapIdentityHandler;
+
+import com.mbed.coap.packet.BlockSize;
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.server.TcpCoapServer;
+import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.transport.javassl.SocketClientTransport;
+import com.mbed.coap.utils.Service;
+
+public class JavaCoapTcpClientEndpointsProvider extends AbstractJavaCoapClientEndpointsProvider {
+
+    public JavaCoapTcpClientEndpointsProvider() {
+        super(Protocol.COAP_TCP, "CoAP over TCP experimental endpoint based on java-coap library",
+                new DefaultCoapIdentityHandler());
+    }
+
+    @Override
+    protected CoapServer createCoapServer(ServerInfo serverInfo, Service<CoapRequest, CoapResponse> router,
+            List<Certificate> trustStore) {
+        return TcpCoapServer.builder() ///
+                .transport(new SocketClientTransport(serverInfo.getAddress(), SocketFactory.getDefault(), true)) //
+                .blockSize(BlockSize.S_1024_BERT) //
+                .outboundFilter(TokenGeneratorFilter.RANDOM)//
+                .route(router) //
+                .build();
+    }
+}

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/AbstractJavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/AbstractJavaCoapClientEndpointsProvider.java
@@ -1,0 +1,307 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.client.endpoint;
+
+import java.io.IOException;
+import java.security.cert.Certificate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
+import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
+import org.eclipse.leshan.client.notification.NotificationManager;
+import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
+import org.eclipse.leshan.client.resource.LwM2mObjectTree;
+import org.eclipse.leshan.client.servers.LwM2mServer;
+import org.eclipse.leshan.client.servers.ServerInfo;
+import org.eclipse.leshan.core.SecurityMode;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.core.peer.OscoreIdentity;
+import org.eclipse.leshan.core.peer.PskIdentity;
+import org.eclipse.leshan.core.peer.RpkIdentity;
+import org.eclipse.leshan.core.peer.X509Identity;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.transport.javacoap.State;
+import org.eclipse.leshan.transport.javacoap.client.observe.HashMapObserversStore;
+import org.eclipse.leshan.transport.javacoap.client.observe.LwM2mKeys;
+import org.eclipse.leshan.transport.javacoap.client.observe.NotificationHandler;
+import org.eclipse.leshan.transport.javacoap.client.observe.ObserversManager;
+import org.eclipse.leshan.transport.javacoap.client.request.ClientCoapMessageTranslator;
+import org.eclipse.leshan.transport.javacoap.client.resource.BootstrapResource;
+import org.eclipse.leshan.transport.javacoap.client.resource.ObjectResource;
+import org.eclipse.leshan.transport.javacoap.client.resource.RootResource;
+import org.eclipse.leshan.transport.javacoap.client.resource.RouterService;
+import org.eclipse.leshan.transport.javacoap.client.resource.ServerIdentityExtractor;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.packet.Method;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.transport.TransportContext;
+import com.mbed.coap.utils.Service;
+
+public abstract class AbstractJavaCoapClientEndpointsProvider implements LwM2mClientEndpointsProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractJavaCoapClientEndpointsProvider.class);
+
+    private final Protocol supportedProtocol;
+    private final String endpointDescription;
+    private final ClientCoapMessageTranslator messagetranslator;
+    private LwM2mObjectTree objectTree;
+    private Service<CoapRequest, CoapResponse> router;
+    private ClientEndpointToolbox toolbox;
+    private final IdentityHandler identityHandler;
+
+    private JavaCoapClientEndpoint lwm2mEndpoint;
+    private CoapServer coapServer;
+    private volatile ServerInfo currentServerInfo;
+    private volatile List<Certificate> currentTrustStore;
+    private volatile LwM2mServer currentServer;
+
+    protected State state = State.INITIAL;
+    private ObserversManager observersManager;
+
+    public AbstractJavaCoapClientEndpointsProvider(Protocol protocol, String endpointDescription,
+            IdentityHandler identityHandler) {
+        this.supportedProtocol = protocol;
+        this.endpointDescription = endpointDescription;
+        this.identityHandler = identityHandler;
+        this.messagetranslator = new ClientCoapMessageTranslator(identityHandler);
+    }
+
+    @Override
+    public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
+            NotificationManager notificationManager, ClientEndpointToolbox toolbox) {
+        this.objectTree = objectTree;
+        this.toolbox = toolbox;
+
+        ServerIdentityExtractor identityExtractor = new ServerIdentityExtractor() {
+            @Override
+            public LwM2mServer extractIdentity(IpPeer foreignPeer) {
+                if (currentServer == null) {
+                    return null;
+                }
+                if (supportedProtocol != Protocol.COAP || currentServer.getTransportData().equals(foreignPeer)) {
+                    return currentServer;
+                }
+                return null;
+            }
+        };
+
+        // Create Observers Manager
+        observersManager = new ObserversManager(new HashMapObserversStore() {
+            @Override
+            public void add(CoapRequest observeRequest) {
+                if (observeRequest.getMethod() == Method.FETCH && observeRequest.options().getContentFormat() != null) {
+                    // TODO code below is duplicate from RootResource :
+                    // because for now there is no way to avoid to decode twice on observe :/
+                    ContentFormat requestContentFormat = ContentFormat
+                            .fromCode(observeRequest.options().getContentFormat());
+                    List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(observeRequest.getPayload().getBytes(),
+                            requestContentFormat);
+
+                    // optimization for LWM2M Composite Observe : to not decode LWM2M paths each time
+                    TransportContext extendedContext = observeRequest.getTransContext() //
+                            .with(LwM2mKeys.LESHAN_OBSERVED_PATHS, paths);
+
+                    CoapRequest modifiedObservedRequest = new CoapRequest(observeRequest.getMethod(),
+                            observeRequest.getToken(), observeRequest.options(), observeRequest.getPayload(),
+                            observeRequest.getPeerAddress(), extendedContext);
+
+                    super.add(modifiedObservedRequest);
+                } else {
+                    super.add(observeRequest);
+                }
+            }
+        });
+
+        // Create Resources / Routes
+        RouterService.RouteBuilder routerBuilder = new RouterService.RouteBuilder();
+        routerBuilder //
+                .any("/",
+                        observersManager
+                                .then(new RootResource(requestReceiver, toolbox, identityHandler, identityExtractor))) //
+                .any("/bs", new BootstrapResource(requestReceiver, identityHandler, identityExtractor)) //
+                .any("/*", observersManager.then(new ObjectResource(requestReceiver, "/", toolbox, identityHandler,
+                        identityExtractor, notificationManager, observersManager)));
+        router = routerBuilder.build();
+
+        // Create notification handler
+        NotificationHandler notificationHandler = new NotificationHandler(
+                // use router but change Observe request in Read request and also flag request as notification
+                req -> {
+                    TransportContext extendedContext = req.getTransContext() //
+                            .with(LwM2mKeys.LESHAN_NOTIFICATION, true);
+
+                    CoapRequest newReq = new CoapRequest(req.getMethod(), req.getToken(), req.options(),
+                            req.getPayload(), req.getPeerAddress(), extendedContext);
+
+                    return router.apply(newReq.withOptions(coapOptionsBuilder -> coapOptionsBuilder.observe(null)));
+                } //
+                , observersManager);
+        objectTree.addListener(notificationHandler);
+    }
+
+    @Override
+    public synchronized LwM2mServer createEndpoint(ServerInfo serverInfo, boolean clientInitiatedOnly,
+            List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
+
+        if (!this.supportedProtocol.getUriScheme().equals(serverInfo.getFullUri().getScheme())) {
+            return null;
+        }
+
+        // As we support only 1 server destroy previous one first
+        destroyEndpoints();
+
+        // Create a new endpoints
+        currentServerInfo = serverInfo;
+        currentTrustStore = trustStore;
+        createLwM2mEndpoint(serverInfo, trustStore);
+        currentServer = extractIdentity(serverInfo);
+
+        // Start it if needed.
+        if (state.isStarted()) {
+            try {
+                coapServer.start();
+            } catch (IOException e) {
+                LOG.warn("Unable to start endpoint", e);
+                return null;
+            }
+        }
+        return currentServer;
+    }
+
+    public void createLwM2mEndpoint(ServerInfo lwm2mServer, List<Certificate> trustStore) {
+        // Create a new endpoints
+        coapServer = createCoapServer(lwm2mServer, router, trustStore);
+        observersManager.init(coapServer);
+        lwm2mEndpoint = new JavaCoapClientEndpoint(supportedProtocol, endpointDescription, coapServer,
+                messagetranslator, toolbox, objectTree.getModel());
+    }
+
+    protected abstract CoapServer createCoapServer(ServerInfo serverInfo, Service<CoapRequest, CoapResponse> router,
+            List<Certificate> trustStore);
+
+    @Override
+    public synchronized Collection<LwM2mServer> createEndpoints(Collection<? extends ServerInfo> serverInfo,
+            boolean clientInitiatedOnly, List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
+        // TODO TL : need to be implemented or removed ?
+        return null;
+    }
+
+    @Override
+    public synchronized void destroyEndpoints() {
+        // java-coap does not support several endpoints by server so we just kill current server
+        if (coapServer != null)
+            coapServer.stop();
+        coapServer = null;
+        lwm2mEndpoint = null;
+    }
+
+    @Override
+    public List<LwM2mClientEndpoint> getEndpoints() {
+        return Arrays.asList(lwm2mEndpoint);
+    }
+
+    @Override
+    public LwM2mClientEndpoint getEndpoint(LwM2mServer server) {
+        if (server.equals(currentServer)) {
+            return lwm2mEndpoint;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public synchronized void start() {
+        try {
+            if (state.isDestroyed()) {
+                throw new IllegalStateException("Can not start a destroyed provider");
+            }
+            if (state.isStarted()) {
+                return;
+            }
+            if (state.isStopped()) {
+                if (currentServer != null) {
+                    createLwM2mEndpoint(currentServerInfo, currentTrustStore);
+                }
+            }
+            if (coapServer != null)
+                coapServer.start();
+            state = State.STARTED;
+        } catch (
+
+        IOException e) {
+            throw new IllegalStateException("Unable to start java-coap endpoint", e);
+        }
+    }
+
+    @Override
+    public synchronized void stop() {
+        if (state.isDestroyed()) {
+            throw new IllegalStateException("Can not start a destroyed provider");
+        }
+        if (state.isStopped()) {
+            return;
+        }
+        state = State.STOPPED;
+        destroyEndpoints();
+    }
+
+    @Override
+    public synchronized void destroy() {
+        state = State.DESTROYED;
+        destroyEndpoints();
+    }
+
+    private LwM2mServer extractIdentity(ServerInfo serverInfo) {
+        IpPeer transportData;
+        if (serverInfo.isSecure()) {
+            // Support PSK
+            if (serverInfo.secureMode == SecurityMode.PSK) {
+                transportData = new IpPeer(serverInfo.getAddress(), new PskIdentity(serverInfo.pskId));
+            } else if (serverInfo.secureMode == SecurityMode.RPK) {
+                transportData = new IpPeer(serverInfo.getAddress(), new RpkIdentity(serverInfo.serverPublicKey));
+            } else if (serverInfo.secureMode == SecurityMode.X509) {
+                // TODO We set CN with '*' as we are not able to know the CN for some certificate usage and so this is
+                // not used anymore to identify a server with x509.
+                // See : https://github.com/eclipse/leshan/issues/992
+                transportData = new IpPeer(serverInfo.getAddress(), new X509Identity("*"));
+            } else {
+                throw new RuntimeException("Unable to create connector : unsupported security mode");
+            }
+        } else if (serverInfo.useOscore) {
+            // Build server identity for OSCORE
+            transportData = new IpPeer(serverInfo.getAddress(),
+                    new OscoreIdentity(serverInfo.oscoreSetting.getRecipientId()));
+        } else {
+            transportData = new IpPeer((serverInfo.getAddress()));
+        }
+
+        if (serverInfo.bootstrap) {
+            return new LwM2mServer(transportData, serverInfo.serverUri);
+        } else {
+            return new LwM2mServer(transportData, serverInfo.serverId, serverInfo.serverUri);
+        }
+    }
+}

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpoint.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpoint.java
@@ -49,6 +49,8 @@ import com.mbed.coap.server.CoapServer;
 
 public class JavaCoapClientEndpoint implements LwM2mClientEndpoint {
 
+    private final Protocol supportedProtocol;
+    private final String endpointDescription;
     private final CoapServer coapServer;
     private final ClientCoapMessageTranslator translator;
     private final ClientEndpointToolbox toolbox;
@@ -56,8 +58,11 @@ public class JavaCoapClientEndpoint implements LwM2mClientEndpoint {
     private final ScheduledExecutorService executor = Executors.newScheduledThreadPool(1,
             new NamedThreadFactory("Leshan Async Request timeout"));
 
-    public JavaCoapClientEndpoint(CoapServer coapServer, ClientCoapMessageTranslator translator,
-            ClientEndpointToolbox toolbox, LwM2mModel model) {
+    public JavaCoapClientEndpoint(Protocol protocol, String endpointDescription, CoapServer coapServer,
+            ClientCoapMessageTranslator translator, ClientEndpointToolbox toolbox, LwM2mModel model) {
+        this.supportedProtocol = protocol;
+        this.endpointDescription = endpointDescription;
+
         this.coapServer = coapServer;
         this.translator = translator;
         this.toolbox = toolbox;
@@ -66,12 +71,12 @@ public class JavaCoapClientEndpoint implements LwM2mClientEndpoint {
 
     @Override
     public Protocol getProtocol() {
-        return Protocol.COAP;
+        return supportedProtocol;
     }
 
     @Override
     public String getDescription() {
-        return "CoAP over UDP endpoint based on java-coap library";
+        return endpointDescription;
     }
 
     @Override

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/JavaCoapClientEndpointsProvider.java
@@ -15,261 +15,30 @@
  *******************************************************************************/
 package org.eclipse.leshan.transport.javacoap.client.endpoint;
 
-import java.io.IOException;
 import java.security.cert.Certificate;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 
-import org.eclipse.leshan.client.endpoint.ClientEndpointToolbox;
-import org.eclipse.leshan.client.endpoint.LwM2mClientEndpoint;
-import org.eclipse.leshan.client.endpoint.LwM2mClientEndpointsProvider;
-import org.eclipse.leshan.client.notification.NotificationManager;
-import org.eclipse.leshan.client.request.DownlinkRequestReceiver;
-import org.eclipse.leshan.client.resource.LwM2mObjectTree;
-import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.client.servers.ServerInfo;
-import org.eclipse.leshan.core.SecurityMode;
-import org.eclipse.leshan.core.node.LwM2mPath;
-import org.eclipse.leshan.core.peer.IpPeer;
-import org.eclipse.leshan.core.peer.OscoreIdentity;
-import org.eclipse.leshan.core.peer.PskIdentity;
-import org.eclipse.leshan.core.peer.RpkIdentity;
-import org.eclipse.leshan.core.peer.X509Identity;
-import org.eclipse.leshan.core.request.ContentFormat;
-import org.eclipse.leshan.transport.javacoap.State;
-import org.eclipse.leshan.transport.javacoap.client.observe.HashMapObserversStore;
-import org.eclipse.leshan.transport.javacoap.client.observe.LwM2mKeys;
-import org.eclipse.leshan.transport.javacoap.client.observe.NotificationHandler;
-import org.eclipse.leshan.transport.javacoap.client.observe.ObserversManager;
-import org.eclipse.leshan.transport.javacoap.client.request.ClientCoapMessageTranslator;
-import org.eclipse.leshan.transport.javacoap.client.resource.BootstrapResource;
-import org.eclipse.leshan.transport.javacoap.client.resource.ObjectResource;
-import org.eclipse.leshan.transport.javacoap.client.resource.RootResource;
-import org.eclipse.leshan.transport.javacoap.client.resource.RouterService;
-import org.eclipse.leshan.transport.javacoap.client.resource.ServerIdentityExtractor;
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.transport.javacoap.identity.DefaultCoapIdentityHandler;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
-import com.mbed.coap.packet.Method;
 import com.mbed.coap.server.CoapServer;
 import com.mbed.coap.server.filter.TokenGeneratorFilter;
-import com.mbed.coap.transport.TransportContext;
 import com.mbed.coap.transport.udp.DatagramSocketTransport;
 import com.mbed.coap.utils.Service;
 
-public class JavaCoapClientEndpointsProvider implements LwM2mClientEndpointsProvider {
+public class JavaCoapClientEndpointsProvider extends AbstractJavaCoapClientEndpointsProvider {
 
-    private final ClientCoapMessageTranslator messagetranslator = new ClientCoapMessageTranslator();
-    private LwM2mObjectTree objectTree;
-    Service<CoapRequest, CoapResponse> router;
-    private ClientEndpointToolbox toolbox;
-
-    private JavaCoapClientEndpoint lwm2mEndpoint;
-    private CoapServer coapServer;
-    private volatile LwM2mServer currentServer;
-
-    protected State state = State.INITIAL;
-    private ObserversManager observersManager;
-
-    @Override
-    public void init(LwM2mObjectTree objectTree, DownlinkRequestReceiver requestReceiver,
-            NotificationManager notificationManager, ClientEndpointToolbox toolbox) {
-        this.objectTree = objectTree;
-        this.toolbox = toolbox;
-
-        ServerIdentityExtractor identityExtractor = new ServerIdentityExtractor() {
-            @Override
-            public LwM2mServer extractIdentity(IpPeer foreignPeer) {
-                if (currentServer == null) {
-                    return null;
-                }
-                if (currentServer.getTransportData().equals(foreignPeer)) {
-                    return currentServer;
-                }
-                return null;
-            }
-        };
-
-        // Create Observers Manager
-        observersManager = new ObserversManager(new HashMapObserversStore() {
-            @Override
-            public void add(CoapRequest observeRequest) {
-                if (observeRequest.getMethod() == Method.FETCH && observeRequest.options().getContentFormat() != null) {
-                    // TODO code below is duplicate from RootResource :
-                    // because for now there is no way to avoid to decode twice on observe :/
-                    ContentFormat requestContentFormat = ContentFormat
-                            .fromCode(observeRequest.options().getContentFormat());
-                    List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(observeRequest.getPayload().getBytes(),
-                            requestContentFormat);
-
-                    // optimization for LWM2M Composite Observe : to not decode LWM2M paths each time
-                    TransportContext extendedContext = observeRequest.getTransContext() //
-                            .with(LwM2mKeys.LESHAN_OBSERVED_PATHS, paths);
-
-                    CoapRequest modifiedObservedRequest = new CoapRequest(observeRequest.getMethod(),
-                            observeRequest.getToken(), observeRequest.options(), observeRequest.getPayload(),
-                            observeRequest.getPeerAddress(), extendedContext);
-
-                    super.add(modifiedObservedRequest);
-                } else {
-                    super.add(observeRequest);
-                }
-            }
-        });
-
-        // Create Resources / Routes
-        RouterService.RouteBuilder routerBuilder = new RouterService.RouteBuilder();
-        routerBuilder //
-                .any("/", observersManager.then(new RootResource(requestReceiver, toolbox, identityExtractor))) //
-                .any("/bs", new BootstrapResource(requestReceiver, identityExtractor)) //
-                .any("/*", observersManager.then(new ObjectResource(requestReceiver, "/", toolbox, identityExtractor,
-                        notificationManager, observersManager)));
-        router = routerBuilder.build();
-
-        // Create notification handler
-        NotificationHandler notificationHandler = new NotificationHandler(
-                // use router but change Observe request in Read request and also flag request as notification
-                req -> {
-                    TransportContext extendedContext = req.getTransContext() //
-                            .with(LwM2mKeys.LESHAN_NOTIFICATION, true);
-
-                    CoapRequest newReq = new CoapRequest(req.getMethod(), req.getToken(), req.options(),
-                            req.getPayload(), req.getPeerAddress(), extendedContext);
-
-                    return router.apply(newReq.withOptions(coapOptionsBuilder -> coapOptionsBuilder.observe(null)));
-                } //
-                , observersManager);
-        objectTree.addListener(notificationHandler);
+    public JavaCoapClientEndpointsProvider() {
+        super(Protocol.COAP, "CoAP over UDP endpoint based on java-coap library", new DefaultCoapIdentityHandler());
     }
 
     @Override
-    public synchronized LwM2mServer createEndpoint(ServerInfo serverInfo, boolean clientInitiatedOnly,
-            List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
-        // As we support only 1 server destroy previous one first
-        destroyEndpoints();
-
-        // Create a new endpoints
-        createLwM2mEndpoint();
-        currentServer = extractIdentity(serverInfo);
-
-        // Start it if needed.
-        if (state.isStarted()) {
-            try {
-                coapServer.start();
-            } catch (IOException e) {
-                throw new RuntimeException("Unable to start endpoint", e);
-            }
-        }
-        return currentServer;
-    }
-
-    public void createLwM2mEndpoint() {
-        // Create a new endpoints
-        coapServer = CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM)
+    protected CoapServer createCoapServer(ServerInfo serverInfo, Service<CoapRequest, CoapResponse> router,
+            List<Certificate> trustStore) {
+        return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM)
                 .transport(new DatagramSocketTransport(0)).route(router).build();
-        observersManager.init(coapServer);
-        lwm2mEndpoint = new JavaCoapClientEndpoint(coapServer, messagetranslator, toolbox, objectTree.getModel());
-    }
-
-    @Override
-    public synchronized Collection<LwM2mServer> createEndpoints(Collection<? extends ServerInfo> serverInfo,
-            boolean clientInitiatedOnly, List<Certificate> trustStore, ClientEndpointToolbox toolbox) {
-        // TODO TL : need to be implemented or removed ?
-        return null;
-    }
-
-    @Override
-    public synchronized void destroyEndpoints() {
-        // java-coap does not support several endpoints by server so we just kill current server
-        if (coapServer != null)
-            coapServer.stop();
-        coapServer = null;
-        lwm2mEndpoint = null;
-    }
-
-    @Override
-    public List<LwM2mClientEndpoint> getEndpoints() {
-        return Arrays.asList(lwm2mEndpoint);
-    }
-
-    @Override
-    public LwM2mClientEndpoint getEndpoint(LwM2mServer server) {
-        if (server.equals(currentServer)) {
-            return lwm2mEndpoint;
-        } else {
-            return null;
-        }
-    }
-
-    @Override
-    public synchronized void start() {
-        try {
-            if (state.isDestroyed()) {
-                throw new IllegalStateException("Can not start a destroyed provider");
-            }
-            if (state.isStarted()) {
-                return;
-            }
-            if (state.isStopped()) {
-                createLwM2mEndpoint();
-            }
-            if (coapServer != null)
-                coapServer.start();
-            state = State.STARTED;
-        } catch (
-
-        IOException e) {
-            throw new IllegalStateException("Unable to start java-coap endpoint", e);
-        }
-    }
-
-    @Override
-    public synchronized void stop() {
-        if (state.isDestroyed()) {
-            throw new IllegalStateException("Can not start a destroyed provider");
-        }
-        if (state.isStopped()) {
-            return;
-        }
-        state = State.STOPPED;
-        destroyEndpoints();
-    }
-
-    @Override
-    public synchronized void destroy() {
-        state = State.DESTROYED;
-        destroyEndpoints();
-    }
-
-    private LwM2mServer extractIdentity(ServerInfo serverInfo) {
-        IpPeer transportData;
-        if (serverInfo.isSecure()) {
-            // Support PSK
-            if (serverInfo.secureMode == SecurityMode.PSK) {
-                transportData = new IpPeer(serverInfo.getAddress(), new PskIdentity(serverInfo.pskId));
-            } else if (serverInfo.secureMode == SecurityMode.RPK) {
-                transportData = new IpPeer(serverInfo.getAddress(), new RpkIdentity(serverInfo.serverPublicKey));
-            } else if (serverInfo.secureMode == SecurityMode.X509) {
-                // TODO We set CN with '*' as we are not able to know the CN for some certificate usage and so this is
-                // not used anymore to identify a server with x509.
-                // See : https://github.com/eclipse/leshan/issues/992
-                transportData = new IpPeer(serverInfo.getAddress(), new X509Identity("*"));
-            } else {
-                throw new RuntimeException("Unable to create connector : unsupported security mode");
-            }
-        } else if (serverInfo.useOscore) {
-            // Build server identity for OSCORE
-            transportData = new IpPeer(serverInfo.getAddress(),
-                    new OscoreIdentity(serverInfo.oscoreSetting.getRecipientId()));
-        } else {
-            transportData = new IpPeer((serverInfo.getAddress()));
-        }
-
-        if (serverInfo.bootstrap) {
-            return new LwM2mServer(transportData, serverInfo.serverUri);
-        } else {
-            return new LwM2mServer(transportData, serverInfo.serverId, serverInfo.serverUri);
-        }
     }
 }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/ClientCoapMessageTranslator.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/ClientCoapMessageTranslator.java
@@ -22,11 +22,18 @@ import org.eclipse.leshan.core.peer.IpPeer;
 import org.eclipse.leshan.core.peer.LwM2mPeer;
 import org.eclipse.leshan.core.request.UplinkRequest;
 import org.eclipse.leshan.core.response.LwM2mResponse;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
 
 public class ClientCoapMessageTranslator {
+
+    private final IdentityHandler identityHandler;
+
+    public ClientCoapMessageTranslator(IdentityHandler identityHandler) {
+        this.identityHandler = identityHandler;
+    }
 
     public CoapRequest createCoapRequest(LwM2mServer server, UplinkRequest<? extends LwM2mResponse> lwm2mRequest,
             ClientEndpointToolbox toolbox, LwM2mModel model) {
@@ -39,7 +46,7 @@ public class ClientCoapMessageTranslator {
 
         // create CoAP Request
         CoapRequestBuilder builder = new CoapRequestBuilder((IpPeer) lwm2mPeer, toolbox.getEncoder(), model,
-                toolbox.getLinkSerializer());
+                toolbox.getLinkSerializer(), identityHandler);
         lwm2mRequest.accept(builder);
         return builder.getRequest();
     }

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/CoapRequestBuilder.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/CoapRequestBuilder.java
@@ -35,6 +35,7 @@ import org.eclipse.leshan.core.request.SendRequest;
 import org.eclipse.leshan.core.request.UpdateRequest;
 import org.eclipse.leshan.core.request.UplinkRequest;
 import org.eclipse.leshan.core.request.UplinkRequestVisitor;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.Opaque;
@@ -51,13 +52,15 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
     protected final LwM2mEncoder encoder;
     protected final LwM2mModel model;
     protected final LinkSerializer linkSerializer;
+    protected final IdentityHandler identityHandler;
 
-    public CoapRequestBuilder(IpPeer server, LwM2mEncoder encoder, LwM2mModel model, LinkSerializer linkSerializer) {
+    public CoapRequestBuilder(IpPeer server, LwM2mEncoder encoder, LwM2mModel model, LinkSerializer linkSerializer,
+            IdentityHandler identityHandler) {
         this.server = server;
         this.encoder = encoder;
         this.model = model;
         this.linkSerializer = linkSerializer;
-
+        this.identityHandler = identityHandler;
     }
 
     @Override
@@ -173,7 +176,8 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
     }
 
     public CoapRequest getRequest() {
-        return coapRequestBuilder.address(getAddress()).build();
+        return coapRequestBuilder.address(getAddress()).context(identityHandler.createTransportContext(server, true))
+                .build();
     }
 
     protected InetSocketAddress getAddress() {

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/BootstrapResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/BootstrapResource.java
@@ -24,6 +24,7 @@ import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.core.request.BootstrapFinishRequest;
 import org.eclipse.leshan.core.response.BootstrapFinishResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.resource.LwM2mCoapResource;
 
 import com.mbed.coap.packet.CoapRequest;
@@ -36,8 +37,9 @@ public class BootstrapResource extends LwM2mClientCoapResource {
 
     protected DownlinkRequestReceiver requestReceiver;
 
-    public BootstrapResource(DownlinkRequestReceiver requestReceiver, ServerIdentityExtractor serverIdentityExtractor) {
-        super("bs", serverIdentityExtractor);
+    public BootstrapResource(DownlinkRequestReceiver requestReceiver, IdentityHandler identityHandler,
+            ServerIdentityExtractor serverIdentityExtractor) {
+        super("bs", identityHandler, serverIdentityExtractor);
         this.requestReceiver = requestReceiver;
     }
 

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/LwM2mClientCoapResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/LwM2mClientCoapResource.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.leshan.client.servers.LwM2mServer;
 import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.resource.LwM2mCoapResource;
 
 import com.mbed.coap.packet.CoapRequest;
@@ -32,8 +33,9 @@ public class LwM2mClientCoapResource extends LwM2mCoapResource {
 
     protected final ServerIdentityExtractor serverIdentityExtractor;
 
-    public LwM2mClientCoapResource(String uri, ServerIdentityExtractor identityExtractor) {
-        super(uri);
+    public LwM2mClientCoapResource(String uri, IdentityHandler identityHandler,
+            ServerIdentityExtractor identityExtractor) {
+        super(uri, identityHandler);
         this.serverIdentityExtractor = identityExtractor;
     }
 

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
@@ -66,6 +66,7 @@ import org.eclipse.leshan.core.response.WriteResponse;
 import org.eclipse.leshan.transport.javacoap.client.observe.LwM2mKeys;
 import org.eclipse.leshan.transport.javacoap.client.observe.ObserversListener;
 import org.eclipse.leshan.transport.javacoap.client.observe.ObserversManager;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,9 +86,9 @@ public class ObjectResource extends LwM2mClientCoapResource {
     protected ObserversManager observersManager;
 
     public ObjectResource(DownlinkRequestReceiver requestReceiver, String uri, ClientEndpointToolbox toolbox,
-            ServerIdentityExtractor serverIdentityExtractor, NotificationManager notificationManager,
-            ObserversManager observersManager) {
-        super(uri, serverIdentityExtractor);
+            IdentityHandler identityHandler, ServerIdentityExtractor serverIdentityExtractor,
+            NotificationManager notificationManager, ObserversManager observersManager) {
+        super(uri, identityHandler, serverIdentityExtractor);
         this.requestReceiver = requestReceiver;
         this.toolbox = toolbox;
         this.notificationManager = notificationManager;

--- a/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RootResource.java
+++ b/leshan-tl-javacoap-client/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RootResource.java
@@ -38,6 +38,7 @@ import org.eclipse.leshan.core.response.BootstrapDiscoverResponse;
 import org.eclipse.leshan.core.response.ObserveCompositeResponse;
 import org.eclipse.leshan.core.response.ReadCompositeResponse;
 import org.eclipse.leshan.core.response.WriteCompositeResponse;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
 
 import com.mbed.coap.packet.CoapRequest;
@@ -51,8 +52,8 @@ public class RootResource extends LwM2mClientCoapResource {
     protected ClientEndpointToolbox toolbox;
 
     public RootResource(DownlinkRequestReceiver requestReceiver, ClientEndpointToolbox toolbox,
-            ServerIdentityExtractor serverIdentityExtractor) {
-        super("", serverIdentityExtractor);
+            IdentityHandler identityHandler, ServerIdentityExtractor serverIdentityExtractor) {
+        super("", identityHandler, serverIdentityExtractor);
         this.requestReceiver = requestReceiver;
         this.toolbox = toolbox;
     }

--- a/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultCoapIdentityHandler.java
+++ b/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/identity/DefaultCoapIdentityHandler.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.core.peer.LwM2mPeer;
+
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.SeparateResponse;
+import com.mbed.coap.transport.TransportContext;
+
+public class DefaultCoapIdentityHandler implements IdentityHandler {
+
+    @Override
+    public LwM2mPeer getIdentity(Object receivedMessage) {
+        // TODO we need a Message Abstraction ?
+        if (receivedMessage instanceof CoapRequest) {
+            CoapRequest receivedRequest = (CoapRequest) receivedMessage;
+            return getIdentity(receivedRequest);
+        } else if (receivedMessage instanceof SeparateResponse) {
+            SeparateResponse separatedResponse = (SeparateResponse) receivedMessage;
+            return getIdentity(separatedResponse);
+        }
+        return null;
+    }
+
+    protected LwM2mPeer getIdentity(CoapRequest receivedRequest) {
+        return getIdentity(receivedRequest.getPeerAddress(), receivedRequest.getTransContext());
+    }
+
+    protected LwM2mPeer getIdentity(SeparateResponse separatedResponse) {
+        return getIdentity(separatedResponse.getPeerAddress(), separatedResponse.getTransContext());
+    }
+
+    protected LwM2mPeer getIdentity(InetSocketAddress address, TransportContext context) {
+        return new IpPeer(address);
+    }
+
+    @Override
+    public TransportContext createTransportContext(LwM2mPeer client, boolean allowConnectionInitiation) {
+        return TransportContext.EMPTY;
+    }
+}

--- a/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/identity/IdentityHandler.java
+++ b/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/identity/IdentityHandler.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.identity;
+
+import org.eclipse.leshan.core.peer.LwM2mPeer;
+
+import com.mbed.coap.transport.TransportContext;
+
+public interface IdentityHandler {
+
+    LwM2mPeer getIdentity(Object receivedMessage);
+
+    TransportContext createTransportContext(LwM2mPeer client, boolean allowConnectionInitiation);
+}

--- a/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/resource/LwM2mCoapResource.java
+++ b/leshan-tl-javacoap-core/src/main/java/org/eclipse/leshan/transport/javacoap/resource/LwM2mCoapResource.java
@@ -25,6 +25,7 @@ import org.eclipse.leshan.core.ResponseCode;
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,9 +44,11 @@ public abstract class LwM2mCoapResource implements Service<CoapRequest, CoapResp
     private static final Logger LOG = LoggerFactory.getLogger(LwM2mCoapResource.class);
 
     private final String uri;
+    IdentityHandler identityHandler;
 
-    public LwM2mCoapResource(String uri) {
+    public LwM2mCoapResource(String uri, IdentityHandler identityHandler) {
         this.uri = uri;
+        this.identityHandler = identityHandler;
     }
 
     @Override
@@ -122,7 +125,7 @@ public abstract class LwM2mCoapResource implements Service<CoapRequest, CoapResp
     }
 
     protected IpPeer getForeignPeerIdentity(CoapRequest coapRequest) {
-        return new IpPeer(coapRequest.getPeerAddress());
+        return (IpPeer) identityHandler.getIdentity(coapRequest);
     }
 
     protected IpPeer extractIdentitySafely(CoapRequest coapRequest) {

--- a/leshan-tl-javacoap-server-coaptcp/logback-leshan-test.xml
+++ b/leshan-tl-javacoap-server-coaptcp/logback-leshan-test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2013 Sierra Wireless and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v20.html
+and the Eclipse Distribution License is available at
+   http://www.eclipse.org/org/documents/edl-v10.html.
+
+Contributors:
+    Sierra Wireless - initial API and implementation
+-->
+<configuration>
+	<!--
+		This file will only be used by maven by default.
+		If you want to use it in your IDE, just :
+		 - use -Dlogback.configurationFile=logback-test-.xml argument  
+		or
+		 - put a logback-test.xml file in your classpath (it will be ignore by git)
+	-->
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d %p %C{1} [%t] %m%n</pattern>
+		</encoder>
+	</appender>
+
+	<root level="ERROR">
+		<appender-ref ref="STDOUT" />
+	</root>
+</configuration>
+

--- a/leshan-tl-javacoap-server-coaptcp/pom.xml
+++ b/leshan-tl-javacoap-server-coaptcp/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+Copyright (c) 2023 Sierra Wireless and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License v2.0
+and Eclipse Distribution License v1.0 which accompany this distribution.
+
+The Eclipse Public License is available at
+   http://www.eclipse.org/legal/epl-v20.html
+and the Eclipse Distribution License is available at
+   http://www.eclipse.org/org/documents/edl-v10.html.
+
+Contributors:
+    Sierra Wireless - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.leshan</groupId>
+    <artifactId>lib-build-config</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../build-config/lib-build-config/pom.xml</relativePath>
+  </parent>
+  <artifactId>leshan-tl-javacoap-server-coaptcp</artifactId>
+  <packaging>bundle</packaging>
+  <name>leshan - server java-coap</name>
+  <description>A CoAP over TCP transport implementation for leshan server based on Java CoAP and Netty</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-server-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.leshan</groupId>
+      <artifactId>leshan-tl-javacoap-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.open-coap</groupId>
+      <artifactId>coap-tcp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-transport</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/JavaCoapTcpServerEndpointsProvider.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/JavaCoapTcpServerEndpointsProvider.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.endpoint;
+
+import java.net.InetSocketAddress;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.server.security.SecurityStore;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.identity.DefaultCoapIdentityHandler;
+import org.eclipse.leshan.transport.javacoap.server.coaptcp.transport.CoapTcpTransportResolver;
+import org.eclipse.leshan.transport.javacoap.server.coaptcp.transport.DefaultTransportContextMatcher;
+import org.eclipse.leshan.transport.javacoap.server.coaptcp.transport.NettyCoapTcpTransport;
+import org.eclipse.leshan.transport.javacoap.server.endpoint.AbstractJavaCoapServerEndpointsProvider;
+
+import com.mbed.coap.packet.BlockSize;
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.server.CoapServerBuilderForTcp;
+import com.mbed.coap.server.TcpCoapServer;
+import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.server.observe.NotificationsReceiver;
+import com.mbed.coap.server.observe.ObservationsStore;
+import com.mbed.coap.utils.Service;
+
+public class JavaCoapTcpServerEndpointsProvider extends AbstractJavaCoapServerEndpointsProvider {
+
+    public JavaCoapTcpServerEndpointsProvider(InetSocketAddress localAddress) {
+        super(Protocol.COAP_TCP, "CoAP over TCP experimental endpoint based on java-coap and netty libraries",
+                localAddress, new DefaultCoapIdentityHandler());
+    }
+
+    @Override
+    protected CoapServer createCoapServer(InetSocketAddress localAddress, ServerSecurityInfo serverSecurityInfo,
+            SecurityStore securityStore, Service<CoapRequest, CoapResponse> resources,
+            NotificationsReceiver notificationReceiver, ObservationsStore observationsStore) {
+        return createCoapServer() //
+                .transport(new NettyCoapTcpTransport(localAddress, new CoapTcpTransportResolver(),
+                        new DefaultTransportContextMatcher())) //
+                .blockSize(BlockSize.S_1024_BERT) //
+                .maxIncomingBlockTransferSize(4000) //
+                .maxMessageSize(2100) //
+                .route(resources) //
+                .notificationsReceiver(notificationReceiver) //
+                .observationsStore(observationsStore) //
+                .build();
+    }
+
+    protected CoapServerBuilderForTcp createCoapServer() {
+        return TcpCoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM);
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpDecoder.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpDecoder.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapTcpPacketSerializer;
+import com.mbed.coap.transport.TransportContext;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ReplayingDecoder;
+
+public class CoapTcpDecoder extends ReplayingDecoder<CoapPacket> {
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+
+        // Maybe we should use CHECKPOINT to improve performance :
+        // see : https://docs.jboss.org/netty/3.2/api/org/jboss/netty/handler/codec/replay/ReplayingDecoder.html
+        CoapPacket coap = CoapTcpPacketSerializer.deserialize((InetSocketAddress) ctx.channel().remoteAddress(),
+                new ByteBufInputStream(in));
+
+        // Attach transport context to packet
+        TransportContext transportContext = ctx.channel().attr(TransportContextHandler.TRANSPORT_CONTEXT_ATTR).get();
+        if (transportContext == null)
+            throw new IllegalStateException("transport context should not be null");
+        coap.setTransportContext(transportContext);
+
+        // Push decoded packet
+        out.add(coap);
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpEncoder.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpEncoder.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import java.util.function.BiFunction;
+
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.packet.CoapTcpPacketSerializer;
+import com.mbed.coap.transport.TransportContext;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.MessageToByteEncoder;
+
+public class CoapTcpEncoder extends MessageToByteEncoder<CoapPacket> {
+
+    private final BiFunction<TransportContext, TransportContext, Boolean> contextMatcher;
+
+    public CoapTcpEncoder(BiFunction<TransportContext, TransportContext, Boolean> contextMatcher) {
+        this.contextMatcher = contextMatcher;
+    }
+
+    @Override
+    protected void encode(ChannelHandlerContext ctx, CoapPacket msg, ByteBuf out) throws Exception {
+        // Get attached transport context
+        TransportContext transportContext = ctx.channel().attr(TransportContextHandler.TRANSPORT_CONTEXT_ATTR).get();
+        if (transportContext == null)
+            throw new IllegalStateException("transport context should not be null");
+
+        // Check if "destination transport context" packet matches transport context of current channel / "connection".
+        // TODO java-coap doesn't set context on response.
+        if (msg.getMethod() != null) { // do msg is a request
+            if (!contextMatcher.apply(msg.getTransportContext(), transportContext)) {
+                throw new UnconnectedPeerException(
+                        String.format("transport context expected doesn't match current one at %s",
+                                msg.getRemoteAddress().getHostString()));
+            }
+        }
+
+        byte[] bytes = CoapTcpPacketSerializer.serialize(msg);
+        out.writeBytes(bytes);
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpTransportResolver.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/CoapTcpTransportResolver.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.function.Function;
+
+import com.mbed.coap.transport.TransportContext;
+
+import io.netty.channel.Channel;
+
+public class CoapTcpTransportResolver implements Function<Channel, TransportContext> {
+
+    public static final TransportContext.Key<InetSocketAddress> REMOTE_ADDRESS = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<String> CONNECTION_ID = new TransportContext.Key<>(null);
+    public static final TransportContext.Key<Instant> CONNECTION_START_TIMESTAMP = new TransportContext.Key<>(null);
+
+    @Override
+    public TransportContext apply(Channel channel) {
+        return TransportContext.of(REMOTE_ADDRESS, (InetSocketAddress) channel.remoteAddress()) //
+                .with(CONNECTION_ID, channel.id().asShortText()) //
+                .with(CONNECTION_START_TIMESTAMP, Instant.now());
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/DefaultTransportContextMatcher.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/DefaultTransportContextMatcher.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import java.util.function.BiFunction;
+
+import com.mbed.coap.transport.TransportContext;
+import com.mbed.coap.transport.TransportContext.Key;
+
+public class DefaultTransportContextMatcher implements BiFunction<TransportContext, TransportContext, Boolean> {
+
+    private final Key<?>[] knownKeys;
+
+    public DefaultTransportContextMatcher() {
+        this(CoapTcpTransportResolver.REMOTE_ADDRESS, //
+                CoapTcpTransportResolver.CONNECTION_ID, //
+                CoapTcpTransportResolver.CONNECTION_START_TIMESTAMP);
+    }
+
+    public DefaultTransportContextMatcher(Key<?>... knownKeys) {
+        this.knownKeys = knownKeys;
+    }
+
+    @Override
+    public Boolean apply(TransportContext packetTransport, TransportContext channelTransport) {
+        // TODO we should be able to iterate on all keys ...
+        // As we can not workaround is to test all known key
+        for (Key<?> key : knownKeys) {
+
+            Object packetValue = packetTransport.get(key);
+            if (packetValue != null) {
+                Object channelValue = channelTransport.get(key);
+
+                if (!matches(key, packetValue, channelValue))
+                    return false;
+            }
+        }
+        return true;
+    }
+
+    protected boolean matches(Key<?> key, Object packetValue, Object channelValue) {
+        return packetValue.equals(channelValue);
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyCoapTcpTransport.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyCoapTcpTransport.java
@@ -1,0 +1,242 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import static org.eclipse.leshan.transport.javacoap.server.coaptcp.transport.NettyUtils.toCompletableFuture;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import com.mbed.coap.packet.CoapPacket;
+import com.mbed.coap.transport.CoapTcpListener;
+import com.mbed.coap.transport.CoapTcpTransport;
+import com.mbed.coap.transport.TransportContext;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+
+public class NettyCoapTcpTransport implements CoapTcpTransport {
+
+    private final InetSocketAddress localAddress;
+    private volatile Channel mainChannel;
+    private final ConcurrentMap<SocketAddress, Channel> activeChannels = new ConcurrentHashMap<>();
+    private volatile CoapTcpListener listener;
+    private CompletableFuture<CoapPacket> receivePromise = new CompletableFuture<>();
+    private final Function<Channel, TransportContext> contextResolver;
+    private final BiFunction<TransportContext, TransportContext, Boolean> contextMatcher;
+
+    public NettyCoapTcpTransport(InetSocketAddress localadddress, //
+            Function<Channel, TransportContext> contextResolver, //
+            BiFunction<TransportContext, TransportContext, Boolean> contextMatcher) {
+        this.localAddress = localadddress;
+        this.contextResolver = contextResolver;
+        this.contextMatcher = contextMatcher;
+    }
+
+    @Override
+    public synchronized void start() throws IOException {
+        // Init transport
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        NioEventLoopGroup bossGroup = new NioEventLoopGroup(1);
+        NioEventLoopGroup workerGroup = new NioEventLoopGroup(1);
+        bootstrap.group(bossGroup, workerGroup) //
+                .channel(NioServerSocketChannel.class) //
+                .childHandler(new ChannelRegistry()) //
+                .option(ChannelOption.SO_BACKLOG, 100) //
+                .option(ChannelOption.AUTO_READ, true) //
+                .childOption(ChannelOption.SO_KEEPALIVE, true);
+
+        // start it
+        mainChannel = bootstrap.bind(localAddress).syncUninterruptibly().channel();
+    }
+
+    private class ChannelRegistry extends ChannelInitializer<SocketChannel> {
+        @Override
+        protected void initChannel(SocketChannel ch) throws Exception {
+
+            // Handler order:
+            // 0. Register/unregister new channel: all messages can only be sent
+            // over open connections.
+            // 1. Generate Idle events
+            // 2. Close idle channels.
+            // 3. Stream-to-message decoder
+            // 4. Hand-off decoded messages to CoAP stack
+            // 5. Close connections on errors.
+
+            ch.pipeline().addLast(new TransportContextHandler(contextResolver));
+            ch.pipeline().addLast(new ChannelTracker());
+            // Remove IdleStateHandler for now because, we could define expected behavoir
+            // See : https://github.com/eclipse-leshan/leshan/wiki/CoAP-over-TCP#half-open-connection-at-server-side
+            // ch.pipeline().addLast(new IdleStateHandler(0, 0, 10 /* seconds */));
+            ch.pipeline().addLast(new IdleStateHandler(0, 0, 0 /* disabled */));
+            ch.pipeline().addLast(new CloseOnIdleHandler());
+            ch.pipeline().addLast(new CoapTcpDecoder());
+            ch.pipeline().addLast(new CoapTcpEncoder(contextMatcher));
+            ch.pipeline().addLast(new DispatchHandler());
+            ch.pipeline().addLast(new CloseOnErrorHandler());
+        }
+    }
+
+//    public static class TransportContextHandler extends ChannelInboundHandlerAdapter {
+//
+//        public static final AttributeKey<TransportContext> TRANSPORT_CONTEXT_ATTR = AttributeKey
+//                .newInstance("transport");
+//
+//        @Override
+//        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+//            // create context
+//            TransportContext tansportContext = createTransportContext();
+//            if (tansportContext == null) {
+//                throw new IllegalStateException("transport context must not be null");
+//            }
+//
+//            // add it to the channel
+//            TransportContext oldTansportContext = ctx.channel().attr(TRANSPORT_CONTEXT_ATTR)
+//                    .setIfAbsent(tansportContext);
+//            if (oldTansportContext != null) {
+//                throw new IllegalStateException(
+//                        String.format("Can not create new transport context %s as %s already exists.", tansportContext,
+//                                oldTansportContext));
+//            }
+//            super.channelActive(ctx);
+//        }
+//    }
+
+    class ChannelTracker extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+            activeChannels.put(ctx.channel().remoteAddress(), ctx.channel());
+            super.channelActive(ctx);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            activeChannels.remove(ctx.channel().remoteAddress());
+            super.channelInactive(ctx);
+        }
+    }
+
+    public class DispatchHandler extends ChannelInboundHandlerAdapter {
+
+        @Override
+        public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+            if (!receivePromise.complete((CoapPacket) msg)) {
+                ctx.fireChannelRead(msg);
+            }
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext ctx) throws Exception {
+//            TransportContext tansportContext = ctx.channel().attr(TransportContextHandler.TRANSPORT_CONTEXT_ATTR).get();
+//            if (tansportContext == null)
+//                throw new IllegalStateException("transport context should not be null");
+
+            if (listener != null)
+                listener.onConnected((InetSocketAddress) ctx.channel().remoteAddress());
+
+            super.channelActive(ctx);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+//            TransportContext tansportContext = ctx.channel().attr(TransportContextHandler.TRANSPORT_CONTEXT_ATTR).get();
+//            if (tansportContext == null)
+//                throw new IllegalStateException("transport context should not be null");
+
+            if (listener != null)
+                listener.onDisconnected((InetSocketAddress) ctx.channel().remoteAddress());
+
+            super.channelInactive(ctx);
+        }
+    }
+
+    private static class CloseOnIdleHandler extends ChannelDuplexHandler {
+        @Override
+        public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+            if (evt instanceof IdleStateEvent) {
+                ctx.channel().close();
+            }
+        }
+    }
+
+    private static class CloseOnErrorHandler extends ChannelInboundHandlerAdapter {
+        @Override
+        public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            cause.printStackTrace();
+            ctx.close();
+        }
+    }
+
+    @Override
+    public void stop() {
+        mainChannel.close();
+        mainChannel.closeFuture().syncUninterruptibly();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> sendPacket(CoapPacket packet) {
+        InetSocketAddress peerAddress = packet.getRemoteAddress();
+        Channel channel = activeChannels.get(peerAddress);
+        if (channel == null) {
+            CompletableFuture<Boolean> future = new CompletableFuture<>();
+            future.completeExceptionally(
+                    new UnconnectedPeerException(String.format("Peer %s is not connected", peerAddress)));
+            return future;
+        }
+        ChannelPromise channelPromise = channel.newPromise();
+        channel.writeAndFlush(packet, channelPromise);
+
+        return toCompletableFuture(channelPromise).thenApply(__ -> true);
+    }
+
+    @Override
+    public CompletableFuture<CoapPacket> receive() {
+        receivePromise = new CompletableFuture<>();
+        return receivePromise;
+    }
+
+    @Override
+    public InetSocketAddress getLocalSocketAddress() {
+        return (InetSocketAddress) mainChannel.localAddress();
+    }
+
+    public Channel getChannel() {
+        return mainChannel;
+    }
+
+    @Override
+    public void setListener(CoapTcpListener listener) {
+        this.listener = listener;
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyUtils.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/NettyUtils.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.util.concurrent.CompletableFuture;
+
+import io.netty.util.concurrent.Promise;
+
+public class NettyUtils {
+
+    public static <T> CompletableFuture<T> toCompletableFuture(Promise<T> nettyPromise) {
+
+        if (nettyPromise.isSuccess()) {
+            return completedFuture(nettyPromise.getNow());
+        }
+
+        CompletableFuture<T> promise = new CompletableFuture<>();
+        nettyPromise.addListener(future -> {
+            if (future.cause() != null) {
+                promise.completeExceptionally(future.cause());
+            } else {
+                promise.complete(nettyPromise.getNow());
+            }
+        });
+
+        return promise;
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/TransportContextHandler.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/TransportContextHandler.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+
+import com.mbed.coap.transport.TransportContext;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.AttributeKey;
+
+public class TransportContextHandler extends ChannelInboundHandlerAdapter {
+
+    public static final AttributeKey<TransportContext> TRANSPORT_CONTEXT_ATTR = AttributeKey.newInstance("transport");
+
+    private final Function<Channel, TransportContext> contextResolver;
+
+    public TransportContextHandler(Function<Channel, TransportContext> contextResolver) {
+        this.contextResolver = requireNonNull(contextResolver);
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        attachContextToChannel(ctx);
+        super.channelActive(ctx);
+    }
+
+    protected void attachContextToChannel(ChannelHandlerContext ctx) {
+        // create context
+        TransportContext transportContext = contextResolver.apply(ctx.channel());
+        if (transportContext == null) {
+            throw new IllegalStateException("transport context must not be null");
+        }
+
+        // add it to the channel
+        TransportContext oldTransportContext = ctx.channel().attr(TRANSPORT_CONTEXT_ATTR).setIfAbsent(transportContext);
+        if (oldTransportContext != null) {
+            throw new IllegalStateException(
+                    String.format("Can not create new endpoint context %s as %s already exists.", transportContext,
+                            oldTransportContext));
+        }
+    }
+}

--- a/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/UnconnectedPeerException.java
+++ b/leshan-tl-javacoap-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/transport/UnconnectedPeerException.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.coaptcp.transport;
+
+import java.io.IOException;
+
+public class UnconnectedPeerException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    public UnconnectedPeerException(String message) {
+        super(message);
+    }
+
+    public UnconnectedPeerException(Throwable cause) {
+        super(cause);
+    }
+
+    public UnconnectedPeerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/AbstractJavaCoapServerEndpointsProvider.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/AbstractJavaCoapServerEndpointsProvider.java
@@ -1,0 +1,148 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.transport.javacoap.server.endpoint;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.leshan.core.endpoint.Protocol;
+import org.eclipse.leshan.server.LeshanServer;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpoint;
+import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
+import org.eclipse.leshan.server.endpoint.ServerEndpointToolbox;
+import org.eclipse.leshan.server.observation.LwM2mNotificationReceiver;
+import org.eclipse.leshan.server.request.UplinkRequestReceiver;
+import org.eclipse.leshan.server.security.SecurityStore;
+import org.eclipse.leshan.server.security.ServerSecurityInfo;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
+import org.eclipse.leshan.transport.javacoap.server.observation.CoapNotificationReceiver;
+import org.eclipse.leshan.transport.javacoap.server.observation.LwM2mObservationsStore;
+import org.eclipse.leshan.transport.javacoap.server.resource.RegistrationResource;
+import org.eclipse.leshan.transport.javacoap.server.resource.SendResource;
+
+import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapResponse;
+import com.mbed.coap.server.CoapServer;
+import com.mbed.coap.server.RouterService;
+import com.mbed.coap.server.observe.NotificationsReceiver;
+import com.mbed.coap.server.observe.ObservationsStore;
+import com.mbed.coap.utils.Service;
+
+public abstract class AbstractJavaCoapServerEndpointsProvider implements LwM2mServerEndpointsProvider {
+
+    private final Protocol supportedProtocol;
+    private final String endpointDescription;
+    private final InetSocketAddress localAddress;
+    private CoapServer coapServer;
+    private JavaCoapServerEndpoint lwm2mEndpoint;
+    private final IdentityHandler identityHandler;
+
+    public AbstractJavaCoapServerEndpointsProvider(Protocol protocol, String endpointDescription,
+            InetSocketAddress localAddress, IdentityHandler identityHandler) {
+        this.supportedProtocol = protocol;
+        this.endpointDescription = endpointDescription;
+        this.localAddress = localAddress;
+        this.identityHandler = identityHandler;
+    }
+
+    @Override
+    public void createEndpoints(UplinkRequestReceiver requestReceiver,
+            final LwM2mNotificationReceiver notificationReceiver, final ServerEndpointToolbox toolbox,
+            ServerSecurityInfo serverSecurityInfo, LeshanServer server) {
+
+        // TODO: HACK to be able to get local URI in resource, need to discuss about it with java-coap.
+        EndpointUriProvider endpointUriProvider = new EndpointUriProvider(supportedProtocol);
+
+        // Create Resources / Routes
+        RegistrationResource registerResource = new RegistrationResource(requestReceiver, toolbox.getLinkParser(),
+                endpointUriProvider, identityHandler);
+        Service<CoapRequest, CoapResponse> resources = RouterService.builder() //
+                .any("/rd/*", registerResource) //
+                .any("/rd", registerResource)//
+                .any("/dp",
+                        new SendResource(requestReceiver, toolbox.getDecoder(), toolbox.getProfileProvider(),
+                                endpointUriProvider, identityHandler))//
+                .build();
+
+        // Create CoAP Server
+        coapServer = createCoapServer(localAddress, //
+                serverSecurityInfo, //
+                server.getSecurityStore(), //
+                resources, //
+                new CoapNotificationReceiver(coapServer, notificationReceiver, server.getRegistrationStore(),
+                        server.getModelProvider(), toolbox.getDecoder()), //
+                new LwM2mObservationsStore(server.getRegistrationStore(), notificationReceiver, identityHandler) //
+        );
+        endpointUriProvider.setCoapServer(coapServer);
+
+        lwm2mEndpoint = new JavaCoapServerEndpoint(supportedProtocol, endpointDescription, coapServer,
+                new ServerCoapMessageTranslator(identityHandler), toolbox);
+    }
+
+    protected abstract CoapServer createCoapServer(InetSocketAddress localAddress,
+            ServerSecurityInfo serverSecurityInfo, SecurityStore SecurityStore,
+            Service<CoapRequest, CoapResponse> resources, NotificationsReceiver notificationReceiver,
+            ObservationsStore observationsStore);
+
+    @Override
+    public List<LwM2mServerEndpoint> getEndpoints() {
+        // java-coap CoapServer support only 1 socket/endpoint by server.
+        // So for now this endpoint provider support only 1 endpoint.
+        // If we want to support more, we need to :
+        // - either create serveral coap server by provider
+        // - or create a kind or custom transport proxy with several transport.
+        if (lwm2mEndpoint == null) {
+            return Collections.emptyList();
+        } else {
+            return Arrays.asList(lwm2mEndpoint);
+        }
+    }
+
+    @Override
+    public LwM2mServerEndpoint getEndpoint(URI uri) {
+        if (lwm2mEndpoint != null && lwm2mEndpoint.getURI().equals(uri))
+            return lwm2mEndpoint;
+        else
+            return null;
+    }
+
+    @Override
+    public void start() {
+        try {
+            coapServer.start();
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to start java-coap endpoint", e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        // TODO in Leshan stop means "we can restart after a stop"
+        // but in java-coap : There is no restart after stop, need to create new instance to start again.
+        // I don't know if we should remove stop from Leshan API ?
+        coapServer.stop();
+    }
+
+    @Override
+    public void destroy() {
+        // TODO there is no destroy, so we just stop ?
+        coapServer.stop();
+    }
+}

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpoint.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpoint.java
@@ -54,6 +54,8 @@ import com.mbed.coap.server.CoapServer;
 
 public class JavaCoapServerEndpoint implements LwM2mServerEndpoint {
 
+    private final Protocol supportedProtocol;
+    private final String endpointDescription;
     private final CoapServer coapServer;
     private final ServerCoapMessageTranslator translator;
     private final ServerEndpointToolbox toolbox;
@@ -68,8 +70,10 @@ public class JavaCoapServerEndpoint implements LwM2mServerEndpoint {
             CompletableFuture<? extends LwM2mResponse>> // future of the ongoing Coap Request
     ongoingRequests = new ConcurrentSkipListMap<>();
 
-    public JavaCoapServerEndpoint(CoapServer coapServer, ServerCoapMessageTranslator translator,
-            ServerEndpointToolbox toolbox) {
+    public JavaCoapServerEndpoint(Protocol protocol, String endpointDescription, CoapServer coapServer,
+            ServerCoapMessageTranslator translator, ServerEndpointToolbox toolbox) {
+        this.supportedProtocol = protocol;
+        this.endpointDescription = endpointDescription;
         this.coapServer = coapServer;
         this.translator = translator;
         this.toolbox = toolbox;
@@ -77,12 +81,12 @@ public class JavaCoapServerEndpoint implements LwM2mServerEndpoint {
 
     @Override
     public Protocol getProtocol() {
-        return Protocol.COAP;
+        return supportedProtocol;
     }
 
     @Override
     public String getDescription() {
-        return "CoAP over UDP endpoint based on java-coap library";
+        return endpointDescription;
     }
 
     @Override

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpointsProvider.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/JavaCoapServerEndpointsProvider.java
@@ -15,124 +15,43 @@
  *******************************************************************************/
 package org.eclipse.leshan.transport.javacoap.server.endpoint;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import org.eclipse.leshan.core.endpoint.Protocol;
-import org.eclipse.leshan.server.LeshanServer;
-import org.eclipse.leshan.server.endpoint.LwM2mServerEndpoint;
-import org.eclipse.leshan.server.endpoint.LwM2mServerEndpointsProvider;
-import org.eclipse.leshan.server.endpoint.ServerEndpointToolbox;
-import org.eclipse.leshan.server.observation.LwM2mNotificationReceiver;
-import org.eclipse.leshan.server.request.UplinkRequestReceiver;
+import org.eclipse.leshan.server.security.SecurityStore;
 import org.eclipse.leshan.server.security.ServerSecurityInfo;
-import org.eclipse.leshan.transport.javacoap.server.observation.CoapNotificationReceiver;
-import org.eclipse.leshan.transport.javacoap.server.observation.LwM2mObservationsStore;
-import org.eclipse.leshan.transport.javacoap.server.resource.RegistrationResource;
-import org.eclipse.leshan.transport.javacoap.server.resource.SendResource;
+import org.eclipse.leshan.transport.javacoap.identity.DefaultCoapIdentityHandler;
 
 import com.mbed.coap.packet.CoapRequest;
 import com.mbed.coap.packet.CoapResponse;
 import com.mbed.coap.server.CoapServer;
 import com.mbed.coap.server.CoapServerBuilder;
-import com.mbed.coap.server.RouterService;
 import com.mbed.coap.server.filter.TokenGeneratorFilter;
+import com.mbed.coap.server.observe.NotificationsReceiver;
+import com.mbed.coap.server.observe.ObservationsStore;
 import com.mbed.coap.transport.udp.DatagramSocketTransport;
 import com.mbed.coap.utils.Service;
 
-public class JavaCoapServerEndpointsProvider implements LwM2mServerEndpointsProvider {
-
-    private CoapServer coapServer;
-    private final InetSocketAddress localAddress;
-    private JavaCoapServerEndpoint lwm2mEndpoint;
+public class JavaCoapServerEndpointsProvider extends AbstractJavaCoapServerEndpointsProvider {
 
     public JavaCoapServerEndpointsProvider(InetSocketAddress localAddress) {
-        this.localAddress = localAddress;
+        super(Protocol.COAP, "CoAP over UDP endpoint based on java-coap library", localAddress,
+                new DefaultCoapIdentityHandler());
     }
 
     @Override
-    public void createEndpoints(UplinkRequestReceiver requestReceiver,
-            final LwM2mNotificationReceiver notificationReceiver, final ServerEndpointToolbox toolbox,
-            ServerSecurityInfo serverSecurityInfo, LeshanServer server) {
-
-        // TODO: HACK to be able to get local URI in resource, need to discuss about it with java-coap.
-        EndpointUriProvider endpointUriProvider = new EndpointUriProvider(Protocol.COAP);
-
-        // Create Resources / Routes
-        RegistrationResource registerResource = new RegistrationResource(requestReceiver, toolbox.getLinkParser(),
-                endpointUriProvider);
-        Service<CoapRequest, CoapResponse> resources = RouterService.builder() //
-                .any("/rd/*", registerResource) //
-                .any("/rd", registerResource)//
-                .any("/dp",
-                        new SendResource(requestReceiver, toolbox.getDecoder(), toolbox.getProfileProvider(),
-                                endpointUriProvider))//
-                .build();
-
-        // Create CoAP Server
-        coapServer = createCoapServer() //
+    protected CoapServer createCoapServer(InetSocketAddress localAddress, ServerSecurityInfo serverSecurityInfo,
+            SecurityStore securityStore, Service<CoapRequest, CoapResponse> resources,
+            NotificationsReceiver notificationReceiver, ObservationsStore observationsStore) {
+        return createCoapServer() //
                 .transport(new DatagramSocketTransport(localAddress)) //
                 .route(resources) //
-                .notificationsReceiver(new CoapNotificationReceiver(coapServer, notificationReceiver,
-                        server.getRegistrationStore(), server.getModelProvider(), toolbox.getDecoder())) //
-                .observationsStore(new LwM2mObservationsStore(server.getRegistrationStore(), notificationReceiver)) //
+                .notificationsReceiver(notificationReceiver) //
+                .observationsStore(observationsStore) //
                 .build();
-        endpointUriProvider.setCoapServer(coapServer);
-
-        lwm2mEndpoint = new JavaCoapServerEndpoint(coapServer, new ServerCoapMessageTranslator(), toolbox);
-
     }
 
     protected CoapServerBuilder createCoapServer() {
         return CoapServer.builder().outboundFilter(TokenGeneratorFilter.RANDOM);
-    }
-
-    @Override
-    public List<LwM2mServerEndpoint> getEndpoints() {
-        // java-coap CoapServer support only 1 socket/endpoint by server.
-        // So for now this endpoint provider support only 1 endpoint.
-        // If we want to support more, we need to :
-        // - either create serveral coap server by provider
-        // - or create a kind or custom transport proxy with several transport.
-        if (lwm2mEndpoint == null) {
-            return Collections.emptyList();
-        } else {
-            return Arrays.asList(lwm2mEndpoint);
-        }
-    }
-
-    @Override
-    public LwM2mServerEndpoint getEndpoint(URI uri) {
-        if (lwm2mEndpoint != null && lwm2mEndpoint.getURI().equals(uri))
-            return lwm2mEndpoint;
-        else
-            return null;
-    }
-
-    @Override
-    public void start() {
-        try {
-            coapServer.start();
-        } catch (IOException e) {
-            throw new IllegalStateException("Unable to start java-coap endpoint", e);
-        }
-    }
-
-    @Override
-    public void stop() {
-        // TODO in Leshan stop means "we can restart after a stop"
-        // but in java-coap : There is no restart after stop, need to create new instance to start again.
-        // I don't know if we should remove stop from Leshan API ?
-        coapServer.stop();
-    }
-
-    @Override
-    public void destroy() {
-        // TODO there is no destroy, so we just stop ?
-        coapServer.stop();
     }
 }

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ServerCoapMessageTranslator.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ServerCoapMessageTranslator.java
@@ -19,6 +19,7 @@ import org.eclipse.leshan.core.request.DownlinkRequest;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 import org.eclipse.leshan.server.endpoint.ServerEndpointToolbox;
 import org.eclipse.leshan.server.profile.ClientProfile;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.server.request.CoapRequestBuilder;
 import org.eclipse.leshan.transport.javacoap.server.request.LwM2mResponseBuilder;
 
@@ -27,12 +28,18 @@ import com.mbed.coap.packet.CoapResponse;
 
 public class ServerCoapMessageTranslator {
 
+    private final IdentityHandler identityHandler;
+
+    public ServerCoapMessageTranslator(IdentityHandler identityHandler) {
+        this.identityHandler = identityHandler;
+    }
+
     public CoapRequest createCoapRequest(ClientProfile clientProfile,
             DownlinkRequest<? extends LwM2mResponse> lwm2mRequest, ServerEndpointToolbox toolbox) {
 
         CoapRequestBuilder builder = new CoapRequestBuilder(clientProfile.getRegistration(),
                 clientProfile.getTransportData(), clientProfile.getRootPath(), clientProfile.getModel(),
-                toolbox.getEncoder());
+                toolbox.getEncoder(), identityHandler);
         lwm2mRequest.accept(builder);
         return builder.getRequest();
     }

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/CoapRequestBuilder.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/CoapRequestBuilder.java
@@ -52,10 +52,12 @@ import org.eclipse.leshan.core.request.WriteAttributesRequest;
 import org.eclipse.leshan.core.request.WriteCompositeRequest;
 import org.eclipse.leshan.core.request.WriteRequest;
 import org.eclipse.leshan.server.registration.Registration;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.RandomTokenGenerator;
 import org.eclipse.leshan.transport.javacoap.server.observation.LwM2mKeys;
 
 import com.mbed.coap.packet.CoapRequest;
+import com.mbed.coap.packet.CoapRequest.Builder;
 import com.mbed.coap.packet.MediaTypes;
 import com.mbed.coap.packet.Opaque;
 import com.mbed.coap.transport.TransportContext;
@@ -75,21 +77,24 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     private final String rootPath;
     private final LwM2mEncoder encoder;
     private final LwM2mModel model;
+    private final IdentityHandler identityHandler;
     // TODO we should better manage this and especially better handle token conflict
     private final RandomTokenGenerator tokenGenerator = new RandomTokenGenerator(8);
 
     public CoapRequestBuilder(Registration registration, LwM2mPeer destination, String rootPath, LwM2mModel model,
-            LwM2mEncoder encoder) {
+            LwM2mEncoder encoder, IdentityHandler identityHandler) {
         this.registration = registration;
         this.destination = destination;
         this.rootPath = rootPath;
         this.model = model;
         this.encoder = encoder;
+        this.identityHandler = identityHandler;
     }
 
     @Override
     public void visit(ReadRequest request) {
         coapRequestBuilder = CoapRequest.get(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
         if (request.getContentFormat() != null)
             coapRequestBuilder.accept((short) request.getContentFormat().getCode());
     }
@@ -98,6 +103,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public void visit(DiscoverRequest request) {
         coapRequestBuilder = CoapRequest.get(getURI(request.getPath())) //
                 .accept(MediaTypes.CT_APPLICATION_LINK__FORMAT);
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
@@ -105,22 +111,26 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequestBuilder = request.isReplaceRequest() ? //
                 CoapRequest.put(getURI(request.getPath())) : //
                 CoapRequest.post(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
 
         ContentFormat format = request.getContentFormat();
         coapRequestBuilder //
                 .contentFormat((short) format.getCode()) //
                 .payload(Opaque.of(encoder.encode(request.getNode(), format, request.getPath(), model)));
+
     }
 
     @Override
     public void visit(WriteAttributesRequest request) {
         coapRequestBuilder = CoapRequest.put(getURI(request.getPath())) //
                 .query(request.getAttributes().toString());
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
     public void visit(ExecuteRequest request) {
         coapRequestBuilder = CoapRequest.post(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
         String payload = request.getArguments().serialize();
         if (payload != null) {
             coapRequestBuilder.payload(payload) //
@@ -141,16 +151,19 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequestBuilder = CoapRequest.post(getURI(request.getPath())) //
                 .contentFormat((short) request.getContentFormat().getCode()) //
                 .payload(Opaque.of(encoder.encode(node, request.getContentFormat(), request.getPath(), model)));
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
     public void visit(DeleteRequest request) {
         coapRequestBuilder = CoapRequest.delete(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
     public void visit(ObserveRequest request) {
         coapRequestBuilder = CoapRequest.observe(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
 
         if (request.getContentFormat() != null)
             coapRequestBuilder.accept((short) request.getContentFormat().getCode());
@@ -178,6 +191,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequestBuilder = CoapRequest.observe(getURI(request.getPath())) //
                 .token(Opaque.of(request.getObservation().getId().getBytes())) //
                 .deregisterObserve();
+        addDefaultContext(coapRequestBuilder);
 
         if (request.getContentFormat() != null)
             coapRequestBuilder.accept((short) request.getContentFormat().getCode());
@@ -188,6 +202,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequestBuilder = CoapRequest.fetch(getURI(LwM2mPath.ROOTPATH)) //
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
                 .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat())));
+        addDefaultContext(coapRequestBuilder);
 
         if (request.getResponseContentFormat() != null) {
             coapRequestBuilder.accept((short) request.getResponseContentFormat().getCode());
@@ -200,6 +215,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
                 .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()))) //
                 .observe();
+        addDefaultContext(coapRequestBuilder);
 
         if (request.getResponseContentFormat() != null) {
             coapRequestBuilder.accept((short) request.getResponseContentFormat().getCode());
@@ -212,11 +228,9 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
                 request.getResponseContentFormat(), request.getContext(), Collections.emptyMap());
 
         // Add Observation to request context
-        TransportContext extendedContext = TransportContext.EMPTY //
-                .with(LwM2mKeys.LESHAN_OBSERVATION, observation) //
-                .with(LwM2mKeys.LESHAN_REGISTRATION, registration);
         coapRequestBuilder //
-                .context(extendedContext) //
+                .context(LwM2mKeys.LESHAN_OBSERVATION, observation) //
+                .context(LwM2mKeys.LESHAN_REGISTRATION, registration) //
                 .token(token);
     }
 
@@ -227,6 +241,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
                 .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()))) //
                 .deregisterObserve(); //
+        addDefaultContext(coapRequestBuilder);
 
         if (request.getResponseContentFormat() != null) {
             coapRequestBuilder.accept((short) request.getResponseContentFormat().getCode());
@@ -238,12 +253,14 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
         coapRequestBuilder = CoapRequest.iPatch(getURI(LwM2mPath.ROOTPATH)) //
                 .contentFormat((short) request.getContentFormat().getCode()) //
                 .payload(Opaque.of(encoder.encodeNodes(request.getNodes(), request.getContentFormat(), model)));
+        addDefaultContext(coapRequestBuilder);
 
     }
 
     @Override
     public void visit(BootstrapWriteRequest request) {
         coapRequestBuilder = CoapRequest.put(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
 
         ContentFormat format = request.getContentFormat();
         coapRequestBuilder //
@@ -254,6 +271,7 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     @Override
     public void visit(BootstrapReadRequest request) {
         coapRequestBuilder = CoapRequest.get(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
         if (request.getContentFormat() != null)
             coapRequestBuilder.accept((short) request.getContentFormat().getCode());
     }
@@ -262,16 +280,19 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public void visit(BootstrapDiscoverRequest request) {
         coapRequestBuilder = CoapRequest.get(getURI(request.getPath())) //
                 .accept(MediaTypes.CT_APPLICATION_LINK__FORMAT);
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
     public void visit(BootstrapDeleteRequest request) {
         coapRequestBuilder = CoapRequest.delete(getURI(request.getPath()));
+        addDefaultContext(coapRequestBuilder);
     }
 
     @Override
     public void visit(BootstrapFinishRequest request) {
         coapRequestBuilder = CoapRequest.post("bs");
+        addDefaultContext(coapRequestBuilder);
     }
 
     protected InetSocketAddress getAddress() {
@@ -301,5 +322,9 @@ public class CoapRequestBuilder implements DownlinkRequestVisitor {
     public CoapRequest getRequest() {
         coapRequestBuilder.address(getAddress());
         return coapRequestBuilder.build();
+    }
+
+    public void addDefaultContext(Builder builder) {
+        builder.context(identityHandler.createTransportContext(destination, false));
     }
 }

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/RegistrationResource.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/RegistrationResource.java
@@ -37,6 +37,7 @@ import org.eclipse.leshan.core.response.RegisterResponse;
 import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.core.response.UpdateResponse;
 import org.eclipse.leshan.server.request.UplinkRequestReceiver;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
 import org.eclipse.leshan.transport.javacoap.resource.LwM2mCoapResource;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.EndpointUriProvider;
@@ -66,8 +67,8 @@ public class RegistrationResource extends LwM2mCoapResource {
     private final EndpointUriProvider endpointUriProvider;
 
     public RegistrationResource(UplinkRequestReceiver receiver, LinkParser linkParser,
-            EndpointUriProvider endpointUriProvider) {
-        super(RESOURCE_URI);
+            EndpointUriProvider endpointUriProvider, IdentityHandler identityHandler) {
+        super(RESOURCE_URI, identityHandler);
         this.receiver = receiver;
         this.linkParser = linkParser;
         this.endpointUriProvider = endpointUriProvider;

--- a/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/SendResource.java
+++ b/leshan-tl-javacoap-server/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/SendResource.java
@@ -32,6 +32,7 @@ import org.eclipse.leshan.core.response.SendableResponse;
 import org.eclipse.leshan.server.profile.ClientProfile;
 import org.eclipse.leshan.server.profile.ClientProfileProvider;
 import org.eclipse.leshan.server.request.UplinkRequestReceiver;
+import org.eclipse.leshan.transport.javacoap.identity.IdentityHandler;
 import org.eclipse.leshan.transport.javacoap.request.ResponseCodeUtil;
 import org.eclipse.leshan.transport.javacoap.resource.LwM2mCoapResource;
 import org.eclipse.leshan.transport.javacoap.server.endpoint.EndpointUriProvider;
@@ -56,8 +57,8 @@ public class SendResource extends LwM2mCoapResource {
     private final EndpointUriProvider endpointUriProvider;
 
     public SendResource(UplinkRequestReceiver receiver, LwM2mDecoder decoder, ClientProfileProvider profileProvider,
-            EndpointUriProvider endpointUriProvider) {
-        super(RESOURCE_URI);
+            EndpointUriProvider endpointUriProvider, IdentityHandler identityHandler) {
+        super(RESOURCE_URI, identityHandler);
         this.decoder = decoder;
         this.receiver = receiver;
         this.profileProvider = profileProvider;

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@ Contributors:
     <!-- dependencies version -->
     <californium.version>3.10.0</californium.version>
     <logback.version>1.3.12</logback.version>
+    <javacoap.version>6.19.0</javacoap.version>
     <slf4j.api.version>2.0.9</slf4j.api.version>
     <!-- stuck to 9.4.x for java8 compliance -->
     <jetty.version>9.4.53.v20231009</jetty.version>
@@ -244,7 +245,7 @@ Contributors:
       <dependency>
         <groupId>io.github.open-coap</groupId>
         <artifactId>coap-core</artifactId>
-        <version>6.19.0</version>
+        <version>${javacoap.version}</version>
       </dependency>
 
       <!-- Demos, examples and tests dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,8 @@ Contributors:
     <module>leshan-tl-javacoap-core</module>
     <module>leshan-tl-javacoap-server</module>
     <module>leshan-tl-javacoap-client</module>
+    <module>leshan-tl-javacoap-server-coaptcp</module>
+    <module>leshan-tl-javacoap-client-coaptcp</module>
 
     <!--  integration tests -->
     <module>leshan-integration-tests</module>
@@ -123,6 +125,7 @@ Contributors:
     <californium.version>3.10.0</californium.version>
     <logback.version>1.3.12</logback.version>
     <javacoap.version>6.19.0</javacoap.version>
+    <netty.version>4.1.109.Final</netty.version>
     <slf4j.api.version>2.0.9</slf4j.api.version>
     <!-- stuck to 9.4.x for java8 compliance -->
     <jetty.version>9.4.53.v20231009</jetty.version>
@@ -190,6 +193,16 @@ Contributors:
         <artifactId>leshan-tl-javacoap-client</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>leshan-tl-javacoap-server-coaptcp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>leshan-tl-javacoap-client-coaptcp</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <!-- demo -->
       <dependency>
         <groupId>${project.groupId}</groupId>
@@ -246,6 +259,21 @@ Contributors:
         <groupId>io.github.open-coap</groupId>
         <artifactId>coap-core</artifactId>
         <version>${javacoap.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.github.open-coap</groupId>
+        <artifactId>coap-tcp</artifactId>
+        <version>${javacoap.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
       </dependency>
 
       <!-- Demos, examples and tests dependencies -->


### PR DESCRIPTION
This is a first try about adding` coap+tcp` support based on **java-coap**.

This include a `CoapTcpTransport` based on **netty** which is not Leshan dependent and could be included in **java-coap** repository.
All code about that is in package : `org.eclipse.leshan.transport.javacoap.server.coaptcp.transport` 

This is not mature at all (especially all around connection/deconnection/reconnection) but this is in a testable state. 

**leshan-server-demo** provide a new endpoint for `coap+tcp` at port 5683.
**leshan-client-demo** can be used with `coap+tcp` launching command : `java -jar leshan-client-demo.jar -u coap+tcp://localhost:5683 `

(This doesn't include bootstrap server support)
