### PR TITLE
Fix TlvEncoder Date encoding for dates in a distant future (exceeding MAX_INT)

### DIFF
--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/TlvEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/TlvEncoder.java
@@ -115,7 +115,13 @@ public class TlvEncoder {
     public static byte[] encodeDate(Date value) {
         ByteBuffer tBuf;
         long lValue = value.getTime() / 1000L;
-        if (lValue <= Integer.MAX_VALUE) {
+        if (lValue <= Byte.MAX_VALUE && lValue >= Byte.MIN_VALUE) {
+            tBuf = ByteBuffer.allocate(1);
+            tBuf.put((byte) lValue);
+        } else if (lValue <= Short.MAX_VALUE && lValue >= Short.MIN_VALUE) {
+            tBuf = ByteBuffer.allocate(2);
+            tBuf.putShort((short) lValue);
+        } else if (lValue <= Integer.MAX_VALUE && lValue >= Integer.MIN_VALUE) {
             tBuf = ByteBuffer.allocate(4);
             tBuf.putInt((int) lValue);
         } else {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/TlvEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/TlvEncoder.java
@@ -113,8 +113,15 @@ public class TlvEncoder {
      * Encodes a date value.
      */
     public static byte[] encodeDate(Date value) {
-        ByteBuffer tBuf = ByteBuffer.allocate(4);
-        tBuf.putInt((int) (value.getTime() / 1000L));
+        ByteBuffer tBuf;
+        long lValue = value.getTime() / 1000L;
+        if (lValue <= Integer.MAX_VALUE) {
+            tBuf = ByteBuffer.allocate(4);
+            tBuf.putInt((int) lValue);
+        } else {
+            tBuf = ByteBuffer.allocate(8);
+            tBuf.putLong(lValue);
+        }
         return tBuf.array();
     }
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvEncoderTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvEncoderTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.ByteBuffer;
+import java.util.Calendar;
 import java.util.Date;
 
 import org.eclipse.leshan.core.tlv.Tlv.TlvType;
@@ -58,14 +59,37 @@ public class TlvEncoderTest {
     }
 
     @Test
-    public void encode_date() {
-        long timestamp = System.currentTimeMillis();
+    public void encode_date_4_bytes() throws TlvException {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2024, 1, 1, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 534);
+        long timestamp = cal.getTimeInMillis();
         byte[] encoded = TlvEncoder.encodeDate(new Date(timestamp));
 
         // check value
         ByteBuffer bb = ByteBuffer.wrap(encoded);
         assertEquals((int) (timestamp / 1000), bb.getInt());
         assertEquals(0, bb.remaining());
+        cal.set(Calendar.MILLISECOND, 0);
+        Date date = TlvDecoder.decodeDate(encoded);
+        assertEquals(cal.getTimeInMillis(), date.getTime());
+    }
+
+    @Test
+    public void encode_date_8_bytes() throws TlvException {
+        Calendar cal = Calendar.getInstance();
+        cal.set(2700, 1, 1, 0, 0, 0);
+        cal.set(Calendar.MILLISECOND, 523);
+        long timestamp = cal.getTimeInMillis();
+        byte[] encoded = TlvEncoder.encodeDate(new Date(timestamp));
+
+        // check value
+        ByteBuffer bb = ByteBuffer.wrap(encoded);
+        assertEquals(timestamp / 1000, bb.getLong());
+        assertEquals(0, bb.remaining());
+        cal.set(Calendar.MILLISECOND, 0);
+        Date date = TlvDecoder.decodeDate(encoded);
+        assertEquals(cal.getTimeInMillis(), date.getTime());
     }
 
     @Test


### PR DESCRIPTION
If encoded date is in distant future (number of seconds since 1970 exceeds MAX_INT), TlvEncoder breaks because it always tries to encode dates as 4-byte integers. This fix checks whether number of seconds exceeds MAX_INT, and if it does the value is encoded in 8-bytes. Otherwise, previous behavior will be used (4-bytes). 


