### PR TITLE
Nightly build now execute tests on all LTS JDK

### DIFF
--- a/.jenkins/ci.jenkins
+++ b/.jenkins/ci.jenkins
@@ -36,12 +36,12 @@ pipeline {
   }
   post {
     unsuccessful {
-      mail to: 'sbernard@sierrawireless.com',
+      mail to: 'code@simonbernard.eu',
            subject: "Build ${env.BUILD_TAG} failed!",
            body: "Check console output at ${env.BUILD_URL} to view the results."
     }
     fixed {
-      mail to: 'sbernard@sierrawireless.com',
+      mail to: 'code@simonbernard.eu',
            subject: "Build ${env.BUILD_TAG} back to normal.",
            body: "Check console output at ${env.BUILD_URL} to view the results."
     }

--- a/.jenkins/nightly.jenkins
+++ b/.jenkins/nightly.jenkins
@@ -28,25 +28,32 @@ pipeline {
         // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
         // see : https://github.com/eclipse-leshan/leshan/pull/1484
         sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
-          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins '''
+          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins -DskipTests'''
         }
+        
+        // test with minimal supported version
+        sh '''mvn -B test -PuseToolchain  -Dskip.yarn'''
+        // test with all LTS version
+        sh '''mvn -B test -PuseToolchain  -Dskip.yarn -Dtoolchain.version=11'''
+        sh '''mvn -B test -PuseToolchain  -Dskip.yarn -Dtoolchain.version=17'''
+        sh '''mvn -B test -PuseToolchain  -Dskip.yarn -Dtoolchain.version=21'''
       }
     }
     stage('Deploy') {
       steps {
-        // Build 
+        // Deploy 
         sh '''mvn -B deploy -Prelease-nightly -DskipTests -Dskip.yarn'''
       }
     }
   }
   post {
     unsuccessful {
-      mail to: 'sbernard@sierrawireless.com',
+      mail to: 'code@simonbernard.eu',
            subject: "Build ${env.BUILD_TAG} failed!",
            body: "Check console output at ${env.BUILD_URL} to view the results."
     }
     fixed {
-      mail to: 'sbernard@sierrawireless.com',
+      mail to: 'code@simonbernard.eu',
            subject: "Build ${env.BUILD_TAG} back to normal.",
            body: "Check console output at ${env.BUILD_URL} to view the results."
     }

--- a/.jenkins/test.jenkins
+++ b/.jenkins/test.jenkins
@@ -1,0 +1,77 @@
+/************************************************************************************
+
+  Manual job used to test to build a branch on jenkins
+  Take 1 parameters (BRANCH).
+
+    Checks out current ${BRANCH}'s HEAD
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  parameters {
+    string(
+        name: 'BRANCH',
+        defaultValue: 'master',
+        description: 'The branch to build. Examples: master, 1.x')
+    booleanParam(
+        name: 'TEST_WITH_TOOLCHAIN',
+        defaultValue: false,
+        description: 'To execute tests using toolchain')
+    string(
+        name: 'JDK_TOOLCHAIN_VERSION',
+        defaultValue: '',
+        description: 'The jdk version used to execute tests when `TEST_WITH_TOOLCHAIN` is used. (e.g. 1.7 1.8 11 17 21 ...). By default, this is an empty string which means use minimal supported java version')
+  }
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'temurin-jdk11-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    skipDefaultCheckout()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  stages {
+        stage('Build') {
+      steps {
+        // Checkout code
+        git url: 'git@github.com:eclipse-leshan/leshan.git',
+            credentialsId: 'github-bot-ssh',
+            branch: '${BRANCH}'
+      
+        // Build 
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom ''' 
+        // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
+        // see : https://github.com/eclipse-leshan/leshan/pull/1484
+        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins -DskipTests'''
+        }
+
+        
+        // test with 
+        // - given toolchain version
+        // - OR minimal version supported
+        // - OR jvm used to build. 
+        sh ''' 
+            if [[ $TEST_WITH_TOOLCHAIN == true ]]; then
+                if [[ -n $JDK_TOOLCHAIN_VERSION ]]; then
+                    mvn -B test -PuseToolchain  -Dskip.yarn -Dtoolchain.version="${JDK_TOOLCHAIN_VERSION}"
+                else
+                    mvn -B test -PuseToolchain -Dskip.yarn
+                fi
+            else
+                mvn -B test -Dskip.yarn
+            fi
+        '''
+        
+        // Copy artifacts
+        sh ''' cp leshan-server-demo/target/leshan-server-demo-*-jar-with-dependencies.jar leshan-server-demo.jar
+               cp leshan-bsserver-demo/target/leshan-bsserver-demo-*-jar-with-dependencies.jar leshan-bsserver-demo.jar
+               cp leshan-client-demo/target/leshan-client-demo-*-jar-with-dependencies.jar leshan-client-demo.jar
+        '''
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -628,5 +628,27 @@ Contributors:
         <sort.skip>true</sort.skip>
       </properties>
     </profile>
+    <profile>
+      <!-- This profile launch tests with given jdk version using toolchain -->
+      <id>useToolchain</id>
+      <properties>
+        <!-- Default value is minimal supported version, but another version can be used with : 
+            mvn clean install -PuseToolchain -Dtoolchain.version=11
+        -->
+        <toolchain.version>1.8</toolchain.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <jdkToolchain>
+                <version>${toolchain.version}</version>
+              </jdkToolchain>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This PR aims to implement  #1498.

This also add a manual job : https://ci.eclipse.org/leshan/job/leshan-test/ where you could chose branch and java version to execute tests. 