### PR TITLE
Fix serialization issue in demo server

### DIFF
--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/EventServlet.java
@@ -45,6 +45,7 @@ import org.eclipse.leshan.server.californium.endpoint.CaliforniumServerEndpoint;
 import org.eclipse.leshan.server.demo.servlet.json.JacksonLinkSerializer;
 import org.eclipse.leshan.server.demo.servlet.json.JacksonLwM2mNodeSerializer;
 import org.eclipse.leshan.server.demo.servlet.json.JacksonRegistrationSerializer;
+import org.eclipse.leshan.server.demo.servlet.json.JacksonRegistrationUpdateSerializer;
 import org.eclipse.leshan.server.demo.servlet.json.JacksonVersionSerializer;
 import org.eclipse.leshan.server.demo.servlet.log.CoapMessage;
 import org.eclipse.leshan.server.demo.servlet.log.CoapMessageListener;
@@ -302,7 +303,7 @@ public class EventServlet extends EventSourceServlet {
         SimpleModule module = new SimpleModule();
         module.addSerializer(Link.class, new JacksonLinkSerializer());
         module.addSerializer(Registration.class, new JacksonRegistrationSerializer(server.getPresenceService()));
-        // TODO like we have a dedicated serializer for Registration, we maybe need one for RegistrationUpdate
+        module.addSerializer(RegistrationUpdate.class, new JacksonRegistrationUpdateSerializer());
         // needed for : registrationListener.updated(RegistrationUpdate, Registration, Registration)
         module.addSerializer(LwM2mNode.class, new JacksonLwM2mNodeSerializer());
         module.addSerializer(Version.class, new JacksonVersionSerializer());

--- a/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/JacksonRegistrationUpdateSerializer.java
+++ b/leshan-server-demo/src/main/java/org/eclipse/leshan/server/demo/servlet/json/JacksonRegistrationUpdateSerializer.java
@@ -1,0 +1,45 @@
+package org.eclipse.leshan.server.demo.servlet.json;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.eclipse.leshan.core.peer.OscoreIdentity;
+import org.eclipse.leshan.server.registration.RegistrationUpdate;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class JacksonRegistrationUpdateSerializer extends StdSerializer<RegistrationUpdate> {
+
+    private static final long serialVersionUID = -2828961931685566265L;
+
+    protected JacksonRegistrationUpdateSerializer(Class<RegistrationUpdate> t) {
+        super(t);
+    }
+
+    public JacksonRegistrationUpdateSerializer() {
+        this(null);
+    }
+
+    @Override
+    public void serialize(RegistrationUpdate src, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        Map<String, Object> map = new LinkedHashMap<>();
+
+        map.put("registrationId", src.getRegistrationId());
+
+        map.put("address", src.getAddress().getHostAddress() + ":" + src.getPort());
+        map.put("smsNumber", src.getSmsNumber());
+        map.put("lifetime", src.getLifeTimeInSec());
+
+        map.put("alternatePath", src.getAlternatePath());
+        map.put("objectLinks", src.getObjectLinks());
+        // TODO secure means over TLS (not OSCORE) but this is not clear so maybe we need to change this.
+        map.put("secure", src.getClientTransportData().getIdentity().isSecure()
+                && !(src.getClientTransportData().getIdentity() instanceof OscoreIdentity));
+        map.put("additionalAttributes", src.getAdditionalAttributes());
+
+        gen.writeObject(map);
+    }
+}


### PR DESCRIPTION
When using the `leshan-server-demo` with DTLS (and a Raw Public Key), serialization of RegistrationUpdate events throw exceptions.

Here is the full error message:
```
java.lang.RuntimeException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException:
 Invalid type definition for type `sun.security.ec.ECPublicKeyImpl`:
 Failed to construct BeanSerializer for [simple type, class sun.security.ec.ECPublicKeyImpl]:
  (java.lang.IllegalArgumentException) Failed to call `setAccess()` on Method 'getW' (of class `sun.security.ec.ECPublicKeyImpl`) due to `java.lang.reflect.InaccessibleObjectException`,
  problem:
    Unable to make public java.security.spec.ECPoint sun.security.ec.ECPublicKeyImpl.getW() accessible:
    module jdk.crypto.ec does not "exports sun.security.ec" to unnamed module @5a6d67c3 
    (through reference chain: 
       org.eclipse.leshan.server.demo.servlet.EventServlet$RegUpdate["update"]
       ->org.eclipse.leshan.server.registration.RegistrationUpdate["clientTransportData"]
       ->org.eclipse.leshan.core.peer.IpPeer["identity"]
       ->org.eclipse.leshan.core.peer.RpkIdentity["publicKey"])
```

The public key should not be part of this message anyways I assume. The proposed solution implements a custom Serializer similar to the already existing `JacksonRegistrationSerializer`.