### PR TITLE
Add `--bootstrap-factory` option to leshan-client-demo

### DIFF
--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/LeshanClientDemo.java
@@ -73,6 +73,7 @@ import org.eclipse.leshan.core.node.codec.DefaultLwM2mEncoder;
 import org.eclipse.leshan.core.node.codec.text.LwM2mNodeTextDecoder;
 import org.eclipse.leshan.core.request.BootstrapWriteRequest;
 import org.eclipse.leshan.core.request.ContentFormat;
+import org.eclipse.leshan.core.response.BootstrapWriteResponse;
 import org.eclipse.leshan.transport.javacoap.client.endpoint.JavaCoapClientEndpointsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -325,17 +326,34 @@ public class LeshanClientDemo {
         builder.setBootstrapAdditionalAttributes(cli.main.bsAdditionalAttributes);
         final LeshanClient client = builder.build();
 
+        // Handle Factory Bootstrap option
         if (cli.main.factoryBootstrap != null) {
             LwM2mNodeTextDecoder textDecoder = new LwM2mNodeTextDecoder();
             cli.main.factoryBootstrap.forEach((resourcePath, resourceValue) -> {
-                // get resource from string resource value
-                LwM2mSingleResource resource = textDecoder.decode(resourceValue.getBytes(), resourcePath,
-                        repository.getLwM2mModel(), LwM2mSingleResource.class);
-                // try to write this resource
-                client.getObjectTree().getObjectEnabler(resourcePath.getObjectId()).write(LwM2mServer.SYSTEM,
-                        new BootstrapWriteRequest(resourcePath, resource, ContentFormat.TEXT));
+                BootstrapWriteResponse response = null;
+                try {
+                    // get resource from string resource value
+                    LwM2mSingleResource resource = textDecoder.decode(resourceValue.getBytes(), resourcePath,
+                            repository.getLwM2mModel(), LwM2mSingleResource.class);
+                    // try to write this resource
+                    response = client.getObjectTree().getObjectEnabler(resourcePath.getObjectId()).write(
+                            LwM2mServer.SYSTEM, new BootstrapWriteRequest(resourcePath, resource, ContentFormat.TEXT));
+                } catch (RuntimeException e) {
+                    // catch any error
+                    throw new IllegalStateException(
+                            String.format(" --factory-bootstrap failed : unable to write resource %s", resourcePath),
+                            e);
+                }
+                // Raise error if bootstrap write request failed
+                if (response == null || !response.isSuccess()) {
+                    throw new IllegalStateException(
+                            String.format("--factory-bootstrap failed : unable to write resource %s%s", resourcePath,
+                                    response.getErrorMessage() == null ? "" : " : " + response.getErrorMessage()));
+                }
             });
         }
+
+        // Add some log about object tree life cycle.
         client.getObjectTree().addListener(new ObjectsListenerAdapter() {
 
             @Override

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -158,7 +158,7 @@ public class LeshanClientDemoCLI implements Runnable {
                         "Use java-coap for CoAP protocol instead of Californium." })
         public boolean useJavaCoap;
 
-        @Option(names = { "-fb", "factory-bootstrap" },
+        @Option(names = { "-fb", "--factory-bootstrap" },
                 description = { //
                         "Use additional factory bootstrap.", //
                         "syntax is :", //

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -160,11 +160,14 @@ public class LeshanClientDemoCLI implements Runnable {
 
         @Option(names = { "-fb", "--factory-bootstrap" },
                 description = { //
-                        "Use additional factory bootstrap.", //
-                        "syntax is :", //
-                        " -fb resourcePath1=resourceValue1,resourcePath2=\\\"resourceValue2\\\"" },
+                        "Can be used to initialize existing resource with custom value.", //
+                        "LWM2M Text Content format encoding should be used for resource value", //
+                        "E.g. to change Short Server ID :", //
+                        " -fb /0/0/10=1234,/1/0/0=1234", //
+                },
                 split = ",",
                 converter = ResourceConverter.class)
+
         public Map<LwM2mPath, String> factoryBootstrap;
     }
 

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -29,7 +29,9 @@ import org.eclipse.leshan.core.demo.cli.StandardHelpOptions;
 import org.eclipse.leshan.core.demo.cli.VersionProvider;
 import org.eclipse.leshan.core.demo.cli.converters.CIDConverter;
 import org.eclipse.leshan.core.demo.cli.converters.InetAddressConverter;
+import org.eclipse.leshan.core.demo.cli.converters.ResourceConverter;
 import org.eclipse.leshan.core.demo.cli.converters.StrictlyPositiveIntegerConverter;
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.util.StringUtils;
 
 import picocli.CommandLine.ArgGroup;
@@ -155,6 +157,15 @@ public class LeshanClientDemoCLI implements Runnable {
                 description = { //
                         "Use java-coap for CoAP protocol instead of Californium." })
         public boolean useJavaCoap;
+
+        @Option(names = { "-fb", "factory-bootstrap" },
+                description = { //
+                        "Use additional factory bootstrap.", //
+                        "syntax is :", //
+                        " -fb resourcePath1=resourceValue1,resourcePath2=\\\"resourceValue2\\\"" },
+                split = ",",
+                converter = ResourceConverter.class)
+        public Map<LwM2mPath, String> factoryBootstrap;
     }
 
     /* ********************************** Location Section ******************************** */

--- a/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
+++ b/leshan-client-demo/src/main/java/org/eclipse/leshan/client/demo/cli/LeshanClientDemoCLI.java
@@ -29,7 +29,7 @@ import org.eclipse.leshan.core.demo.cli.StandardHelpOptions;
 import org.eclipse.leshan.core.demo.cli.VersionProvider;
 import org.eclipse.leshan.core.demo.cli.converters.CIDConverter;
 import org.eclipse.leshan.core.demo.cli.converters.InetAddressConverter;
-import org.eclipse.leshan.core.demo.cli.converters.ResourceConverter;
+import org.eclipse.leshan.core.demo.cli.converters.ResourcePathConverter;
 import org.eclipse.leshan.core.demo.cli.converters.StrictlyPositiveIntegerConverter;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.util.StringUtils;
@@ -166,7 +166,7 @@ public class LeshanClientDemoCLI implements Runnable {
                         " -fb /0/0/10=1234,/1/0/0=1234", //
                 },
                 split = ",",
-                converter = ResourceConverter.class)
+                converter = ResourcePathConverter.class)
 
         public Map<LwM2mPath, String> factoryBootstrap;
     }

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
@@ -23,7 +23,7 @@ public class ResourceConverter extends LwM2mPathConverter {
     public LwM2mPath convert(String path) {
         LwM2mPath lwM2mPath = super.convert(path);
         if (!lwM2mPath.isResource())
-            throw new LwM2mNodeException("Created path is not a path identifying a resource");
+            throw new LwM2mNodeException(String.format("Invalid resource path : %s is not a resource path", lwM2mPath));
         return lwM2mPath;
     }
 }

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Magdalena Kundera
+ *     Orange Polska S.A. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.demo.cli.converters;
+
+import org.eclipse.leshan.core.node.LwM2mNodeException;
+import org.eclipse.leshan.core.node.LwM2mPath;
+
+public class ResourceConverter extends LwM2mPathConverter {
+
+    @Override
+    public LwM2mPath convert(String path) {
+        LwM2mPath lwM2mPath = new LwM2mPath(path);
+        if (!lwM2mPath.isResource())
+            throw new LwM2mNodeException("Created path is not a path identifying a resource");
+        return lwM2mPath;
+    }
+}

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourceConverter.java
@@ -21,7 +21,7 @@ public class ResourceConverter extends LwM2mPathConverter {
 
     @Override
     public LwM2mPath convert(String path) {
-        LwM2mPath lwM2mPath = new LwM2mPath(path);
+        LwM2mPath lwM2mPath = super.convert(path);
         if (!lwM2mPath.isResource())
             throw new LwM2mNodeException("Created path is not a path identifying a resource");
         return lwM2mPath;

--- a/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourcePathConverter.java
+++ b/leshan-core-demo/src/main/java/org/eclipse/leshan/core/demo/cli/converters/ResourcePathConverter.java
@@ -17,7 +17,7 @@ package org.eclipse.leshan.core.demo.cli.converters;
 import org.eclipse.leshan.core.node.LwM2mNodeException;
 import org.eclipse.leshan.core.node.LwM2mPath;
 
-public class ResourceConverter extends LwM2mPathConverter {
+public class ResourcePathConverter extends LwM2mPathConverter {
 
     @Override
     public LwM2mPath convert(String path) {


### PR DESCRIPTION
This aims to implements https://github.com/eclipse-leshan/leshan/issues/1482.

This is based on : https://github.com/eclipse-leshan/leshan/pull/1512.


The new option looks like : 
```
-fb, --factory-bootstrap=<LwM2mPath=String>[,<LwM2mPath=String>...]
                       Can be used to initialize existing resource with
                         custom value.
                       LWM2M Text Content format encoding should be used
                         for resource value
                       E.g. to change Short Server ID :
                        -fb /0/0/10=1234,/1/0/0=1234
```