### PR TITLE
Use `dependency-check-maven` plugin to check dependencies vulnerabilities. 

### DIFF
--- a/.jenkins/test.jenkins
+++ b/.jenkins/test.jenkins
@@ -27,7 +27,7 @@ pipeline {
     jdk 'temurin-jdk11-latest'
   }
   options {
-    timeout (time: 30, unit: 'MINUTES')
+    timeout (time: 180, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '3'))
     disableConcurrentBuilds()
     skipDefaultCheckout()
@@ -50,28 +50,22 @@ pipeline {
         }
 
         
-        // test with 
-        // - given toolchain version
-        // - OR minimal version supported
-        // - OR jvm used to build. 
-        sh ''' 
-            if [[ $TEST_WITH_TOOLCHAIN == true ]]; then
-                if [[ -n $JDK_TOOLCHAIN_VERSION ]]; then
-                    mvn -B test -PuseToolchain  -Dskip.yarn -Dtoolchain.version="${JDK_TOOLCHAIN_VERSION}"
-                else
-                    mvn -B test -PuseToolchain -Dskip.yarn
-                fi
-            else
-                mvn -B test -Dskip.yarn
-            fi
-        '''
-        
-        // Copy artifacts
-        sh ''' cp leshan-server-demo/target/leshan-server-demo-*-jar-with-dependencies.jar leshan-server-demo.jar
-               cp leshan-bsserver-demo/target/leshan-bsserver-demo-*-jar-with-dependencies.jar leshan-bsserver-demo.jar
-               cp leshan-client-demo/target/leshan-client-demo-*-jar-with-dependencies.jar leshan-client-demo.jar
-        '''
+        // check for vulnerability
+        sh '''mvn -B -Paggregate  dependency-check:aggregate'''  
       }
+    }
+  }
+  post {
+    always {
+      // publish HTML report
+      publishHTML target: [
+            allowMissing: false,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'leshan/target/',
+            reportFiles: 'dependency-check-report.htm',
+            reportName: 'Vulnerability Report'
+          ]
     }
   }
 }

--- a/.jenkins/weekly.jenkins
+++ b/.jenkins/weekly.jenkins
@@ -1,0 +1,61 @@
+/************************************************************************************
+  
+  Weekly Build : 
+  Checks for vulnerability
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'temurin-jdk11-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    pollSCM ignorePostCommitHooks: true, scmpoll_spec: 'H H * * Sun'
+  }
+  stages {
+    stage('Build') {
+      steps {
+        // Build 
+        sh ''' mvn -B com.github.ekryd.sortpom:sortpom-maven-plugin:verify -PallPom ''' 
+        // This ssh agent is needed to cache yarn/node to download.eclipse.org when using -PeclipseJenkins
+        // see : https://github.com/eclipse-leshan/leshan/pull/1484
+        sshagent ( ['projects-storage.eclipse.org-bot-ssh']) {
+          sh ''' mvn -B clean install javadoc:javadoc -PeclipseJenkins -DskipTests'''
+        }
+        
+        // check for vulnerability
+        sh '''mvn -B -Paggregate  dependency-check:aggregate'''    
+      }
+    }
+  }
+  post {
+    unsuccessful {
+      mail to: 'code@simonbernard.eu',
+           subject: "Build ${env.BUILD_TAG} failed!",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    fixed {
+      mail to: 'code@simonbernard.eu',
+           subject: "Build ${env.BUILD_TAG} back to normal.",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    always {
+      // publish HTML report
+      publishHTML target: [
+            allowMissing: false,
+            alwaysLinkToLastBuild: false,
+            keepAll: true,
+            reportDir: 'leshan/target/',
+            reportFiles: 'dependency-check-report.htm',
+            reportName: 'Vulnerability Report'
+          ]
+    }
+  }
+}

--- a/build-config/demo-build-config/pom.xml
+++ b/build-config/demo-build-config/pom.xml
@@ -103,6 +103,22 @@ Contributors:
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <configuration>
+            <scanSet>
+              <fileSet>
+                <directory>${project.basedir}/webapp</directory>
+                <includes>
+                  <include>package.json</include>
+                  <include>yarn.lock</include>
+                </includes>
+              </fileSet>
+            </scanSet>
+            <pathToYarn>${project.basedir}/webapp/node/yarn/dist/bin/yarn</pathToYarn>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -666,6 +666,8 @@ Contributors:
             <groupId>org.owasp</groupId>
             <artifactId>dependency-check-maven</artifactId>
             <configuration>
+              <!--format>JENKINS</format-->
+              <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
               <scanSet>
                 <fileSet>
                   <directory>${project.basedir}/leshan-server-demo/webapp</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,14 @@ Contributors:
           <artifactId>wagon-maven-plugin</artifactId>
           <version>2.0.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.owasp</groupId>
+          <artifactId>dependency-check-maven</artifactId>
+          <version>9.0.6</version>
+          <configuration>
+            <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -658,5 +658,35 @@ Contributors:
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>aggregate</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.owasp</groupId>
+            <artifactId>dependency-check-maven</artifactId>
+            <configuration>
+              <scanSet>
+                <fileSet>
+                  <directory>${project.basedir}/leshan-server-demo/webapp</directory>
+                  <includes>
+                    <include>package.json</include>
+                    <include>yarn.lock</include>
+                  </includes>
+                </fileSet>
+                <fileSet>
+                  <directory>${project.basedir}/leshan-bsserver-demo/webapp</directory>
+                  <includes>
+                    <include>package.json</include>
+                    <include>yarn.lock</include>
+                  </includes>
+                </fileSet>
+              </scanSet>
+              <pathToYarn>${project.basedir}/leshan-server-demo/webapp/node/yarn/dist/bin/yarn</pathToYarn>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
This is part of searching a way to check dependencies vulnerabilities, see https://github.com/eclipse-leshan/leshan/issues/1566

It works well with pure maven dependencies but not so good with [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) see https://github.com/jeremylong/DependencyCheck/issues/6325.

Even if we can make it work with workaround, we can maybe found better ? :thinking: 