### PR TITLE
Fix version helper classes

### DIFF
--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -105,24 +105,20 @@ public interface LwM2m {
         protected final short minor;
 
         public Version(int major, int minor) {
-            this(
-                    toShortExact(major, "version (%d.%d) major part (%d) is not a valid short",
-                            major, minor, major),
-                    toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short",
-                            major, minor, minor)
-            );
+            this(toShortExact(major, "version (%d.%d) major part (%d) is not a valid short", major, minor, major),
+                    toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short", major, minor, minor));
         }
 
         public Version(short major, short minor) {
             this.major = major;
             if (this.major < 0) {
-                throw new IllegalArgumentException(String.format("version (%d.%d) major part (%d) must not be negative",
-                        major, minor, major));
+                throw new IllegalArgumentException(
+                        String.format("version (%d.%d) major part (%d) must not be negative", major, minor, major));
             }
             this.minor = minor;
             if (this.minor < 0) {
-                throw new IllegalArgumentException(String.format("version (%d.%d) minor part (%d) must not be negative",
-                        major, minor, minor));
+                throw new IllegalArgumentException(
+                        String.format("version (%d.%d) minor part (%d) must not be negative", major, minor, minor));
             }
         }
 
@@ -196,7 +192,6 @@ public interface LwM2m {
         public int compareTo(Version other) {
             if (major != other.major)
                 return major - other.major;
-
             return minor - other.minor;
         }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -94,22 +94,36 @@ public interface LwM2m {
         public static final Version V1_0 = new Version("1.0");
         public static final Version MAX = new Version(Short.MAX_VALUE, Short.MAX_VALUE);
 
+        private static short toShortExact(int value, String format, Object... args) {
+            if ((short) value != value) {
+                throw new IllegalArgumentException(String.format(format, args));
+            }
+            return (short) value;
+        }
+
         protected final short major;
         protected final short minor;
 
         public Version(int major, int minor) {
-            this((short) major, (short) minor);
-            if (this.major != major) {
-                throw new ArithmeticException("short overflow");
-            }
-            if (this.minor != minor) {
-                throw new ArithmeticException("short overflow");
-            }
+            this(
+                    toShortExact(major, "version (%d.%d) major part (%d) is not a valid short",
+                            major, minor, major),
+                    toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short",
+                            major, minor, minor)
+            );
         }
 
         public Version(short major, short minor) {
             this.major = major;
+            if (this.major < 0) {
+                throw new IllegalArgumentException(String.format("version (%d.%d) major part (%d) must not be negative",
+                        major, minor, major));
+            }
             this.minor = minor;
+            if (this.minor < 0) {
+                throw new IllegalArgumentException(String.format("version (%d.%d) minor part (%d) must not be negative",
+                        major, minor, minor));
+            }
         }
 
         public Version(String version) {
@@ -157,8 +171,8 @@ public interface LwM2m {
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + (int) major;
-            result = prime * result + (int) minor;
+            result = prime * result + major;
+            result = prime * result + minor;
             return result;
         }
 

--- a/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -22,9 +22,9 @@ public interface LwM2m {
      */
     public class LwM2mVersion extends Version {
 
-        public static LwM2mVersion V1_0 = new LwM2mVersion("1.0", true);
-        public static LwM2mVersion V1_1 = new LwM2mVersion("1.1", true);
-        private static LwM2mVersion[] supportedVersions = new LwM2mVersion[] { V1_0, V1_1 };
+        public static final LwM2mVersion V1_0 = new LwM2mVersion("1.0", true);
+        public static final LwM2mVersion V1_1 = new LwM2mVersion("1.1", true);
+        private static final LwM2mVersion[] supportedVersions = new LwM2mVersion[] { V1_0, V1_1 };
 
         private final boolean supported;
 
@@ -91,35 +91,35 @@ public interface LwM2m {
      */
     public class Version implements Comparable<Version> {
 
-        public static Version V1_0 = new Version("1.0");
-        public static final Version MAX = new Version(Short.MAX_VALUE, Short.MIN_VALUE);
+        public static final Version V1_0 = new Version("1.0");
+        public static final Version MAX = new Version(Short.MAX_VALUE, Short.MAX_VALUE);
 
-        protected final Short major;
-        protected final Short minor;
+        protected final short major;
+        protected final short minor;
 
         public Version(int major, int minor) {
-            this.major = (short) major;
-            this.minor = (short) minor;
+            this((short) major, (short) minor);
+            if (this.major != major) {
+                throw new ArithmeticException("short overflow");
+            }
+            if (this.minor != minor) {
+                throw new ArithmeticException("short overflow");
+            }
         }
 
-        public Version(Short major, Short minor) {
+        public Version(short major, short minor) {
             this.major = major;
             this.minor = minor;
         }
 
         public Version(String version) {
-            try {
-                String[] versionPart = version.split("\\.");
-                this.major = Short.parseShort(versionPart[0]);
-                this.minor = Short.parseShort(versionPart[1]);
-            } catch (RuntimeException e) {
-                String err = Version.validate(version);
-                if (err != null) {
-                    throw new IllegalArgumentException(err);
-                } else {
-                    throw e;
-                }
+            String err = Version.validate(version);
+            if (err != null) {
+                throw new IllegalArgumentException(err);
             }
+            String[] versionPart = version.split("\\.");
+            this.major = Short.parseShort(versionPart[0]);
+            this.minor = Short.parseShort(versionPart[1]);
         }
 
         @Override
@@ -133,16 +133,16 @@ public interface LwM2m {
 
         public static String validate(String version) {
             if (version == null || version.isEmpty())
-                return "version  MUST NOT be null or empty";
+                return "version MUST NOT be null or empty";
             String[] versionPart = version.split("\\.");
             if (versionPart.length != 2) {
                 return String.format("version (%s) MUST be composed of 2 parts", version);
             }
             for (int i = 0; i < 2; i++) {
                 try {
-                    Short parsedShort = Short.parseShort(versionPart[i]);
+                    short parsedShort = Short.parseShort(versionPart[i]);
                     if (parsedShort < 0) {
-                        return String.format("version (%s) part %d (%s) is not a valid short", version, i + 1,
+                        return String.format("version (%s) part %d (%s) must not be negative", version, i + 1,
                                 versionPart[i]);
                     }
                 } catch (Exception e) {
@@ -157,8 +157,8 @@ public interface LwM2m {
         public int hashCode() {
             final int prime = 31;
             int result = 1;
-            result = prime * result + ((major == null) ? 0 : major.hashCode());
-            result = prime * result + ((minor == null) ? 0 : minor.hashCode());
+            result = prime * result + (int) major;
+            result = prime * result + (int) minor;
             return result;
         }
 
@@ -171,15 +171,9 @@ public interface LwM2m {
             if (getClass() != obj.getClass())
                 return false;
             Version other = (Version) obj;
-            if (major == null) {
-                if (other.major != null)
-                    return false;
-            } else if (!major.equals(other.major))
+            if (major != other.major)
                 return false;
-            if (minor == null) {
-                if (other.minor != null)
-                    return false;
-            } else if (!minor.equals(other.minor))
+            if (minor != other.minor)
                 return false;
             return true;
         }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
@@ -15,13 +15,16 @@
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class VersionTest {
     @Test
@@ -36,26 +39,68 @@ public class VersionTest {
     @Test
     public void compare_tests() {
         assertTrue(new Version("1.0").compareTo(new Version("1.2")) < 0);
+        assertTrue(new Version("1.0").olderThan(new Version("1.2")));
+        assertNotEquals(new Version("1.0").hashCode(), new Version("1.2").hashCode());
+
         assertTrue(new Version("0.9").compareTo(new Version("1.2")) < 0);
-        assertTrue(new Version("1.2").compareTo(new Version("1.2")) == 0);
-        assertTrue(new Version("1.3").compareTo(new Version("1.2")) > 0);
-        assertTrue(new Version("2.0").compareTo(new Version("1.2")) > 0);
+        assertTrue(new Version("0.9").olderThan(new Version("1.2")));
+        assertNotEquals(new Version("0.9"), new Version("1.2"));
+
         assertTrue(new Version("128.0").compareTo(new Version("128.2")) < 0);
+        assertTrue(new Version("128.0").olderThan(new Version("128.2")));
+        assertNotEquals(new Version("128.0"), new Version("128.2"));
+
+        assertTrue(new Version("1.2").compareTo(new Version("1.2")) == 0);
+        assertEquals(new Version("1.2"), new Version("1.2"));
+        assertEquals(new Version("1.2").hashCode(), new Version("1.2").hashCode());
+
         assertTrue(new Version("128.0").compareTo(new Version("128.0")) == 0);
+        assertEquals(new Version("128.0"), new Version("128.0"));
+        assertEquals(new Version("128.0").hashCode(), new Version("128.0").hashCode());
+
+        assertTrue(new Version("1.3").compareTo(new Version("1.2")) > 0);
+        assertTrue(new Version("1.3").newerThan(new Version("1.2")));
+
+        assertTrue(new Version("2.0").compareTo(new Version("1.2")) > 0);
+        assertTrue(new Version("2.0").newerThan(new Version("1.2")));
+
         assertTrue(new Version("128.2").compareTo(new Version("128.0")) > 0);
+        assertTrue(new Version("128.2").newerThan(new Version("128.0")));
+        assertNotEquals(new Version("128.2"), new Version("128.0"));
     }
 
-    @Test
-    public void short_overflow_tests() {
-        assertThrows(ArithmeticException.class, () -> new Version(Short.MIN_VALUE - 1, Short.MIN_VALUE));
-        assertThrows(ArithmeticException.class, () -> new Version(Short.MIN_VALUE, Short.MIN_VALUE - 1));
-        assertThrows(ArithmeticException.class, () -> new Version(Short.MAX_VALUE + 1, Short.MAX_VALUE));
-        assertThrows(ArithmeticException.class, () -> new Version(Short.MAX_VALUE, Short.MAX_VALUE + 1));
+    @ParameterizedTest
+    @MethodSource("illegal_arguments")
+    public void illegal_argument_tests(Executable executable, String expectedMessage) {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, executable);
+        assertEquals(expectedMessage, e.getMessage());
     }
 
-    @Test
-    public void negative_number_tests() {
-        assertThrows(IllegalArgumentException.class, () -> new Version("-1.0"));
-        assertThrows(IllegalArgumentException.class, () -> new Version("1.-1"));
+    private static Stream<Arguments> illegal_arguments() {
+        return Stream.of(
+                args(() -> new Version(null), "version MUST NOT be null or empty"),
+                args(() -> new Version(""), "version MUST NOT be null or empty"),
+                args(() -> new Version("foo"), "version (foo) MUST be composed of 2 parts"),
+                args(() -> new Version("1.0.0"), "version (1.0.0) MUST be composed of 2 parts"),
+                args(() -> new Version("-1.0"), "version (-1.0) part 1 (-1) must not be negative"),
+                args(() -> new Version("1.-1"), "version (1.-1) part 2 (-1) must not be negative"),
+                args(() -> new Version("-1.0"), "version (-1.0) part 1 (-1) must not be negative"),
+                args(() -> new Version("1.-1"), "version (1.-1) part 2 (-1) must not be negative"),
+                args(() -> new Version("a.0"), "version (a.0) part 1 (a) is not a valid short"),
+                args(() -> new Version("32768.32767"), "version (32768.32767) part 1 (32768) is not a valid short"),
+                args(() -> new Version("32767.32768"), "version (32767.32768) part 2 (32768) is not a valid short"),
+                args(() -> new Version(-32769, -32768), "version (-32769.-32768) major part (-32769) is not a valid short"),
+                args(() -> new Version(-32768, -32769), "version (-32768.-32769) minor part (-32769) is not a valid short"),
+                args(() -> new Version(32768, 32767), "version (32768.32767) major part (32768) is not a valid short"),
+                args(() -> new Version(32767, 32768), "version (32767.32768) minor part (32768) is not a valid short"),
+                args(() -> new Version(-1, 0), "version (-1.0) major part (-1) must not be negative"),
+                args(() -> new Version(1, -1), "version (1.-1) minor part (-1) must not be negative"),
+                args(() -> new Version((short) -1, (short) 0), "version (-1.0) major part (-1) must not be negative"),
+                args(() -> new Version((short) 1, (short) -1), "version (1.-1) minor part (-1) must not be negative")
+        );
+    }
+
+    private static Arguments args(Executable executable, String expectedMessage) {
+        return Arguments.of(executable, expectedMessage);
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
@@ -15,6 +15,14 @@
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.junit.jupiter.api.Test;
@@ -22,9 +30,6 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class VersionTest {
     @Test
@@ -39,34 +44,45 @@ public class VersionTest {
     @Test
     public void compare_tests() {
         assertTrue(new Version("1.0").compareTo(new Version("1.2")) < 0);
-        assertTrue(new Version("1.0").olderThan(new Version("1.2")));
-        assertNotEquals(new Version("1.0").hashCode(), new Version("1.2").hashCode());
-
         assertTrue(new Version("0.9").compareTo(new Version("1.2")) < 0);
-        assertTrue(new Version("0.9").olderThan(new Version("1.2")));
-        assertNotEquals(new Version("0.9"), new Version("1.2"));
-
         assertTrue(new Version("128.0").compareTo(new Version("128.2")) < 0);
-        assertTrue(new Version("128.0").olderThan(new Version("128.2")));
-        assertNotEquals(new Version("128.0"), new Version("128.2"));
-
         assertTrue(new Version("1.2").compareTo(new Version("1.2")) == 0);
-        assertEquals(new Version("1.2"), new Version("1.2"));
-        assertEquals(new Version("1.2").hashCode(), new Version("1.2").hashCode());
-
         assertTrue(new Version("128.0").compareTo(new Version("128.0")) == 0);
-        assertEquals(new Version("128.0"), new Version("128.0"));
-        assertEquals(new Version("128.0").hashCode(), new Version("128.0").hashCode());
-
         assertTrue(new Version("1.3").compareTo(new Version("1.2")) > 0);
-        assertTrue(new Version("1.3").newerThan(new Version("1.2")));
-
         assertTrue(new Version("2.0").compareTo(new Version("1.2")) > 0);
-        assertTrue(new Version("2.0").newerThan(new Version("1.2")));
-
         assertTrue(new Version("128.2").compareTo(new Version("128.0")) > 0);
-        assertTrue(new Version("128.2").newerThan(new Version("128.0")));
-        assertNotEquals(new Version("128.2"), new Version("128.0"));
+    }
+
+    @Test
+    public void equals_tests() {
+        assertEquals(Version.V1_0, Version.V1_0);
+        assertEquals(new Version("1.1"), new Version("1.1"));
+    }
+
+    @Test
+    public void not_equals_tests() {
+        assertNotEquals(new Version("1.0"), null);
+        assertNotEquals(new Version("1.0"), "");
+        assertNotEquals(new Version("1.0"), new Version("1.1"));
+        assertNotEquals(new Version("1.0"), new Version("0.9"));
+    }
+
+    @Test
+    public void hash_code_tests() {
+        assertEquals(new Version("1.1").hashCode(), new Version("1.1").hashCode());
+        assertNotEquals(new Version("1.0").hashCode(), new Version("1.1").hashCode());
+    }
+
+    @Test
+    public void older_then_tests() {
+        assertTrue(new Version("1.0").olderThan(new Version("1.1")));
+        assertTrue(new Version("0.9").olderThan(new Version("1.1")));
+    }
+
+    @Test
+    public void newer_then_tests() {
+        assertTrue(new Version("1.1").newerThan(new Version("1.0")));
+        assertTrue(new Version("1.0").newerThan(new Version("0.9")));
     }
 
     @ParameterizedTest
@@ -77,8 +93,7 @@ public class VersionTest {
     }
 
     private static Stream<Arguments> illegal_arguments() {
-        return Stream.of(
-                args(() -> new Version(null), "version MUST NOT be null or empty"),
+        return Stream.of(args(() -> new Version(null), "version MUST NOT be null or empty"),
                 args(() -> new Version(""), "version MUST NOT be null or empty"),
                 args(() -> new Version("foo"), "version (foo) MUST be composed of 2 parts"),
                 args(() -> new Version("1.0.0"), "version (1.0.0) MUST be composed of 2 parts"),
@@ -87,15 +102,16 @@ public class VersionTest {
                 args(() -> new Version("a.0"), "version (a.0) part 1 (a) is not a valid short"),
                 args(() -> new Version("32768.32767"), "version (32768.32767) part 1 (32768) is not a valid short"),
                 args(() -> new Version("32767.32768"), "version (32767.32768) part 2 (32768) is not a valid short"),
-                args(() -> new Version(-32769, -32768), "version (-32769.-32768) major part (-32769) is not a valid short"),
-                args(() -> new Version(-32768, -32769), "version (-32768.-32769) minor part (-32769) is not a valid short"),
+                args(() -> new Version(-32769, -32768),
+                        "version (-32769.-32768) major part (-32769) is not a valid short"),
+                args(() -> new Version(-32768, -32769),
+                        "version (-32768.-32769) minor part (-32769) is not a valid short"),
                 args(() -> new Version(32768, 32767), "version (32768.32767) major part (32768) is not a valid short"),
                 args(() -> new Version(32767, 32768), "version (32767.32768) minor part (32768) is not a valid short"),
                 args(() -> new Version(-1, 0), "version (-1.0) major part (-1) must not be negative"),
                 args(() -> new Version(1, -1), "version (1.-1) minor part (-1) must not be negative"),
                 args(() -> new Version((short) -1, (short) 0), "version (-1.0) major part (-1) must not be negative"),
-                args(() -> new Version((short) 1, (short) -1), "version (1.-1) minor part (-1) must not be negative")
-        );
+                args(() -> new Version((short) 1, (short) -1), "version (1.-1) minor part (-1) must not be negative"));
     }
 
     private static Arguments args(Executable executable, String expectedMessage) {

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
@@ -42,7 +42,7 @@ public class VersionTest {
     }
 
     @Test
-    public void compare_tests() {
+    public void compare_to_tests() {
         assertTrue(new Version("1.0").compareTo(new Version("1.2")) < 0);
         assertTrue(new Version("0.9").compareTo(new Version("1.2")) < 0);
         assertTrue(new Version("128.0").compareTo(new Version("128.2")) < 0);
@@ -74,13 +74,13 @@ public class VersionTest {
     }
 
     @Test
-    public void older_then_tests() {
+    public void older_than_tests() {
         assertTrue(new Version("1.0").olderThan(new Version("1.1")));
         assertTrue(new Version("0.9").olderThan(new Version("1.1")));
     }
 
     @Test
-    public void newer_then_tests() {
+    public void newer_than_tests() {
         assertTrue(new Version("1.1").newerThan(new Version("1.0")));
         assertTrue(new Version("1.0").newerThan(new Version("0.9")));
     }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
@@ -39,5 +40,22 @@ public class VersionTest {
         assertTrue(new Version("1.2").compareTo(new Version("1.2")) == 0);
         assertTrue(new Version("1.3").compareTo(new Version("1.2")) > 0);
         assertTrue(new Version("2.0").compareTo(new Version("1.2")) > 0);
+        assertTrue(new Version("128.0").compareTo(new Version("128.2")) < 0);
+        assertTrue(new Version("128.0").compareTo(new Version("128.0")) == 0);
+        assertTrue(new Version("128.2").compareTo(new Version("128.0")) > 0);
+    }
+
+    @Test
+    public void short_overflow_tests() {
+        assertThrows(ArithmeticException.class, () -> new Version(Short.MIN_VALUE - 1, Short.MIN_VALUE));
+        assertThrows(ArithmeticException.class, () -> new Version(Short.MIN_VALUE, Short.MIN_VALUE - 1));
+        assertThrows(ArithmeticException.class, () -> new Version(Short.MAX_VALUE + 1, Short.MAX_VALUE));
+        assertThrows(ArithmeticException.class, () -> new Version(Short.MAX_VALUE, Short.MAX_VALUE + 1));
+    }
+
+    @Test
+    public void negative_number_tests() {
+        assertThrows(IllegalArgumentException.class, () -> new Version("-1.0"));
+        assertThrows(IllegalArgumentException.class, () -> new Version("1.-1"));
     }
 }

--- a/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
+++ b/leshan-core/src/test/java/org/eclipse/leshan/core/VersionTest.java
@@ -84,8 +84,6 @@ public class VersionTest {
                 args(() -> new Version("1.0.0"), "version (1.0.0) MUST be composed of 2 parts"),
                 args(() -> new Version("-1.0"), "version (-1.0) part 1 (-1) must not be negative"),
                 args(() -> new Version("1.-1"), "version (1.-1) part 2 (-1) must not be negative"),
-                args(() -> new Version("-1.0"), "version (-1.0) part 1 (-1) must not be negative"),
-                args(() -> new Version("1.-1"), "version (1.-1) part 2 (-1) must not be negative"),
                 args(() -> new Version("a.0"), "version (a.0) part 1 (a) is not a valid short"),
                 args(() -> new Version("32768.32767"), "version (32768.32767) part 1 (32768) is not a valid short"),
                 args(() -> new Version("32767.32768"), "version (32767.32768) part 2 (32768) is not a valid short"),


### PR DESCRIPTION
I think the `Version` class has some issues which I tried to fix. I have added some test cases which fail without these changes. Feel free to have a look.

Also I think `Version.V1_0`, `LwM2mVersion.V1_0` and `LwM2mVersion.V1_1` should probably be `final`… so I changed that, too. Happy to hear your opinions.