### PR TITLE
Add Weekly Jenkins Build to check dependencies vulnerabilites with trivy

### DIFF
--- a/.jenkins/weekly.jenkins
+++ b/.jenkins/weekly.jenkins
@@ -1,0 +1,52 @@
+/************************************************************************************
+  
+  Weekly Build : 
+  Checks for vulnerability
+  
+*************************************************************************************/
+pipeline {
+  agent any
+  tools {
+    maven 'apache-maven-latest'
+    jdk 'temurin-jdk11-latest'
+  }
+  options {
+    timeout (time: 30, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '3'))
+    disableConcurrentBuilds()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+  }
+  triggers {
+    // every night between Saturday and Sunday
+    cron 'H H * * 6'
+  }
+  environment {
+    PATH = "${env.HOME}/bin:${env.PATH}"
+  }
+  stages {
+    stage('Build') {
+      steps {
+        // install trivy
+        sh 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b ~/bin v0.48.1'
+      
+        // Build 
+        sh ''' mvn -B clean install javadoc:javadoc -DskipTests ''' 
+        
+        // check for vulnerabilities
+        sh 'trivy -f table --scanners vuln fs . --include-dev-deps --exit-code 1'     
+      }
+    }
+  }
+  post {
+    unsuccessful {
+      mail to: 'code@simonbernard.eu',
+           subject: "Build ${env.BUILD_TAG} failed!",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+    fixed {
+      mail to: 'code@simonbernard.eu',
+           subject: "Build ${env.BUILD_TAG} back to normal.",
+           body: "Check console output at ${env.BUILD_URL} to view the results."
+    }
+  }
+}


### PR DESCRIPTION
This do the job (see https://github.com/eclipse-leshan/leshan/issues/1566) but it seems there is some maven dependencies which are not taking into account.  

(See possible limitation : https://github.com/aquasecurity/trivy/discussions/5874)

So maybe we should use more dedicated tool to generated SBOM (e.g. [cyclonedx-maven-plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin)) and then use trivy (or something else) to check vulnerabilities. 