### PR TITLE
Upgrade to upload/download v4 (v3 is deprecated)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
 
     - name: Upload Build Status File for "Comment Pull Request" Workflow
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
        name: ${{env.build_status_filename}}
        path: ${{env.build_status_filename}}


### PR DESCRIPTION
GitHub has issued a deprecation notice for some commonly used actions.

* actions/upload-artifact
* actions/download-artifact

The following versions are deprecated and will stop working in the not so near future:

* v1 and v2: from 30/06/2024
* v3: from 30/11/2024

It is highly encouraged to update to v4 of these actions asap to avoid any disruption.

See more details at:
 - https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
 - https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/