### PR TITLE
Use Alternate path in SenML payload.

### DIFF
--- a/leshan-demo-client/src/main/java/org/eclipse/leshan/demo/client/LeshanClientDemo.java
+++ b/leshan-demo-client/src/main/java/org/eclipse/leshan/demo/client/LeshanClientDemo.java
@@ -346,7 +346,7 @@ public class LeshanClientDemo {
                 BootstrapWriteResponse response = null;
                 try {
                     // get resource from string resource value
-                    LwM2mSingleResource resource = textDecoder.decode(resourceValue.getBytes(), resourcePath,
+                    LwM2mSingleResource resource = textDecoder.decode(resourceValue.getBytes(), null, resourcePath,
                             repository.getLwM2mModel(), LwM2mSingleResource.class);
                     // try to write this resource
                     response = client.getObjectTree().getObjectEnabler(resourcePath.getObjectId()).write(

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/lockstep/LockStepTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/lockstep/LockStepTest.java
@@ -463,7 +463,7 @@ public class LockStepTest {
         Instant t1 = Instant.now();
         LwM2mSingleResource resource = LwM2mSingleResource.newIntegerResource(1, 3600);
         TimestampedLwM2mNode timestampedNode = new TimestampedLwM2mNode(t1, resource);
-        byte[] payload = encoder.encodeTimestampedData(Arrays.asList(timestampedNode), ContentFormat.SENML_JSON,
+        byte[] payload = encoder.encodeTimestampedData(Arrays.asList(timestampedNode), ContentFormat.SENML_JSON, null,
                 new LwM2mPath("/1/0/1"), client.getLwM2mModel());
 
         // send read request
@@ -499,7 +499,7 @@ public class LockStepTest {
         Instant t1 = Instant.now();
         LwM2mSingleResource resource = LwM2mSingleResource.newIntegerResource(1, 3600);
         TimestampedLwM2mNode timestampedNode = new TimestampedLwM2mNode(t1, resource);
-        byte[] payload = encoder.encodeTimestampedData(Arrays.asList(timestampedNode), ContentFormat.SENML_JSON,
+        byte[] payload = encoder.encodeTimestampedData(Arrays.asList(timestampedNode), ContentFormat.SENML_JSON, null,
                 new LwM2mPath("/1/0/1"), client.getLwM2mModel());
 
         // send observe request
@@ -558,7 +558,7 @@ public class LockStepTest {
 
         LwM2mEncoder encoder = new DefaultLwM2mEncoder();
 
-        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, ContentFormat.SENML_JSON,
+        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, ContentFormat.SENML_JSON, null,
                 client.getLwM2mModel());
 
         // send read request
@@ -604,7 +604,7 @@ public class LockStepTest {
 
         LwM2mEncoder encoder = new DefaultLwM2mEncoder();
 
-        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, ContentFormat.SENML_JSON,
+        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, ContentFormat.SENML_JSON, null,
                 client.getLwM2mModel());
 
         // send read request

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveCompositeTimeStampTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveCompositeTimeStampTest.java
@@ -261,7 +261,7 @@ public class ObserveCompositeTimeStampTest {
         server.waitForNewObservation(observation);
 
         // *** HACK send time-stamped notification as Leshan client does not support it *** //
-        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, contentFormat,
+        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, contentFormat, null,
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(
@@ -363,7 +363,7 @@ public class ObserveCompositeTimeStampTest {
         server.waitForNewObservation(observation);
 
         // *** HACK send time-stamped notification as Leshan client does not support it *** //
-        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, contentFormat,
+        byte[] payload = encoder.encodeTimestampedNodes(timestampednodes, contentFormat, null,
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveServerOnlyTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveServerOnlyTest.java
@@ -125,7 +125,7 @@ public class ObserveServerOnlyTest {
         assertThat(observations).containsExactly(observation);
 
         // *** HACK send a notification with unsupported content format *** //
-        byte[] payload = new LwM2mNodeJsonEncoder().encode(LwM2mSingleResource.newStringResource(15, "Paris"),
+        byte[] payload = new LwM2mNodeJsonEncoder().encode(LwM2mSingleResource.newStringResource(15, "Paris"), null,
                 new LwM2mPath("/3/0/15"), client.getObjectTree().getModel(), new LwM2mValueChecker());
 
         // 666 is not a supported content format.

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveTimeStampTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/observe/ObserveTimeStampTest.java
@@ -139,7 +139,7 @@ public class ObserveTimeStampTest {
         timestampedNodes.add(mostRecentNode);
         timestampedNodes.add(new TimestampedLwM2mNode(mostRecentNode.getTimestamp().minusMillis(2),
                 LwM2mSingleResource.newStringResource(15, "Londres")));
-        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, new LwM2mPath("/3/0/15"),
+        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, null, new LwM2mPath("/3/0/15"),
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(
@@ -183,7 +183,7 @@ public class ObserveTimeStampTest {
                 new LwM2mObjectInstance(0, LwM2mSingleResource.newStringResource(15, "Londres"))));
         timestampedNodes.add(new TimestampedLwM2mNode(Instant.ofEpochMilli(System.currentTimeMillis()).minusMillis(4),
                 new LwM2mObjectInstance(0, LwM2mSingleResource.newStringResource(15, "Londres"))));
-        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, new LwM2mPath("/3/0"),
+        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, null, new LwM2mPath("/3/0"),
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(
@@ -230,7 +230,7 @@ public class ObserveTimeStampTest {
                 new LwM2mObjectInstance(0, LwM2mSingleResource.newStringResource(15, "Londres"))));
         timestampedNodes.add(new TimestampedLwM2mNode(anInstant.minusMillis(4),
                 new LwM2mObjectInstance(0, LwM2mSingleResource.newStringResource(15, "Londres"))));
-        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, new LwM2mPath("/3/0"),
+        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, null, new LwM2mPath("/3/0"),
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(
@@ -272,7 +272,7 @@ public class ObserveTimeStampTest {
         timestampedNodes.add(mostRecentNode);
         timestampedNodes.add(new TimestampedLwM2mNode(mostRecentNode.getTimestamp().minusMillis(2),
                 new LwM2mObject(3, new LwM2mObjectInstance(0, LwM2mSingleResource.newStringResource(15, "Londres")))));
-        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, new LwM2mPath("/3"),
+        byte[] payload = encoder.encodeTimestampedData(timestampedNodes, contentFormat, null, new LwM2mPath("/3"),
                 client.getObjectTree().getModel());
 
         TestObserveUtil.sendNotification(

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
@@ -363,6 +363,14 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
+        appendTo(b);
+        return b.toString();
+    }
+
+    /**
+     * Append LwM2m Path to given {@link StringBuilder}
+     */
+    public void appendTo(StringBuilder b) {
         b.append("/");
         if (getObjectId() != null) {
             b.append(getObjectId());
@@ -376,7 +384,6 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
                 }
             }
         }
-        return b.toString();
     }
 
     @Override
@@ -417,9 +424,7 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
      * @param lwm2mRootpath the expected rootpath. <code>null</code> is considered as "/"
      * @return A valid {@link LwM2mPath} or null it does not start by lwm2mRootPath
      *
-     * @exception NumberFormatException if path contains not Numeric value
      * @exception InvalidLwM2mPathException if path is invalid (e.g. too big number in path)
-     * @exception IllegalArgumentException if path length is invalid
      */
     public static LwM2mPath parse(String fullpath, String lwm2mRootpath)
             throws NumberFormatException, InvalidLwM2mPathException, IllegalArgumentException {
@@ -441,7 +446,6 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
      * @return list of paths as {@link LwM2mPath}.
      *
      * @exception LwM2mNodeException if path is invalid (e.g. too big number in path)
-     * @exception IllegalArgumentException if path length is invalid or if path contains not Numeric value
      */
     public static List<LwM2mPath> getLwM2mPathList(List<String> paths) {
         List<LwM2mPath> res = new ArrayList<>(paths.size());

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPathParser.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPathParser.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.node;
+
+import org.eclipse.leshan.core.parser.StringParser;
+import org.eclipse.leshan.core.util.Validate;
+
+public class LwM2mPathParser {
+
+    public enum Start {
+        WITH_SLASH, WITHOUT_SLASH, WITH_OR_WITHOUT_SLASH
+    }
+
+    private final Start startMode;
+
+    public LwM2mPathParser() {
+        this(Start.WITH_SLASH);
+    }
+
+    public LwM2mPathParser(Start startMode) {
+        this.startMode = startMode;
+    }
+
+    public LwM2mPath parse(String path) {
+        Validate.notNull(path);
+
+        // create a String Parser
+        StringParser<InvalidLwM2mPathException> parser = new StringParser<InvalidLwM2mPathException>(path) {
+            @Override
+            public void raiseException(String message, Exception cause) throws InvalidLwM2mPathException {
+                throw new InvalidLwM2mPathException(message, cause);
+            }
+        };
+
+        // Parse path segment
+        LwM2mPath lwm2mPath = consumeLwM2mPath(parser);
+        if (parser.hasMoreChar()) {
+            parser.raiseException("Unable to parse [%s] : Unexpected charaters '%s' after '%s'",
+                    parser.getStringToParse(), parser.getNextChar(), parser.getAlreadyParsedString());
+        }
+        return lwm2mPath;
+    }
+
+    public <T extends Throwable> LwM2mPath consumeLwM2mPath(StringParser<T> parser) throws T {
+
+        // consume starting /
+        consumeStartingSlash(parser);
+        if (!parser.nextCharIsDIGIT()) {
+            return LwM2mPath.ROOTPATH;
+        }
+
+        // consume object id
+        int objectId = consumeNodeId(parser);
+        if (!hasMoreNodeId(parser)) {
+            return new LwM2mPath(objectId);
+        }
+
+        // consume object instance id
+        parser.consumeChar('/');
+        int objectInstanceId = consumeNodeId(parser);
+        if (!hasMoreNodeId(parser)) {
+            return new LwM2mPath(objectId, objectInstanceId);
+        }
+
+        // consume resource id
+        parser.consumeChar('/');
+        int resourceId = consumeNodeId(parser);
+        if (!hasMoreNodeId(parser)) {
+            return new LwM2mPath(objectId, objectInstanceId, resourceId);
+        }
+        // consume resource instance id
+        parser.consumeChar('/');
+        int resourceInstanceId = consumeNodeId(parser);
+        return new LwM2mPath(objectId, objectInstanceId, resourceId, resourceInstanceId);
+    }
+
+    protected <T extends Throwable> void consumeStartingSlash(StringParser<T> parser) throws T {
+        switch (startMode) {
+        case WITHOUT_SLASH:
+            // Do Nothing...
+            break;
+        case WITH_OR_WITHOUT_SLASH:
+            if (parser.nextCharIs('/')) {
+                parser.consumeChar('/');
+            }
+            break;
+        case WITH_SLASH:
+        default:
+            parser.consumeChar('/');
+            break;
+        }
+    }
+
+    protected <T extends Throwable> boolean hasMoreNodeId(StringParser<T> parser) throws T {
+        if (parser.nextCharIs('/')) {
+            parser.consumeChar('/');
+            boolean result = parser.nextCharIsDIGIT();
+            parser.backtrackLastChar(); // cancel '/' consumption
+            return result;
+        } else {
+            return false;
+        }
+    }
+
+    protected <T extends Throwable> int consumeNodeId(StringParser<T> parser) throws T {
+        return Integer.valueOf(parser.consumeCardinal());
+    }
+}

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/PrefixedLwM2mPath.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/PrefixedLwM2mPath.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.node;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.leshan.core.util.Validate;
+
+/**
+ * A {@link LwM2mPath} prefixed by some URI segment.
+ */
+public class PrefixedLwM2mPath implements Comparable<PrefixedLwM2mPath> {
+
+    private final List<String> prefix;
+    private final LwM2mPath path;
+
+    public PrefixedLwM2mPath(List<String> prefix, LwM2mPath path) {
+        Validate.notNull(path);
+        Validate.notNull(prefix);
+        this.prefix = prefix.isEmpty() ? Collections.emptyList() : prefix;
+        this.path = path;
+    }
+
+    public boolean hasPrefix() {
+        return !prefix.isEmpty();
+    }
+
+    public List<String> getPrefix() {
+        return prefix;
+    }
+
+    /**
+     * @return prefix as string if there is no prefix then it returns an empty string
+     */
+    public String getPrefixAsString() {
+        StringBuilder b = new StringBuilder();
+        appendPrefixTo(b);
+        return b.toString();
+    }
+
+    /**
+     * @param rootPath it should start "/" but not end with "/". (can eventually be <code>null</code> if there is no
+     *        rootpath)
+     * @return <code>true</code> if this path start with given rootPath.
+     */
+    public boolean useRootPath(String rootPath) {
+        if (rootPath == null) {
+            return !hasPrefix();
+        }
+        if (rootPath.length() == 0 || rootPath.charAt(0) != '/') {
+            throw new IllegalArgumentException("rootPath should start by '/'");
+        }
+        if (rootPath.length() == 1) {
+            return !hasPrefix();
+        }
+        return rootPath.equals(getPrefixAsString());
+    }
+
+    public LwM2mPath getPath() {
+        return path;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(path, prefix);
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof PrefixedLwM2mPath))
+            return false;
+        PrefixedLwM2mPath other = (PrefixedLwM2mPath) obj;
+        return Objects.equals(path, other.path) && Objects.equals(prefix, other.prefix);
+    }
+
+    /**
+     * Append prefix to given {@link StringBuilder}
+     */
+    public void appendPrefixTo(StringBuilder b) {
+        if (hasPrefix()) {
+            for (String prefixSegment : getPrefix()) {
+                b.append('/');
+                b.append(prefixSegment);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        appendPrefixTo(b);
+        getPath().appendTo(b);
+        return b.toString();
+    }
+
+    @Override
+    public int compareTo(PrefixedLwM2mPath other) {
+        if (!hasPrefix()) {
+            if (other.hasPrefix()) {
+                return -1; // arbitrary we decide that prefixed path should be after unprefixed path
+            } else {
+                // both without prefix
+                return getPath().compareTo(other.getPath());
+            }
+        } else {
+            if (!other.hasPrefix()) {
+                return 1; // arbitrary we decide that prefixed path should be after unprefixed path
+            } else {
+                // both with prefix
+                int minLength = Math.min(this.getPrefix().size(), other.getPrefix().size());
+                for (int i = 0; i < minLength; i++) {
+                    int cmp = getPrefix().get(i).compareTo(other.getPrefix().get(i));
+                    if (cmp != 0) {
+                        return cmp;
+                    }
+                }
+                // If all elements are equal so far, compare by length
+                int lengthComparison = Integer.compare(this.getPrefix().size(), other.getPrefix().size());
+                if (lengthComparison == 0) {
+                    // if length are equal, compare path
+                    return getPath().compareTo(other.getPath());
+                } else {
+                    // else shorter is before
+                    return lengthComparison;
+                }
+            }
+        }
+    }
+}

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/PrefixedLwM2mPathParser.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/PrefixedLwM2mPathParser.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.core.node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.leshan.core.node.LwM2mPathParser.Start;
+import org.eclipse.leshan.core.parser.StringParser;
+import org.eclipse.leshan.core.util.Validate;
+
+public class PrefixedLwM2mPathParser {
+
+    private final Start startMode;
+    private final LwM2mPathParser pathParser = new LwM2mPathParser(Start.WITHOUT_SLASH);
+
+    public PrefixedLwM2mPathParser() {
+        this(Start.WITH_SLASH);
+    }
+
+    public PrefixedLwM2mPathParser(Start startMode) {
+        this.startMode = startMode;
+    }
+
+    public PrefixedLwM2mPath parsePrefixedPath(String path) {
+        Validate.notNull(path);
+
+        // create a String Parser
+        StringParser<InvalidLwM2mPathException> parser = new StringParser<InvalidLwM2mPathException>(path) {
+            @Override
+            public void raiseException(String message, Exception cause) throws InvalidLwM2mPathException {
+                throw new InvalidLwM2mPathException(message, cause);
+            }
+        };
+
+        // Parse path segment
+        PrefixedLwM2mPath lwm2mPath = consumePrefixedLwM2mPath(parser);
+        if (parser.hasMoreChar()) {
+            parser.raiseException("Unable to parse LWM2M path [%s] : Unexpected charaters '%s' after '%s'",
+                    parser.getStringToParse(), parser.getNextChar(), parser.getAlreadyParsedString());
+        }
+        return lwm2mPath;
+    }
+
+    public List<String> parsePrefix(String pathPrefix) {
+        Validate.notNull(pathPrefix);
+
+        // create a String Parser
+        StringParser<InvalidLwM2mPathException> parser = new StringParser<InvalidLwM2mPathException>(pathPrefix) {
+            @Override
+            public void raiseException(String message, Exception cause) throws InvalidLwM2mPathException {
+                throw new InvalidLwM2mPathException(message, cause);
+            }
+        };
+
+        // Parse path segment
+        List<String> prefix = consumePrefix(parser);
+        if (parser.hasMoreChar()) {
+            parser.raiseException("Unable to parse LWM2M path prefix [%s] : Unexpected charaters '%s' after '%s'",
+                    parser.getStringToParse(), parser.getNextChar(), parser.getAlreadyParsedString());
+        }
+        return prefix;
+    }
+
+    public <T extends Throwable> PrefixedLwM2mPath consumePrefixedLwM2mPath(StringParser<T> parser) throws T {
+
+        // Consume prefix segments
+        List<String> prefix = consumePrefix(parser);
+
+        // Consume path
+        LwM2mPath path = null;
+        // If there is no prefix then consume starting slash
+        if (prefix.isEmpty()) {
+            consumeStartingSlash(parser);
+            path = consumeLwM2mPath(parser);
+        } else {
+            // if there is a prefix consume slash separator
+            if (parser.nextCharIs('/')) {
+                parser.consumeChar('/');
+                path = consumeLwM2mPath(parser);
+            } else {
+                path = LwM2mPath.ROOTPATH;
+            }
+        }
+
+        return new PrefixedLwM2mPath(prefix, path);
+    }
+
+    public <T extends Throwable> List<String> consumePrefix(StringParser<T> parser) throws T {
+
+        // consume starting '/'
+        boolean slashConsumed = consumeStartingSlash(parser);
+
+        // Consume URI segments
+        List<String> prefix = new ArrayList<>();
+        while (true) {
+            String segment = tryConsumePrefixSegment(parser);
+            // if no more segment we stop
+            if (segment == null) {
+                // we don't want to consume last slash
+                if (slashConsumed) {
+                    parser.backtrackLastChar();
+                }
+                break;
+            }
+            // else we add segment
+            prefix.add(segment);
+
+            if (parser.hasMoreChar() && parser.nextCharIs('/')) {
+                parser.consumeChar('/');
+                slashConsumed = true;
+            } else {
+                // if no more char we stop
+                break;
+            }
+        }
+
+        return prefix;
+    }
+
+    private <T extends Throwable> LwM2mPath consumeLwM2mPath(StringParser<T> parser) throws T {
+        return pathParser.consumeLwM2mPath(parser);
+    }
+
+    /**
+     * Try to consume a segment of a prefix.
+     *
+     * @return the segment parsed OR <code>null</code> if there is no more segment to consume.
+     */
+    protected <T extends Throwable> String tryConsumePrefixSegment(StringParser<T> parser) throws T {
+        int begin = parser.getPosition();
+
+        // the spec says : link (talking about alternate path) MUST NOT contain numerical URI segment.
+        // https://www.openmobilealliance.org/release/LightweightM2M/V1_2_1-20221209-A/HTML-Version/OMA-TS-LightweightM2M_Transport-V1_2_1-20221209-A.html#6-4-1-0-641-Alternate-Path
+        // We suppose this is true for all prefixed segment.
+
+        boolean isNumericalSegment = true;
+        while (parser.hasMoreChar() && !parser.nextCharIs('/')) {
+            if (!parser.nextCharIsDIGIT()) {
+                isNumericalSegment = false;
+            }
+            parser.consumeNextChar();
+        }
+
+        // if it is a numerical segment we failed to consume a prefixed segment, then rollback
+        if (isNumericalSegment) {
+            parser.backtrackTo(begin);
+            return null;
+        }
+        // else
+        int end = parser.getPosition();
+        if (end == begin) {
+            parser.raiseException(
+                    "Unable to parse [%s] : URI Segment (at char index %d) prefixing LWM2M Path can not be empty",
+                    parser.getStringToParse(), begin);
+        }
+        return parser.substring(begin, end);
+    }
+
+    /**
+     * consume starting slash if needed.
+     *
+     * @return true if slash is consumed.
+     */
+    protected <T extends Throwable> boolean consumeStartingSlash(StringParser<T> parser) throws T {
+        switch (startMode) {
+        case WITHOUT_SLASH:
+            // Do Nothing...
+            return false;
+        case WITH_OR_WITHOUT_SLASH:
+            if (parser.nextCharIs('/')) {
+                parser.consumeChar('/');
+                return true;
+            } else {
+                return false;
+            }
+        case WITH_SLASH:
+        default:
+            parser.consumeChar('/');
+            return true;
+        }
+    }
+}

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/LwM2mDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/LwM2mDecoder.java
@@ -46,26 +46,29 @@ public interface LwM2mDecoder {
      *
      * @param content the content
      * @param format the content format
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param path the path of the node to build
      * @param model the collection of supported object models
      * @return the resulting node
      * @throws CodecException if content is malformed.
      */
-    LwM2mNode decode(byte[] content, ContentFormat format, LwM2mPath path, LwM2mModel model) throws CodecException;
+    LwM2mNode decode(byte[] content, ContentFormat format, String rootPath, LwM2mPath path, LwM2mModel model)
+            throws CodecException;
 
     /**
      * Deserializes a binary content into a {@link LwM2mNode} of the expected type.
      *
      * @param content the content
      * @param format the content format
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param path the path of the node to build
      * @param model the collection of supported object models
      * @param nodeClass the class of the {@link LwM2mNode} to decode
      * @return the resulting node
      * @throws CodecException if content is malformed.
      */
-    <T extends LwM2mNode> T decode(byte[] content, ContentFormat format, LwM2mPath path, LwM2mModel model,
-            Class<T> nodeClass) throws CodecException;
+    <T extends LwM2mNode> T decode(byte[] content, ContentFormat format, String rootPath, LwM2mPath path,
+            LwM2mModel model, Class<T> nodeClass) throws CodecException;
 
     /**
      * Deserializes a binary content into a list of {@link LwM2mNode} of the expected type.
@@ -74,6 +77,7 @@ public interface LwM2mDecoder {
      *
      * @param content the content
      * @param format the content format
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param paths the list of path of node to build. The list of path can be <code>null</code> meaning that we don't
      *        know which kind of {@link LwM2mNode} is encoded. In this case, let's assume this is a list of
      *        {@link LwM2mSingleResource} or {@link LwM2mResourceInstance}.
@@ -82,21 +86,22 @@ public interface LwM2mDecoder {
      *         available for a given path
      * @throws CodecException if content is malformed.
      */
-    Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, ContentFormat format, List<LwM2mPath> paths, LwM2mModel model)
-            throws CodecException;
+    Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, ContentFormat format, String rootPath, List<LwM2mPath> paths,
+            LwM2mModel model) throws CodecException;
 
     /**
      * Deserializes a binary content into a list of time-stamped {@link LwM2mNode} ordering by time-stamp.
      *
      * @param content the content
      * @param format the content format
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param path the path of the node to build
      * @param model the collection of supported object models
      * @return the resulting list of time-stamped {@link LwM2mNode} ordering by time-stamp
      * @exception CodecException if content is malformed.
      */
-    List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, ContentFormat format, LwM2mPath path,
-            LwM2mModel model) throws CodecException;
+    List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, ContentFormat format, String rootPath,
+            LwM2mPath path, LwM2mModel model) throws CodecException;
 
     /**
      * Deserializes a binary content into a {@link TimestampedLwM2mNodes}.
@@ -105,25 +110,27 @@ public interface LwM2mDecoder {
      * @param content the content
      * @param format the content format
      * @param model the collection of supported object models
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param paths the list of path of node to build. The list of path can be <code>null</code> meaning that we don't
      *        know which kind of {@link LwM2mNode} is encoded. In this case, let's assume this is a list of
      *        {@link LwM2mSingleResource} or {@link LwM2mResourceInstance}.
      * @return the decoded timestamped nodes represented by {@link TimestampedLwM2mNodes}
      * @throws CodecException if content is malformed.
      */
-    TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, ContentFormat format, List<LwM2mPath> paths,
-            LwM2mModel model) throws CodecException;
+    TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, ContentFormat format, String rootPath,
+            List<LwM2mPath> paths, LwM2mModel model) throws CodecException;
 
     /**
      * Deserializes a binary content into a list of {@link LwM2mPath}.
      *
      * @param content the content to decode
      * @param format the format used to encode the content
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @return a list of {@link LwM2mPath}
      *
      * @throws CodecException if content is malformed.
      */
-    List<LwM2mPath> decodePaths(byte[] content, ContentFormat format) throws CodecException;
+    List<LwM2mPath> decodePaths(byte[] content, ContentFormat format, String rootPath) throws CodecException;
 
     /**
      * return true is the given {@link ContentFormat} is supported

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/LwM2mEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/LwM2mEncoder.java
@@ -42,12 +42,14 @@ public interface LwM2mEncoder {
      *
      * @param node the object/instance/resource to serialize
      * @param format the content format
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param path the path of the node to serialize
      * @param model the collection of supported object models
      * @return the encoded node as a byte array
      * @throws CodecException if encoding failed.
      */
-    byte[] encode(LwM2mNode node, ContentFormat format, LwM2mPath path, LwM2mModel model) throws CodecException;
+    byte[] encode(LwM2mNode node, ContentFormat format, String rootPath, LwM2mPath path, LwM2mModel model)
+            throws CodecException;
 
     /**
      * Serializes a list of {@link LwM2mNode} using the given content format.
@@ -55,24 +57,27 @@ public interface LwM2mEncoder {
      * @param nodes the Map from {@link LwM2mPath} to {@link LwM2mNode} to serialize. value can be <code>null</code> if
      *        no data was available for a given path
      * @param format the content format
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param model the collection of supported object models
      * @return the encoded nodes as a byte array
      * @throws CodecException if encoding failed.
      */
-    byte[] encodeNodes(Map<LwM2mPath, LwM2mNode> nodes, ContentFormat format, LwM2mModel model) throws CodecException;
+    byte[] encodeNodes(Map<LwM2mPath, LwM2mNode> nodes, ContentFormat format, String rootPath, LwM2mModel model)
+            throws CodecException;
 
     /**
      * Serializes a list of time-stamped {@link LwM2mNode} with the given content format.
      *
      * @param timestampedNodes the list of time-stamped object/instance/resource to serialize
      * @param format the content format
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param path the path of the node to serialize
      * @param model the collection of supported object models
      * @return the encoded node as a byte array
      * @throws CodecException if encoding failed.
      */
-    byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, ContentFormat format, LwM2mPath path,
-            LwM2mModel model) throws CodecException;
+    byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, ContentFormat format, String rootPath,
+            LwM2mPath path, LwM2mModel model) throws CodecException;
 
     /**
      * Serializes a multiple time-stamped nodes contained in {@link TimestampedLwM2mNodes} with the given content
@@ -80,11 +85,12 @@ public interface LwM2mEncoder {
      *
      * @param data the {@link TimestampedLwM2mNodes} to serialize
      * @param format the content format
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param model the collection of supported object models
      * @return the encoded node as a byte array
      * @throws CodecException if encoding failed.
      */
-    byte[] encodeTimestampedNodes(TimestampedLwM2mNodes data, ContentFormat format, LwM2mModel model)
+    byte[] encodeTimestampedNodes(TimestampedLwM2mNodes data, ContentFormat format, String rootPath, LwM2mModel model)
             throws CodecException;
 
     /**
@@ -92,11 +98,12 @@ public interface LwM2mEncoder {
      *
      * @param paths The list of {@link LwM2mPath} to encode
      * @param format the {@link ContentFormat} used to encode
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @return the encoded path as byte array
      *
      * @throws CodecException if encoding failed.
      */
-    byte[] encodePaths(List<LwM2mPath> paths, ContentFormat format) throws CodecException;
+    byte[] encodePaths(List<LwM2mPath> paths, ContentFormat format, String rootPath) throws CodecException;
 
     /**
      * return true is the given {@link ContentFormat} is supported

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/MultiNodeDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/MultiNodeDecoder.java
@@ -38,6 +38,7 @@ public interface MultiNodeDecoder {
      * Expected type is guess from list of {@link LwM2mPath}.
      *
      * @param content the content
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param paths the list of path of node to build. The list of path can be <code>null</code> meaning that we don't
      *        know which kind of {@link LwM2mNode} is encoded. In this case, let's assume this is a list of
      *        {@link LwM2mSingleResource} or {@link LwM2mResourceInstance}.
@@ -46,6 +47,6 @@ public interface MultiNodeDecoder {
      *         available for a given path
      * @throws CodecException if there payload is malformed.
      */
-    Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, List<LwM2mPath> paths, LwM2mModel model)
+    Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, String rootPath, List<LwM2mPath> paths, LwM2mModel model)
             throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/MultiNodeEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/MultiNodeEncoder.java
@@ -32,12 +32,14 @@ public interface MultiNodeEncoder {
     /**
      * Serializes a list of {@link LwM2mNode} using the given content format.
      *
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param nodes the Map from {@link LwM2mPath} to {@link LwM2mNode} to serialize. value can be <code>null</code> if
      *        no data was available for a given path
      * @param model the collection of supported object models
+     *
      * @return the encoded nodes as a byte array
      * @throws CodecException if there payload is malformed.
      */
-    byte[] encodeNodes(Map<LwM2mPath, LwM2mNode> nodes, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException;
+    byte[] encodeNodes(String rootPath, Map<LwM2mPath, LwM2mNode> nodes, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/NodeDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/NodeDecoder.java
@@ -31,6 +31,7 @@ public interface NodeDecoder {
      * Deserializes a binary content into a {@link LwM2mNode} of the expected type.
      *
      * @param content the content
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param path the path of the node to build
      * @param model the collection of supported object models
      * @param nodeClass the class of the {@link LwM2mNode} to decode
@@ -38,6 +39,6 @@ public interface NodeDecoder {
      *
      * @throws CodecException if there payload is malformed.
      */
-    <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException;
+    <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/NodeEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/NodeEncoder.java
@@ -31,6 +31,7 @@ public interface NodeEncoder {
      * Serializes a {@link LwM2mNode}.
      *
      * @param node the object/instance/resource to serialize
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param path the path of the node to serialize
      * @param model the collection of supported object models
      * @param converter a data type converter.
@@ -38,6 +39,6 @@ public interface NodeEncoder {
      *
      * @throws CodecException if there payload is malformed.
      */
-    byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
+    byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
             throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/PathDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/PathDecoder.java
@@ -28,7 +28,8 @@ public interface PathDecoder {
 
     /**
      * @param content The content to decode
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @return The list of {@link LwM2mPath}
      */
-    List<LwM2mPath> decode(byte[] content);
+    List<LwM2mPath> decode(byte[] content, String rootPath);
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/PathEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/PathEncoder.java
@@ -27,8 +27,9 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 public interface PathEncoder {
 
     /**
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param paths The list of {@link LwM2mPath} to encode
      * @return the encoded path as a byte array.
      */
-    byte[] encode(List<LwM2mPath> paths);
+    byte[] encode(String rootPath, List<LwM2mPath> paths);
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedMultiNodeDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedMultiNodeDecoder.java
@@ -35,6 +35,7 @@ public interface TimestampedMultiNodeDecoder {
      * <p>
      *
      * @param content the content
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param paths the list of path of node to build. The list of path can be <code>null</code> meaning that we don't
      *        know which kind of {@link LwM2mNode} is encoded. In this case, let's assume this is a list of
      *        {@link LwM2mSingleResource} or {@link LwM2mResourceInstance}.
@@ -42,7 +43,7 @@ public interface TimestampedMultiNodeDecoder {
      * @return the decoded timestamped nodes represented by {@link TimestampedLwM2mNodes}
      * @throws CodecException if content is malformed.
      */
-    TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, List<LwM2mPath> paths, LwM2mModel model)
-            throws CodecException;
+    TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, String rootPath, List<LwM2mPath> paths,
+            LwM2mModel model) throws CodecException;
 
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedMultiNodeEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedMultiNodeEncoder.java
@@ -28,12 +28,13 @@ public interface TimestampedMultiNodeEncoder {
      * Serializes a {@link TimestampedLwM2mNodes} object into a byte array.
      * <p>
      *
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param timestampedNodes timestamped nodes to be serialized
      * @param model the collection of supported object models
      * @param converter value converter for resources
      * @return the serialized byte array
      * @throws CodecException if encoding fails
      */
-    byte[] encodeTimestampedNodes(TimestampedLwM2mNodes timestampedNodes, LwM2mModel model,
+    byte[] encodeTimestampedNodes(String rootPath, TimestampedLwM2mNodes timestampedNodes, LwM2mModel model,
             LwM2mValueConverter converter) throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedNodeDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedNodeDecoder.java
@@ -32,12 +32,13 @@ public interface TimestampedNodeDecoder extends NodeDecoder {
      * Deserializes a binary content into a list of time-stamped {@link LwM2mNode} ordering by time-stamp.
      *
      * @param content the content
+     * @param rootPath the expected rootPath also known as alternatePath of LWM2M client.
      * @param path the path of the node to build
      * @param model the collection of supported object models
      * @param nodeClass the class of the {@link LwM2mNode} to decode
      * @return the resulting list of time-stamped {@link LwM2mNode} ordering by time-stamp
      * @exception CodecException if there payload is malformed.
      */
-    List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, LwM2mPath path, LwM2mModel model,
+    List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
             Class<? extends LwM2mNode> nodeClass) throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedNodeEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/TimestampedNodeEncoder.java
@@ -33,12 +33,13 @@ public interface TimestampedNodeEncoder extends NodeEncoder {
      * Serializes a list of time-stamped {@link LwM2mNode}.
      *
      * @param timestampedNodes the list of time-stamped object/instance/resource to serialize
+     * @param rootPath to use by LWM2M client (also known as alternate path)
      * @param path the path of the node to serialize
      * @param model the collection of supported object models
      * @param converter a data type converter.
      * @return the encoded node as a byte array
      * @throws CodecException if there payload is malformed.
      */
-    byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, LwM2mPath path, LwM2mModel model,
-            LwM2mValueConverter converter) throws CodecException;
+    byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, String rootPath, LwM2mPath path,
+            LwM2mModel model, LwM2mValueConverter converter) throws CodecException;
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/cbor/LwM2mNodeCborDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/cbor/LwM2mNodeCborDecoder.java
@@ -60,8 +60,8 @@ public class LwM2mNodeCborDecoder implements NodeDecoder {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException {
 
         // Support only single value
         if (!path.isResource() && !path.isResourceInstance())

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/cbor/LwM2mNodeCborEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/cbor/LwM2mNodeCborEncoder.java
@@ -58,8 +58,8 @@ public class LwM2mNodeCborEncoder implements NodeEncoder {
     }
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonDecoder.java
@@ -83,8 +83,8 @@ public class LwM2mNodeJsonDecoder implements TimestampedNodeDecoder {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException {
         try {
             String jsonStrValue = content != null ? new String(content) : "";
             JsonRootObject json = decoder.fromJsonLwM2m(jsonStrValue);
@@ -104,8 +104,8 @@ public class LwM2mNodeJsonDecoder implements TimestampedNodeDecoder {
     }
 
     @Override
-    public List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, LwM2mPath path, LwM2mModel model,
-            Class<? extends LwM2mNode> nodeClass) throws CodecException {
+    public List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, String rootPath, LwM2mPath path,
+            LwM2mModel model, Class<? extends LwM2mNode> nodeClass) throws CodecException {
         try {
             String jsonStrValue = new String(content);
             JsonRootObject json = decoder.fromJsonLwM2m(jsonStrValue);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/json/LwM2mNodeJsonEncoder.java
@@ -75,8 +75,8 @@ public class LwM2mNodeJsonEncoder implements TimestampedNodeEncoder {
     }
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);
@@ -98,8 +98,8 @@ public class LwM2mNodeJsonEncoder implements TimestampedNodeEncoder {
     }
 
     @Override
-    public byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, LwM2mPath path, LwM2mModel model,
-            LwM2mValueConverter converter) {
+    public byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, String rootPath, LwM2mPath path,
+            LwM2mModel model, LwM2mValueConverter converter) {
         Validate.notNull(timestampedNodes);
         Validate.notNull(path);
         Validate.notNull(model);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueDecoder.java
@@ -29,8 +29,8 @@ public class LwM2mNodeOpaqueDecoder implements NodeDecoder {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException {
         if (!path.isResource() && !path.isResourceInstance())
             throw new CodecException("Invalid path %s : OpaqueDecoder decodes resource OR resource instance only",
                     path);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/opaque/LwM2mNodeOpaqueEncoder.java
@@ -37,8 +37,8 @@ public class LwM2mNodeOpaqueEncoder implements NodeEncoder {
     private static final Logger LOG = LoggerFactory.getLogger(LwM2mNodeOpaqueEncoder.class);
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mNodeSenMLEncoder.java
@@ -68,7 +68,8 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
     }
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter) {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);
@@ -76,6 +77,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
         InternalEncoder internalEncoder = new InternalEncoder();
         internalEncoder.objectId = path.getObjectId();
         internalEncoder.model = model;
+        internalEncoder.rootPath = rootPath;
         internalEncoder.requestPath = path;
         internalEncoder.converter = converter;
         node.accept(internalEncoder);
@@ -91,8 +93,8 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
     }
 
     @Override
-    public byte[] encodeNodes(Map<LwM2mPath, LwM2mNode> nodes, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encodeNodes(String rootPath, Map<LwM2mPath, LwM2mNode> nodes, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         // validate arguments
         Validate.notEmpty(nodes);
 
@@ -103,6 +105,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
             InternalEncoder internalEncoder = new InternalEncoder();
             internalEncoder.objectId = path.getObjectId();
             internalEncoder.model = model;
+            internalEncoder.rootPath = rootPath;
             internalEncoder.requestPath = path;
             internalEncoder.converter = converter;
             internalEncoder.records = new ArrayList<>();
@@ -127,8 +130,8 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
     }
 
     @Override
-    public byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, LwM2mPath path, LwM2mModel model,
-            LwM2mValueConverter converter) throws CodecException {
+    public byte[] encodeTimestampedData(List<TimestampedLwM2mNode> timestampedNodes, String rootPath, LwM2mPath path,
+            LwM2mModel model, LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(timestampedNodes);
         Validate.notNull(path);
         Validate.notNull(model);
@@ -148,6 +151,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
             InternalEncoder internalEncoder = new InternalEncoder();
             internalEncoder.objectId = path.getObjectId();
             internalEncoder.model = model;
+            internalEncoder.rootPath = rootPath;
             internalEncoder.requestPath = path;
             internalEncoder.converter = converter;
             internalEncoder.records = new ArrayList<>();
@@ -165,7 +169,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
     }
 
     @Override
-    public byte[] encodeTimestampedNodes(TimestampedLwM2mNodes timestampedNodes, LwM2mModel model,
+    public byte[] encodeTimestampedNodes(String rootPath, TimestampedLwM2mNodes timestampedNodes, LwM2mModel model,
             LwM2mValueConverter converter) throws CodecException {
         Validate.notEmpty(timestampedNodes.getTimestamps());
 
@@ -177,6 +181,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
                 InternalEncoder internalEncoder = new InternalEncoder();
                 internalEncoder.objectId = path.getObjectId();
                 internalEncoder.model = model;
+                internalEncoder.rootPath = rootPath;
                 internalEncoder.requestPath = path;
                 internalEncoder.converter = converter;
                 internalEncoder.records = new ArrayList<>();
@@ -206,6 +211,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
         private LwM2mModel model;
         private LwM2mPath requestPath;
         private LwM2mValueConverter converter;
+        private String rootPath;
 
         // visitor output
         private ArrayList<SenMLRecord> records = new ArrayList<>();
@@ -332,7 +338,7 @@ public class LwM2mNodeSenMLEncoder implements TimestampedNodeEncoder, MultiNodeE
 
             // Set basename only for first record
             if (records.isEmpty()) {
-                record.setBaseName(bn);
+                record.setBaseName(rootPath != null ? rootPath + bn : bn);
             }
             record.setName(n);
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mPathSenMLDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mPathSenMLDecoder.java
@@ -39,7 +39,7 @@ public class LwM2mPathSenMLDecoder implements PathDecoder {
     }
 
     @Override
-    public List<LwM2mPath> decode(byte[] content) throws CodecException {
+    public List<LwM2mPath> decode(byte[] content, String rootPath) throws CodecException {
         // Decode SenML Pack
         SenMLPack pack;
         try {
@@ -55,6 +55,7 @@ public class LwM2mPathSenMLDecoder implements PathDecoder {
             LwM2mResolvedSenMLRecord resolvedRecord;
             try {
                 resolvedRecord = resolver.resolve(record);
+                validateRootPath(resolvedRecord, rootPath);
                 if (record.getType() != null) {
                     throw new CodecException("Invalid record for path encoding : record should not have value %s",
                             record);
@@ -70,5 +71,12 @@ public class LwM2mPathSenMLDecoder implements PathDecoder {
             }
         }
         return res;
+    }
+
+    protected void validateRootPath(LwM2mResolvedSenMLRecord resolvedRecord, String rootPath) {
+        if (!resolvedRecord.getPrefixedPath().useRootPath(rootPath)) {
+            throw new CodecException("Invalid path [%s], it start by the root path [%s]", resolvedRecord.getName(),
+                    rootPath);
+        }
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mPathSenMLEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mPathSenMLEncoder.java
@@ -37,12 +37,12 @@ public class LwM2mPathSenMLEncoder implements PathEncoder {
     }
 
     @Override
-    public byte[] encode(List<LwM2mPath> paths) {
+    public byte[] encode(String rootPath, List<LwM2mPath> paths) {
         // Create SenML Pack
         SenMLPack pack = new SenMLPack();
         for (LwM2mPath path : paths) {
             SenMLRecord record = new SenMLRecord();
-            record.setName(path.toString());
+            record.setName(rootPath != null ? rootPath + path.toString() : path.toString());
             pack.addRecord(record);
         }
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mResolvedSenMLRecord.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mResolvedSenMLRecord.java
@@ -19,33 +19,39 @@ import java.math.BigDecimal;
 
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
 import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.node.PrefixedLwM2mPath;
 import org.eclipse.leshan.senml.ResolvedSenMLRecord;
 import org.eclipse.leshan.senml.SenMLRecord;
 
 /**
- * A {@link ResolvedSenMLRecord} dedicated for LWM2M as a new {@link #getPath()} is available to get the
+ * A {@link ResolvedSenMLRecord} dedicated for LWM2M as a new {@link #getPrefixedPath()} is available to get the
  * {@link LwM2mPath} of this resolved SenML record.
  *
  */
 public class LwM2mResolvedSenMLRecord extends ResolvedSenMLRecord {
 
-    private LwM2mPath path;
+    private final PrefixedLwM2mPath prefixedPath;
 
     /**
-     * @throws IllegalArgumentException if path is invalid
      * @throws InvalidLwM2mPathException if path is invalid
      */
-    public LwM2mResolvedSenMLRecord(SenMLRecord unresolvedRecord, String resolvedName, BigDecimal resolvedTimestamp)
-            throws InvalidLwM2mPathException {
+    public LwM2mResolvedSenMLRecord(SenMLRecord unresolvedRecord, String resolvedName, PrefixedLwM2mPath path,
+            BigDecimal resolvedTimestamp) throws InvalidLwM2mPathException {
         super(unresolvedRecord, resolvedName, resolvedTimestamp);
-        this.path = new LwM2mPath(resolvedName);
+        this.prefixedPath = path;
     }
 
     /**
-     * @return the resolved {@link LwM2mPath} of this record created from resolved record name.
+     * @return the resolved {@link PrefixedLwM2mPath} of this record created from resolved record name.
      */
-    public LwM2mPath getPath() {
-        return path;
+    public PrefixedLwM2mPath getPrefixedPath() {
+        return prefixedPath;
     }
 
+    /**
+     * @return the resolved {@link LwM2mPath} without prefix of this record created from resolved record name.
+     */
+    public LwM2mPath getPath() {
+        return prefixedPath.getPath();
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mSenMLResolver.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/senml/LwM2mSenMLResolver.java
@@ -18,6 +18,8 @@ package org.eclipse.leshan.core.node.codec.senml;
 import java.math.BigDecimal;
 
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
+import org.eclipse.leshan.core.node.PrefixedLwM2mPath;
+import org.eclipse.leshan.core.node.PrefixedLwM2mPathParser;
 import org.eclipse.leshan.senml.SenMLException;
 import org.eclipse.leshan.senml.SenMLRecord;
 import org.eclipse.leshan.senml.SenMLResolver;
@@ -27,11 +29,22 @@ import org.eclipse.leshan.senml.SenMLResolver;
  */
 public class LwM2mSenMLResolver extends SenMLResolver<LwM2mResolvedSenMLRecord> {
 
+    private final PrefixedLwM2mPathParser pathParser;
+
+    public LwM2mSenMLResolver() {
+        this(new PrefixedLwM2mPathParser());
+    }
+
+    public LwM2mSenMLResolver(PrefixedLwM2mPathParser pathParser) {
+        this.pathParser = pathParser;
+    }
+
     @Override
     protected LwM2mResolvedSenMLRecord createResolvedRecord(SenMLRecord unresolvedRecord, String resolvedName,
             BigDecimal resolvedTimestamp) throws SenMLException {
         try {
-            return new LwM2mResolvedSenMLRecord(unresolvedRecord, resolvedName, resolvedTimestamp);
+            PrefixedLwM2mPath path = pathParser.parsePrefixedPath(resolvedName);
+            return new LwM2mResolvedSenMLRecord(unresolvedRecord, resolvedName, path, resolvedTimestamp);
         } catch (InvalidLwM2mPathException e) {
             throw new SenMLException(e, "Unable to resolve record, invalid path", resolvedName);
         }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextDecoder.java
@@ -63,8 +63,8 @@ public class LwM2mNodeTextDecoder implements NodeDecoder {
 
     @Override
     @SuppressWarnings("unchecked")
-    public <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException {
         if (!path.isResource() && !path.isResourceInstance())
             throw new CodecException("Invalid path %s : TextDecoder decodes resource OR resource instance only", path);
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/text/LwM2mNodeTextEncoder.java
@@ -61,8 +61,8 @@ public class LwM2mNodeTextEncoder implements NodeEncoder {
     }
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvDecoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvDecoder.java
@@ -69,8 +69,8 @@ public class LwM2mNodeTlvDecoder implements NodeDecoder {
     }
 
     @Override
-    public <T extends LwM2mNode> T decode(byte[] content, LwM2mPath path, LwM2mModel model, Class<T> nodeClass)
-            throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, String rootPath, LwM2mPath path, LwM2mModel model,
+            Class<T> nodeClass) throws CodecException {
         try {
             Tlv[] tlvs = TlvDecoder.decode(ByteBuffer.wrap(content != null ? content : new byte[0]));
             return parseTlv(tlvs, path, model, nodeClass);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/codec/tlv/LwM2mNodeTlvEncoder.java
@@ -65,8 +65,8 @@ public class LwM2mNodeTlvEncoder implements NodeEncoder {
     }
 
     @Override
-    public byte[] encode(LwM2mNode node, LwM2mPath path, LwM2mModel model, LwM2mValueConverter converter)
-            throws CodecException {
+    public byte[] encode(LwM2mNode node, String rootPath, LwM2mPath path, LwM2mModel model,
+            LwM2mValueConverter converter) throws CodecException {
         Validate.notNull(node);
         Validate.notNull(path);
         Validate.notNull(model);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/parser/StringParser.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/parser/StringParser.java
@@ -22,7 +22,7 @@ import org.eclipse.leshan.core.util.Validate;
  */
 public abstract class StringParser<T extends Throwable> {
 
-    private String strToParse;
+    private final String strToParse;
     private int cursor;
 
     public StringParser(String stringToParse) {
@@ -237,6 +237,26 @@ public abstract class StringParser<T extends Throwable> {
     }
 
     /**
+     * Cancel consumption of last char.
+     */
+    public void backtrackTo(int position) {
+        if (position < 0) {
+            throw new IllegalStateException("can not backtrack to negative position");
+        }
+        cursor = position;
+    }
+
+    /**
+     * Cancel consumption of last char.
+     */
+    public void backtrackLastChar() {
+        if (cursor == 0) {
+            throw new IllegalStateException("can not backtrack char, we already are at the start of the string");
+        }
+        cursor--;
+    }
+
+    /**
      * @return the index of the next char to consume.
      */
     public int getPosition() {
@@ -299,4 +319,5 @@ public abstract class StringParser<T extends Throwable> {
     }
 
     public abstract void raiseException(String message, Exception cause) throws T;
+
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/PrefixedLwM2mPathTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/PrefixedLwM2mPathTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021 Sierra Wireless and others.
+ * Copyright (c) 2024 Sierra Wireless and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -31,19 +31,32 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class LwM2mPathTest {
+public class PrefixedLwM2mPathTest {
 
-    public static List<String> ordererPaths = Arrays.asList( //
-            "/", //
-            "/1", //
-            "/1/1", //
-            "/1/1/1", //
-            "/1/1/1/1", //
-            "/2", //
-            "/2/1", //
-            "/2/1/1", //
-            "/2/1/1/1" //
+    private static List<String> prefixes = Arrays.asList( //
+            "/lwm2m", //
+            "/lwm2m/folder1", //
+            "/lwm2m/folder2" //
     );
+
+    private static List<String> createOrderedPaths() {
+        List<String> result = new ArrayList<>();
+
+        result.addAll(LwM2mPathTest.ordererPaths);
+        for (String prefix : prefixes) {
+            for (String path : LwM2mPathTest.ordererPaths) {
+                if (path.equals("/")) {
+                    result.add(prefix);
+                } else {
+                    result.add(prefix + path);
+                }
+
+            }
+        }
+        return result;
+    }
+
+    private static List<String> ordererPaths = createOrderedPaths();
 
     static Stream<org.junit.jupiter.params.provider.Arguments> equalsTestArguements() {
         return ordererPaths.stream().map(p -> arguments(p));
@@ -62,20 +75,24 @@ public class LwM2mPathTest {
     @ParameterizedTest(name = "[{0}] equals to [{0}]")
     @MethodSource("equalsTestArguements")
     public void test_equals(String path) {
-        assertTrue(new LwM2mPath(path).compareTo(new LwM2mPath(path)) == 0);
-        assertEquals(new LwM2mPath(path), new LwM2mPath(path));
+        PrefixedLwM2mPath parsedPath1 = new PrefixedLwM2mPathParser().parsePrefixedPath(path);
+        PrefixedLwM2mPath parsedPath2 = new PrefixedLwM2mPathParser().parsePrefixedPath(path);
+        assertTrue(parsedPath1.compareTo(parsedPath2) == 0);
+        assertEquals(parsedPath1, parsedPath2);
     }
 
     @ParameterizedTest(name = "[{0}] smaller than [{1}]")
     @MethodSource("smallerTestArguments")
     public void assertFirstSmaller(String path1, String path2) {
-        assertTrue(new LwM2mPath(path1).compareTo(new LwM2mPath(path2)) == -1);
-        assertTrue(new LwM2mPath(path2).compareTo(new LwM2mPath(path1)) == 1);
+        PrefixedLwM2mPath parsedPath1 = new PrefixedLwM2mPathParser().parsePrefixedPath(path1);
+        PrefixedLwM2mPath parsedPath2 = new PrefixedLwM2mPathParser().parsePrefixedPath(path2);
+        assertTrue(parsedPath1.compareTo(parsedPath2) == -1);
+        assertTrue(parsedPath2.compareTo(parsedPath1) == 1);
 
     }
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(LwM2mPath.class).withRedefinedSubclass(LwM2mIncompletePath.class).verify();
+        EqualsVerifier.forClass(PrefixedLwM2mPath.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderEncoderTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderEncoderTest.java
@@ -57,10 +57,11 @@ public class LwM2mNodeDecoderEncoderTest {
         List<TimestampedLwM2mNode> timestampedData = Arrays.asList(new TimestampedLwM2mNode(t1, resource));
 
         // try to encode then to decode and compare result
-        byte[] encodedTimestampedData = encoder.encodeTimestampedData(timestampedData, format, resourcePath, model);
+        byte[] encodedTimestampedData = encoder.encodeTimestampedData(timestampedData, format, null, resourcePath,
+                model);
 
         List<TimestampedLwM2mNode> decodeTimestampedData = decoder.decodeTimestampedData(encodedTimestampedData, format,
-                resourcePath, model);
+                null, resourcePath, model);
 
         assertEquals(timestampedData, decodeTimestampedData);
     }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/codec/LwM2mNodeDecoderTest.java
@@ -24,7 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -33,6 +36,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.eclipse.leshan.core.json.LwM2mJsonException;
 import org.eclipse.leshan.core.link.Link;
@@ -66,6 +70,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -75,6 +80,21 @@ public class LwM2mNodeDecoderTest {
 
     private static LwM2mModel model;
     private static LwM2mDecoder decoder;
+
+    @ParameterizedTest(name = "using [{0}] as rootPath")
+    @MethodSource("rootPaths")
+    @Retention(RetentionPolicy.RUNTIME)
+    private @interface TestAllRootPaths {
+    }
+
+    static Stream<org.junit.jupiter.params.provider.Arguments> rootPaths() {
+        return Stream.of(//
+                arguments((String) null), //
+                arguments("/"), //
+                arguments("/lwm2m"), //
+                arguments("/lwm2m/"), //
+                arguments("/lwm2m/rootpath"));
+    }
 
     @BeforeAll
     public static void loadModel() {
@@ -256,11 +276,11 @@ public class LwM2mNodeDecoderTest {
         assertEquals(0, links[6].getAttributes().asCollection().size());
     }
 
-    @Test
-    public void text_manufacturer_resource() throws CodecException {
+    @TestAllRootPaths
+    public void text_manufacturer_resource(String rootPath) throws CodecException {
         String value = "MyManufacturer";
         LwM2mSingleResource resource = (LwM2mSingleResource) decoder.decode(value.getBytes(StandardCharsets.UTF_8),
-                ContentFormat.TEXT, new LwM2mPath(3, 0, 0), model);
+                ContentFormat.TEXT, rootPath, new LwM2mPath(3, 0, 0), model);
 
         assertEquals(0, resource.getId());
         assertFalse(resource.isMultiInstances());
@@ -268,18 +288,18 @@ public class LwM2mNodeDecoderTest {
         assertEquals(value, resource.getValue());
     }
 
-    @Test()
-    public void content_format_is_mandatory() throws CodecException {
+    @TestAllRootPaths
+    public void content_format_is_mandatory(String rootPath) throws CodecException {
         assertThrowsExactly(CodecException.class, () -> {
             String value = "MyManufacturer";
-            decoder.decode(value.getBytes(StandardCharsets.UTF_8), null, new LwM2mPath(666, 0, 0), model);
+            decoder.decode(value.getBytes(StandardCharsets.UTF_8), null, null, new LwM2mPath(666, 0, 0), model);
         });
     }
 
-    @Test
-    public void text_battery_resource() throws CodecException {
+    @TestAllRootPaths
+    public void text_battery_resource(String rootPath) throws CodecException {
         LwM2mSingleResource resource = (LwM2mSingleResource) decoder.decode("100".getBytes(StandardCharsets.UTF_8),
-                ContentFormat.TEXT, new LwM2mPath(3, 0, 9), model);
+                ContentFormat.TEXT, rootPath, new LwM2mPath(3, 0, 9), model);
 
         assertEquals(9, resource.getId());
         assertFalse(resource.isMultiInstances());
@@ -287,11 +307,11 @@ public class LwM2mNodeDecoderTest {
         assertEquals(100, ((Number) resource.getValue()).intValue());
     }
 
-    @Test
-    public void text_decode_opaque_from_base64_string() throws CodecException {
+    @TestAllRootPaths
+    public void text_decode_opaque_from_base64_string(String rootPath) throws CodecException {
         // Using Firmware Update/Package
         LwM2mSingleResource resource = (LwM2mSingleResource) decoder.decode("AQIDBAU=".getBytes(StandardCharsets.UTF_8),
-                ContentFormat.TEXT, new LwM2mPath(5, 0, 0), model);
+                ContentFormat.TEXT, rootPath, new LwM2mPath(5, 0, 0), model);
 
         byte[] expectedValue = new byte[] { 0x1, 0x2, 0x3, 0x4, 0x5 };
 
@@ -301,21 +321,21 @@ public class LwM2mNodeDecoderTest {
         assertArrayEquals(expectedValue, ((byte[]) resource.getValue()));
     }
 
-    @Test()
-    public void text_decode_should_throw_an_exception_for_invalid_base64() throws CodecException {
+    @TestAllRootPaths
+    public void text_decode_should_throw_an_exception_for_invalid_base64(String rootPath) throws CodecException {
         assertThrowsExactly(CodecException.class, () -> {
             // Using Firmware Update/Package
-            decoder.decode("!,-INVALID$_'".getBytes(StandardCharsets.UTF_8), ContentFormat.TEXT, new LwM2mPath(5, 0, 0),
-                    model);
+            decoder.decode("!,-INVALID$_'".getBytes(StandardCharsets.UTF_8), ContentFormat.TEXT, rootPath,
+                    new LwM2mPath(5, 0, 0), model);
         });
     }
 
-    @Test
-    public void tlv_manufacturer_resource() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_manufacturer_resource(String rootPath) throws CodecException {
         String value = "MyManufacturer";
         byte[] content = TlvEncoder.encode(new Tlv[] { new Tlv(TlvType.RESOURCE_VALUE, null, value.getBytes(), 0) })
                 .array();
-        LwM2mSingleResource resource = (LwM2mSingleResource) decoder.decode(content, ContentFormat.TLV,
+        LwM2mSingleResource resource = (LwM2mSingleResource) decoder.decode(content, ContentFormat.TLV, rootPath,
                 new LwM2mPath(3, 0, 0), model);
 
         assertEquals(0, resource.getId());
@@ -323,87 +343,89 @@ public class LwM2mNodeDecoderTest {
         assertEquals(value, resource.getValue());
     }
 
-    @Test
-    public void tlv_device_object_instance0_from_resources_tlv() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_device_object_instance0_from_resources_tlv(String rootPath) throws CodecException {
 
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(ENCODED_DEVICE_WITHOUT_INSTANCE,
-                ContentFormat.TLV, new LwM2mPath(3, 0), model);
+                ContentFormat.TLV, rootPath, new LwM2mPath(3, 0), model);
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void tlv_device_object_instance0_from_resources_tlv__instance_expected() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_device_object_instance0_from_resources_tlv__instance_expected(String rootPath)
+            throws CodecException {
 
-        LwM2mObjectInstance oInstance = decoder.decode(ENCODED_DEVICE_WITHOUT_INSTANCE, ContentFormat.TLV,
+        LwM2mObjectInstance oInstance = decoder.decode(ENCODED_DEVICE_WITHOUT_INSTANCE, ContentFormat.TLV, rootPath,
                 new LwM2mPath(3), model, LwM2mObjectInstance.class);
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void tlv_device_object_instance0_from_instance_tlv() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_device_object_instance0_from_instance_tlv(String rootPath) throws CodecException {
 
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(ENCODED_DEVICE_WITH_INSTANCE,
-                ContentFormat.TLV, new LwM2mPath(3, 0), model);
+                ContentFormat.TLV, rootPath, new LwM2mPath(3, 0), model);
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void tlv_server_object_multi_instance_with_only_1_instance() throws Exception {
-        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_SERVER, ContentFormat.TLV, new LwM2mPath(1),
-                model));
+    @TestAllRootPaths
+    public void tlv_server_object_multi_instance_with_only_1_instance(String rootPath) throws Exception {
+        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_SERVER, ContentFormat.TLV, rootPath,
+                new LwM2mPath(1), model));
         assertServerInstance(oObject);
     }
 
-    @Test
-    public void tlv_acl_object_multi_instance() throws Exception {
-        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_ACL, ContentFormat.TLV, new LwM2mPath(2), model));
+    @TestAllRootPaths
+    public void tlv_acl_object_multi_instance(String rootPath) throws Exception {
+        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_ACL, ContentFormat.TLV, rootPath, new LwM2mPath(2),
+                model));
         assertAclInstances(oObject);
     }
 
-    @Test()
-    public void tlv_invalid_object_2_instances_with_the_same_id() {
+    @TestAllRootPaths
+    public void tlv_invalid_object_2_instances_with_the_same_id(String rootPath) {
         Tlv objInstance1 = new Tlv(TlvType.OBJECT_INSTANCE, new Tlv[0], null, 1);
         Tlv objInstance2 = new Tlv(TlvType.OBJECT_INSTANCE, new Tlv[0], null, 1);
         byte[] content = TlvEncoder.encode(new Tlv[] { objInstance1, objInstance2 }).array();
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(content, ContentFormat.TLV, new LwM2mPath(2), model);
+            decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(2), model);
         });
 
     }
 
-    @Test()
-    public void tlv_invalid_object__instance_2_resources_with_the_same_id() {
+    @TestAllRootPaths
+    public void tlv_invalid_object__instance_2_resources_with_the_same_id(String rootPath) {
         Tlv resource1 = new Tlv(TlvType.RESOURCE_VALUE, null, new byte[0], 1);
         Tlv resource2 = new Tlv(TlvType.RESOURCE_VALUE, null, new byte[0], 1);
         byte[] content = TlvEncoder.encode(new Tlv[] { resource1, resource2 }).array();
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0), model);
+            decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(3, 0), model);
         });
 
     }
 
-    @Test
-    public void tlv_single_instance_with_obj_link() throws Exception {
+    @TestAllRootPaths
+    public void tlv_single_instance_with_obj_link(String rootPath) throws Exception {
         LwM2mObjectInstance oInstance = ((LwM2mObjectInstance) decoder.decode(ENCODED_OBJ65, ContentFormat.TLV,
-                new LwM2mPath(65, 0), model));
+                rootPath, new LwM2mPath(65, 0), model));
         assertObj65Instance(oInstance);
     }
 
-    @Test
-    public void tlv_multi_instance_with_obj_link() throws Exception {
-        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_OBJ66, ContentFormat.TLV, new LwM2mPath(66),
-                model));
+    @TestAllRootPaths
+    public void tlv_multi_instance_with_obj_link(String rootPath) throws Exception {
+        LwM2mObject oObject = ((LwM2mObject) decoder.decode(ENCODED_OBJ66, ContentFormat.TLV, rootPath,
+                new LwM2mPath(66), model));
         assertObj66Instance(oObject);
     }
 
-    @Test
-    public void tlv_power_source__array_values() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_power_source__array_values(String rootPath) throws CodecException {
         byte[] content = new byte[] { 65, 0, 1, 65, 1, 5 };
 
-        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0, 6),
-                model);
+        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, rootPath,
+                new LwM2mPath(3, 0, 6), model);
 
         assertEquals(6, resource.getId());
         assertEquals(2, resource.getInstances().size());
@@ -411,14 +433,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(5L, resource.getValue(1));
     }
 
-    @Test
-    public void tlv_power_source__multiple_resource() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_power_source__multiple_resource(String rootPath) throws CodecException {
         // this content (a single TLV of type 'multiple_resource' containing the values)
         // is probably not compliant with the spec but it should be supported by the server
         byte[] content = new byte[] { -122, 6, 65, 0, 1, 65, 1, 5 };
 
-        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0, 6),
-                model);
+        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, rootPath,
+                new LwM2mPath(3, 0, 6), model);
 
         assertEquals(6, resource.getId());
         assertEquals(2, resource.getInstances().size());
@@ -426,72 +448,74 @@ public class LwM2mNodeDecoderTest {
         assertEquals(5L, resource.getValue(1));
     }
 
-    @Test
-    public void tlv_instance_without_id_tlv() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_instance_without_id_tlv(String rootPath) throws CodecException {
         // this is "special" case where instance ID is not defined ...
         byte[] content = TlvEncoder
                 .encode(new Tlv[] { new Tlv(TlvType.RESOURCE_VALUE, null, TlvEncoder.encodeInteger(11), 1),
                         new Tlv(TlvType.RESOURCE_VALUE, null, TlvEncoder.encodeInteger(10), 2) })
                 .array();
 
-        LwM2mObject object = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(2), model);
+        LwM2mObject object = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(2),
+                model);
         assertEquals(object.getInstances().size(), 1);
         assertEquals(object.getInstances().values().iterator().next().getId(), LwM2mObjectInstance.UNDEFINED);
     }
 
-    @Test
-    public void tlv_unknown_object__missing_instance_tlv() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_unknown_object__missing_instance_tlv(String rootPath) throws CodecException {
 
         byte[] content = TlvEncoder.encode(new Tlv[] { new Tlv(TlvType.RESOURCE_VALUE, null, "value1".getBytes(), 1),
                 new Tlv(TlvType.RESOURCE_VALUE, null, "value1".getBytes(), 2) }).array();
 
-        LwM2mObject obj = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(10234), model);
+        LwM2mObject obj = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(10234),
+                model);
 
         assertEquals(1, obj.getInstances().size());
         assertEquals(2, obj.getInstance(0).getResources().size());
     }
 
-    @Test
-    public void tlv_resource_with_undesired_object_instance() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_resource_with_undesired_object_instance(String rootPath) throws CodecException {
 
         Tlv resInstance1 = new Tlv(TlvType.RESOURCE_VALUE, null, "client".getBytes(), 1);
         Tlv objInstance = new Tlv(TlvType.OBJECT_INSTANCE, new Tlv[] { resInstance1 }, null, 0);
         byte[] content = TlvEncoder.encode(new Tlv[] { objInstance }).array();
 
-        LwM2mSingleResource res = (LwM2mSingleResource) decoder.decode(content, ContentFormat.TLV,
+        LwM2mSingleResource res = (LwM2mSingleResource) decoder.decode(content, ContentFormat.TLV, rootPath,
                 new LwM2mPath(3, 0, 1), model);
 
         assertEquals("client", res.getValue());
     }
 
-    @Test()
-    public void tlv_resource_with_undesired_invalid_object_instance() throws CodecException {
+    @TestAllRootPaths
+    public void tlv_resource_with_undesired_invalid_object_instance(String rootPath) throws CodecException {
 
         Tlv resInstance1 = new Tlv(TlvType.RESOURCE_VALUE, null, "client".getBytes(), 1);
         Tlv objInstance = new Tlv(TlvType.OBJECT_INSTANCE, new Tlv[] { resInstance1 }, null, 1);
         byte[] content = TlvEncoder.encode(new Tlv[] { objInstance }).array();
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0, 1), model);
+            decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(3, 0, 1), model);
         });
     }
 
-    @Test
-    public void tlv_empty_object() {
+    @TestAllRootPaths
+    public void tlv_empty_object(String rootPath) {
         byte[] content = TlvEncoder.encode(new Tlv[] {}).array();
 
-        LwM2mObject obj = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(2), model);
+        LwM2mObject obj = (LwM2mObject) decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(2), model);
 
         assertNotNull(obj);
         assertEquals(2, obj.getId());
         assertTrue(obj.getInstances().isEmpty());
     }
 
-    @Test
-    public void tlv_empty_instance() {
+    @TestAllRootPaths
+    public void tlv_empty_instance(String rootPath) {
         byte[] content = TlvEncoder.encode(new Tlv[] {}).array();
 
-        LwM2mObjectInstance instance = (LwM2mObjectInstance) decoder.decode(content, ContentFormat.TLV,
+        LwM2mObjectInstance instance = (LwM2mObjectInstance) decoder.decode(content, ContentFormat.TLV, rootPath,
                 new LwM2mPath(2, 0), model);
 
         assertNotNull(instance);
@@ -499,22 +523,22 @@ public class LwM2mNodeDecoderTest {
         assertTrue(instance.getResources().isEmpty());
     }
 
-    @Test()
-    public void tlv_empty_single_resource() {
+    @TestAllRootPaths
+    public void tlv_empty_single_resource(String rootPath) {
         byte[] content = TlvEncoder.encode(new Tlv[] {}).array();
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(content, ContentFormat.TLV, new LwM2mPath(2, 0, 0), model);
+            decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(2, 0, 0), model);
         });
 
     }
 
-    @Test
-    public void tlv_empty_multi_resource() {
+    @TestAllRootPaths
+    public void tlv_empty_multi_resource(String rootPath) {
         byte[] content = TlvEncoder.encode(new Tlv[] {}).array();
 
-        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0, 6),
-                model);
+        LwM2mResource resource = (LwM2mResource) decoder.decode(content, ContentFormat.TLV, rootPath,
+                new LwM2mPath(3, 0, 6), model);
 
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
@@ -522,27 +546,27 @@ public class LwM2mNodeDecoderTest {
         assertTrue(resource.getInstances().isEmpty());
     }
 
-    @Test()
-    public void tlv_invalid_multi_resource_2_instance_with_the_same_id() {
+    @TestAllRootPaths
+    public void tlv_invalid_multi_resource_2_instance_with_the_same_id(String rootPath) {
         Tlv resInstance1 = new Tlv(TlvType.RESOURCE_INSTANCE, null, TlvEncoder.encodeObjlnk(new ObjectLink(100, 1)), 0);
         Tlv resInstance2 = new Tlv(TlvType.RESOURCE_INSTANCE, null, TlvEncoder.encodeObjlnk(new ObjectLink(101, 2)), 0);
         Tlv multiResource = new Tlv(TlvType.MULTIPLE_RESOURCE, new Tlv[] { resInstance1, resInstance2 }, null, 22);
         byte[] content = TlvEncoder.encode(new Tlv[] { multiResource }).array();
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(content, ContentFormat.TLV, new LwM2mPath(3, 0, 22), model);
+            decoder.decode(content, ContentFormat.TLV, rootPath, new LwM2mPath(3, 0, 22), model);
         });
     }
 
-    @Test
-    public void tlv_instance_with_core_link_value() {
+    @TestAllRootPaths
+    public void tlv_instance_with_core_link_value(String rootPath) {
         LwM2mObjectInstance instance = (LwM2mObjectInstance) decoder.decode(ENCODED_OBJ3442, ContentFormat.TLV,
-                new LwM2mPath(3442, 0), model);
+                rootPath, new LwM2mPath(3442, 0), model);
         assertObj3442Instance(instance);
     }
 
-    @Test
-    public void json_device_object_instance0() throws CodecException {
+    @TestAllRootPaths
+    public void json_device_object_instance0(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/3/0/\",");
@@ -565,13 +589,13 @@ public class LwM2mNodeDecoderTest {
         b.append("{\"n\":\"16\",\"sv\":\"U\"}]}");
 
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(3, 0), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(3, 0), model);
 
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void json_device_object_instance0_with_empty_root_basename() throws CodecException {
+    @TestAllRootPaths
+    public void json_device_object_instance0_with_empty_root_basename(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/\",");
@@ -594,13 +618,13 @@ public class LwM2mNodeDecoderTest {
         b.append("{\"n\":\"3/0/16\",\"sv\":\"U\"}]}");
 
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(3, 0), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(3, 0), model);
 
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void json_device_object_instance0_without_basename() throws CodecException {
+    @TestAllRootPaths
+    public void json_device_object_instance0_without_basename(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"e\":[");
@@ -622,13 +646,13 @@ public class LwM2mNodeDecoderTest {
         b.append("{\"n\":\"/3/0/16\",\"sv\":\"U\"}]}");
 
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(3, 0), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(3, 0), model);
 
         assertDeviceInstance(oInstance);
     }
 
-    @Test
-    public void json_custom_object_instance() throws CodecException {
+    @TestAllRootPaths
+    public void json_custom_object_instance(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"1024/0/\", \"e\":[");
@@ -636,7 +660,7 @@ public class LwM2mNodeDecoderTest {
         b.append("{\"n\":\"1\",\"v\":10.5},");
         b.append("{\"n\":\"2\",\"bv\":true}]}");
         LwM2mObjectInstance oInstance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(1024, 0), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(1024, 0), model);
 
         assertEquals(0, oInstance.getId());
 
@@ -645,8 +669,8 @@ public class LwM2mNodeDecoderTest {
         assertEquals(true, oInstance.getResource(2).getValue());
     }
 
-    @Test
-    public void json_timestamped_resources() throws CodecException {
+    @TestAllRootPaths
+    public void json_timestamped_resources(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/1024/0/1\",\"e\":[");
@@ -656,7 +680,7 @@ public class LwM2mNodeDecoderTest {
         b.append("\"bt\":25462634}");
 
         List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(1024, 0, 1), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(1024, 0, 1), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(25462634L - 5), timestampedResources.get(0).getTimestamp());
@@ -667,8 +691,8 @@ public class LwM2mNodeDecoderTest {
         assertEquals(24.1d, ((LwM2mResource) timestampedResources.get(2).getNode()).getValue());
     }
 
-    @Test
-    public void json_timestamped_instances() throws CodecException {
+    @TestAllRootPaths
+    public void json_timestamped_instances(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/1024/0/\",\"e\":[");
@@ -679,7 +703,7 @@ public class LwM2mNodeDecoderTest {
         b.append("\"bt\":25462634}");
 
         List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(1024, 0), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(1024, 0), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(25462634L - 5), timestampedResources.get(0).getTimestamp());
@@ -694,8 +718,8 @@ public class LwM2mNodeDecoderTest {
         assertEquals(24.1d, ((LwM2mObjectInstance) timestampedResources.get(2).getNode()).getResource(1).getValue());
     }
 
-    @Test
-    public void json_timestamped_Object() throws CodecException {
+    @TestAllRootPaths
+    public void json_timestamped_Object(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"/1024/\",\"e\":[");
@@ -707,7 +731,7 @@ public class LwM2mNodeDecoderTest {
         b.append("\"bt\":25462634}");
 
         List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.JSON, new LwM2mPath(1024), model);
+                ContentFormat.JSON, rootPath, new LwM2mPath(1024), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(25462634L - 5), timestampedResources.get(0).getTimestamp());
@@ -725,15 +749,16 @@ public class LwM2mNodeDecoderTest {
                 ((LwM2mObject) timestampedResources.get(2).getNode()).getInstance(0).getResource(1).getValue());
     }
 
-    @Test
-    public void json_empty_object() {
+    @TestAllRootPaths
+    public void json_empty_object(String rootPath) {
         // Completely empty
         LwM2mObject obj = null;
         StringBuilder b = new StringBuilder();
         b.append("{}");
         boolean failedWithCodecException = false;
         try {
-            obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(2), model);
+            obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(2),
+                    model);
         } catch (CodecException e) {
             assertTrue(e.getCause() instanceof LwM2mJsonException);
             failedWithCodecException = true;
@@ -743,7 +768,8 @@ public class LwM2mNodeDecoderTest {
         // with empty resource list
         b = new StringBuilder();
         b.append("{\"e\":[]}");
-        obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(2), model);
+        obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(2),
+                model);
         assertNotNull(obj);
         assertEquals(2, obj.getId());
         assertTrue(obj.getInstances().isEmpty());
@@ -751,21 +777,22 @@ public class LwM2mNodeDecoderTest {
         // with empty resources list and base name
         b = new StringBuilder();
         b.append("{\"bn\":\"2\", \"e\":[]}");
-        obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(2), model);
+        obj = (LwM2mObject) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(2),
+                model);
         assertNotNull(obj);
         assertEquals(2, obj.getId());
         assertTrue(obj.getInstances().isEmpty());
     }
 
-    @Test
-    public void json_empty_instance() {
+    @TestAllRootPaths
+    public void json_empty_instance(String rootPath) {
         // Completely empty
         LwM2mObjectInstance instance = null;
         StringBuilder b = new StringBuilder();
         b.append("{}");
         boolean failedWithCodecException = false;
         try {
-            instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON,
+            instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
                     new LwM2mPath(2, 0), model);
         } catch (CodecException e) {
             assertTrue(e.getCause() instanceof LwM2mJsonException);
@@ -776,7 +803,7 @@ public class LwM2mNodeDecoderTest {
         // with empty resource list
         b = new StringBuilder();
         b.append("{\"e\":[]}");
-        instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON,
+        instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
                 new LwM2mPath(2, 0), model);
         assertNotNull(instance);
         assertEquals(0, instance.getId());
@@ -785,32 +812,32 @@ public class LwM2mNodeDecoderTest {
         // with empty resources list and base name
         b = new StringBuilder();
         b.append("{\"bn\":\"2/0\", \"e\":[]}");
-        instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON,
+        instance = (LwM2mObjectInstance) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
                 new LwM2mPath(2, 0), model);
         assertNotNull(instance);
         assertEquals(0, instance.getId());
         assertTrue(instance.getResources().isEmpty());
     }
 
-    @Test()
-    public void json_empty_single_resource() {
+    @TestAllRootPaths
+    public void json_empty_single_resource(String rootPath) {
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"2/0/0\", \"e\":[]}");
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(2, 0, 0), model);
+            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(2, 0, 0), model);
         });
     }
 
-    @Test
-    public void json_empty_multi_resource() {
+    @TestAllRootPaths
+    public void json_empty_multi_resource(String rootPath) {
         // Completely empty
         LwM2mResource resource = null;
         StringBuilder b = new StringBuilder();
         b.append("{}");
         boolean failedWithCodecException = false;
         try {
-            resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON,
+            resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
                     new LwM2mPath(3, 0, 6), model);
         } catch (CodecException e) {
             assertTrue(e.getCause() instanceof LwM2mJsonException);
@@ -821,8 +848,8 @@ public class LwM2mNodeDecoderTest {
         // with empty resource list
         b = new StringBuilder();
         b.append("{\"e\":[]}");
-        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(3, 0, 6),
-                model);
+        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
+                new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
@@ -831,31 +858,31 @@ public class LwM2mNodeDecoderTest {
         // with empty resources list and base name
         b = new StringBuilder();
         b.append("{\"bn\":\"3/0/6\", \"e\":[]}");
-        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(3, 0, 6),
-                model);
+        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
+                new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
         assertTrue(resource.getInstances().isEmpty());
     }
 
-    @Test
-    public void json_missing_value_for_resource() {
+    @TestAllRootPaths
+    public void json_missing_value_for_resource(String rootPath) {
 
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"2/0/\",\"e\":[");
         b.append("{\"n\":\"0\"}");
         b.append("]}");
         try {
-            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(2, 0, 0), model);
+            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(2, 0, 0), model);
             fail();
         } catch (CodecException e) {
             assertTrue(e.getCause() instanceof LwM2mJsonException);
         }
     }
 
-    @Test()
-    public void json_invalid_instance_2_resources_with_the_same_id() {
+    @TestAllRootPaths
+    public void json_invalid_instance_2_resources_with_the_same_id(String rootPath) {
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"3/0/\",\"e\":[");
         b.append("{\"n\":\"1\",\"sv\":\"client1\"},");
@@ -863,12 +890,12 @@ public class LwM2mNodeDecoderTest {
         b.append("]}");
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(3, 0), model);
+            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(3, 0), model);
         });
     }
 
-    @Test()
-    public void json_invalid_multi_resource_2_instances_with_the_same_id() {
+    @TestAllRootPaths
+    public void json_invalid_multi_resource_2_instances_with_the_same_id(String rootPath) {
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"3/0/11/\",\"e\":[");
         b.append("{\"n\":\"1\",\"v\":2},");
@@ -876,19 +903,19 @@ public class LwM2mNodeDecoderTest {
         b.append("]}");
 
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, new LwM2mPath(3, 0, 11), model);
+            decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath, new LwM2mPath(3, 0, 11), model);
         });
     }
 
-    @Test
-    public void json_cut_basename_name_in_the_middle_of_an_id() {
+    @TestAllRootPaths
+    public void json_cut_basename_name_in_the_middle_of_an_id(String rootPath) {
         StringBuilder b = new StringBuilder();
         b.append("{\"bn\":\"3/0/1\",\"e\":[");
         b.append("{\"n\":\"1/0\",\"v\":0},");
         b.append("{\"n\":\"1/1\",\"v\":0}");
         b.append("]}");
 
-        LwM2mResource resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON,
+        LwM2mResource resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.JSON, rootPath,
                 new LwM2mPath(3, 0, 11), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
@@ -896,18 +923,19 @@ public class LwM2mNodeDecoderTest {
         assertTrue(resource.getInstances().size() == 2);
     }
 
-    @Test
-    public void senml_json_decode_acl_object() {
-        StringBuilder payload = new StringBuilder();
-        payload.append("[{\"bn\":\"/2/3/\",\"n\":\"0\",\"v\":3},");
-        payload.append("{\"n\":\"1\",\"v\":1},");
-        payload.append("{\"n\":\"3\",\"v\":123},");
-        payload.append("{\"bn\":\"/2/2/\",\"n\":\"0\",\"v\":4},");
-        payload.append("{\"n\":\"1\",\"v\":2},");
-        payload.append("{\"n\":\"3\",\"v\":124}]");
+    @TestAllRootPaths
+    public void senml_json_decode_acl_object(String rootPath) {
+        StringBuilder b = new StringBuilder();
+        b.append("[{\"bn\":\"%%ROOTPATH%%/2/3/\",\"n\":\"0\",\"v\":3},");
+        b.append("{\"n\":\"1\",\"v\":1},");
+        b.append("{\"n\":\"3\",\"v\":123},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/2/2/\",\"n\":\"0\",\"v\":4},");
+        b.append("{\"n\":\"1\",\"v\":2},");
+        b.append("{\"n\":\"3\",\"v\":124}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
-        LwM2mObject object = decoder.decode(payload.toString().getBytes(), ContentFormat.SENML_JSON,
-                new LwM2mPath("/2"), model, LwM2mObject.class);
+        LwM2mObject object = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath, new LwM2mPath("/2"),
+                model, LwM2mObject.class);
 
         assertNotNull(object);
         assertEquals(2, object.getId());
@@ -921,27 +949,28 @@ public class LwM2mNodeDecoderTest {
 
     }
 
-    @Test
-    public void senml_json_decode_device_object_instance() {
-        StringBuilder payload = new StringBuilder();
-        payload.append("[{\"bn\":\"/3/0/\",\"n\":\"0\",\"vs\":\"Open Mobile Alliance\"},");
-        payload.append("{\"n\":\"1\",\"vs\":\"Lightweight M2M Client\"},");
-        payload.append("{\"n\":\"2\",\"vs\":\"345000123\"},");
-        payload.append("{\"n\":\"3\",\"vs\":\"1.0\"},");
-        payload.append("{\"n\":\"6/0\",\"v\":1},");
-        payload.append("{\"n\":\"6/1\",\"v\":5},");
-        payload.append("{\"n\":\"7/0\",\"v\":3800},");
-        payload.append("{\"n\":\"7/1\",\"v\":5000},");
-        payload.append("{\"n\":\"8/0\",\"v\":125},");
-        payload.append("{\"n\":\"8/1\",\"v\":900},");
-        payload.append("{\"n\":\"9\",\"v\":100},");
-        payload.append("{\"n\":\"10\",\"v\":15},");
-        payload.append("{\"n\":\"11/0\",\"v\":0},");
-        payload.append("{\"n\":\"13\",\"v\":1367491215},");
-        payload.append("{\"n\":\"14\",\"vs\":\"+02:00\"},");
-        payload.append("{\"n\":\"16\",\"vs\":\"U\"}]");
+    @TestAllRootPaths
+    public void senml_json_decode_device_object_instance(String rootPath) {
+        StringBuilder b = new StringBuilder();
+        b.append("[{\"bn\":\"%%ROOTPATH%%/3/0/\",\"n\":\"0\",\"vs\":\"Open Mobile Alliance\"},");
+        b.append("{\"n\":\"1\",\"vs\":\"Lightweight M2M Client\"},");
+        b.append("{\"n\":\"2\",\"vs\":\"345000123\"},");
+        b.append("{\"n\":\"3\",\"vs\":\"1.0\"},");
+        b.append("{\"n\":\"6/0\",\"v\":1},");
+        b.append("{\"n\":\"6/1\",\"v\":5},");
+        b.append("{\"n\":\"7/0\",\"v\":3800},");
+        b.append("{\"n\":\"7/1\",\"v\":5000},");
+        b.append("{\"n\":\"8/0\",\"v\":125},");
+        b.append("{\"n\":\"8/1\",\"v\":900},");
+        b.append("{\"n\":\"9\",\"v\":100},");
+        b.append("{\"n\":\"10\",\"v\":15},");
+        b.append("{\"n\":\"11/0\",\"v\":0},");
+        b.append("{\"n\":\"13\",\"v\":1367491215},");
+        b.append("{\"n\":\"14\",\"vs\":\"+02:00\"},");
+        b.append("{\"n\":\"16\",\"vs\":\"U\"}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
-        LwM2mObjectInstance instance = decoder.decode(payload.toString().getBytes(), ContentFormat.SENML_JSON,
+        LwM2mObjectInstance instance = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
                 new LwM2mPath("/3/0"), model, LwM2mObjectInstance.class);
 
         assertNotNull(instance);
@@ -973,7 +1002,8 @@ public class LwM2mNodeDecoderTest {
     @ParameterizedTest()
     @ValueSource(strings = { "SENML_JSON", "SENML_CBOR", "TLV" })
     public void decode_null_object(@ConvertWith(ContentFormatArgumentConverter.class) ContentFormat contentFormat) {
-        LwM2mObject object = decoder.decode(new byte[0], contentFormat, new LwM2mPath("/1"), model, LwM2mObject.class);
+        LwM2mObject object = decoder.decode(new byte[0], contentFormat, null, new LwM2mPath("/1"), model,
+                LwM2mObject.class);
 
         assertNotNull(object);
         assertEquals(1, object.getId());
@@ -984,7 +1014,7 @@ public class LwM2mNodeDecoderTest {
     @ValueSource(strings = { "SENML_JSON", "SENML_CBOR", "TLV" })
     public void decode_null_object_instance(
             @ConvertWith(ContentFormatArgumentConverter.class) ContentFormat contentFormat) {
-        LwM2mObjectInstance instance = decoder.decode(new byte[0], contentFormat, new LwM2mPath("/3/0"), model,
+        LwM2mObjectInstance instance = decoder.decode(new byte[0], contentFormat, null, new LwM2mPath("/3/0"), model,
                 LwM2mObjectInstance.class);
 
         assertNotNull(instance);
@@ -996,7 +1026,7 @@ public class LwM2mNodeDecoderTest {
     @ValueSource(strings = { "SENML_JSON", "SENML_CBOR", "TLV" })
     public void decode_null_multi_resource(
             @ConvertWith(ContentFormatArgumentConverter.class) ContentFormat contentFormat) {
-        LwM2mResource resource = decoder.decode(new byte[0], contentFormat, new LwM2mPath("/3/0/7"), model,
+        LwM2mResource resource = decoder.decode(new byte[0], contentFormat, null, new LwM2mPath("/3/0/7"), model,
                 LwM2mResource.class);
 
         assertNotNull(resource);
@@ -1004,20 +1034,23 @@ public class LwM2mNodeDecoderTest {
         assertTrue(resource.getInstances().isEmpty());
     }
 
-    @Test
-    public void senml_json_decode_single_resource() {
-        String payload = "[{\"bn\":\"/3/0/0\",\"vs\":\"Open Mobile Alliance\"}]";
-        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, new LwM2mPath("/3/0/0"),
-                model, LwM2mResource.class);
+    @TestAllRootPaths
+    public void senml_json_decode_single_resource(String rootPath) {
+        String b = "[{\"bn\":\"%%ROOTPATH%%/3/0/0\",\"vs\":\"Open Mobile Alliance\"}]";
+        String payload = addRooPath(b.toString(), rootPath);
+
+        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                new LwM2mPath("/3/0/0"), model, LwM2mResource.class);
 
         assertNotNull(resource);
         assertTrue(!resource.isMultiInstances());
         assertEquals(0, resource.getId());
         assertEquals("Open Mobile Alliance", resource.getValue());
 
-        payload = "[{\"n\":\"/6/0/3\",\"v\":20.0}]";
-        resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, new LwM2mPath("/6/0/3"), model,
-                LwM2mResource.class);
+        b = "[{\"n\":\"%%ROOTPATH%%/6/0/3\",\"v\":20.0}]";
+        payload = addRooPath(b.toString(), rootPath);
+        resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath, new LwM2mPath("/6/0/3"),
+                model, LwM2mResource.class);
 
         assertNotNull(resource);
         assertTrue(!resource.isMultiInstances());
@@ -1025,11 +1058,13 @@ public class LwM2mNodeDecoderTest {
         assertEquals(20.0, resource.getValue());
     }
 
-    @Test
-    public void senml_json_decode_single_resource_using_exponantial_notation() {
-        String payload = "[{\"bn\":\"/3/0/13\",\"v\":1.638435E9}]";
-        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, new LwM2mPath("/3/0/13"),
-                model, LwM2mResource.class);
+    @TestAllRootPaths
+    public void senml_json_decode_single_resource_using_exponantial_notation(String rootPath) {
+        String b = "[{\"bn\":\"%%ROOTPATH%%/3/0/13\",\"v\":1.638435E9}]";
+        String payload = addRooPath(b, rootPath);
+
+        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                new LwM2mPath("/3/0/13"), model, LwM2mResource.class);
 
         assertNotNull(resource);
         assertTrue(!resource.isMultiInstances());
@@ -1037,12 +1072,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(new Date(1638435000000l), resource.getValue());
     }
 
-    @Test
-    public void senml_json_decode_multiple_resource() {
-        StringBuilder payload = new StringBuilder();
-        payload.append("[{\"bn\":\"/3/0/7/\",\"n\":\"0\",\"v\":3800},");
-        payload.append("{\"n\":\"1\",\"v\":5000}]");
-        LwM2mResource multipleResources = decoder.decode(payload.toString().getBytes(), ContentFormat.SENML_JSON,
+    @TestAllRootPaths
+    public void senml_json_decode_multiple_resource(String rootPath) {
+        StringBuilder b = new StringBuilder();
+        b.append("[{\"bn\":\"%%ROOTPATH%%/3/0/7/\",\"n\":\"0\",\"v\":3800},");
+        b.append("{\"n\":\"1\",\"v\":5000}]");
+        String payload = addRooPath(b.toString(), rootPath);
+
+        LwM2mResource multipleResources = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
                 new LwM2mPath("/3/0/7"), model, LwM2mResource.class);
 
         assertNotNull(multipleResources);
@@ -1051,12 +1088,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(5000l, multipleResources.getValue(1));
     }
 
-    @Test
-    public void senml_json_decode_ulong() {
+    @TestAllRootPaths
+    public void senml_json_decode_ulong(String rootPath) {
         // 18446744073709551615 can not hold in Long
-        String payload = "[{\"n\":\"/0/0/16\",\"v\":18446744073709551615}]";
-        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, new LwM2mPath("/0/0/16"),
-                model, LwM2mResource.class);
+        String b = "[{\"n\":\"%%ROOTPATH%%/0/0/16\",\"v\":18446744073709551615}]";
+        String payload = addRooPath(b, rootPath);
+
+        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                new LwM2mPath("/0/0/16"), model, LwM2mResource.class);
 
         assertNotNull(resource);
         assertTrue(!resource.isMultiInstances());
@@ -1064,12 +1103,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(ULong.valueOf("18446744073709551615"), resource.getValue());
     }
 
-    @Test
-    public void senml_json_decode_long() {
+    @TestAllRootPaths
+    public void senml_json_decode_long(String rootPath) {
         // 9223372036854775800 long value can not hold in double (will be approximate to 9223372036854775808)
-        String payload = "[{\"n\":\"/1/0/2\",\"v\":9223372036854775800}]";
-        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, new LwM2mPath("/1/0/2"),
-                model, LwM2mResource.class);
+        String b = "[{\"n\":\"%%ROOTPATH%%/1/0/2\",\"v\":9223372036854775800}]";
+        String payload = addRooPath(b, rootPath);
+
+        LwM2mResource resource = decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                new LwM2mPath("/1/0/2"), model, LwM2mResource.class);
 
         assertNotNull(resource);
         assertTrue(!resource.isMultiInstances());
@@ -1077,13 +1118,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(9223372036854775800l, resource.getValue());
     }
 
-    @Test
-    public void senml_json_empty_multi_resource() {
+    @TestAllRootPaths
+    public void senml_json_empty_multi_resource(String rootPath) {
         // see : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/494
 
         // empty byte array
         LwM2mResource resource = null;
-        resource = (LwM2mResource) decoder.decode(new byte[0], ContentFormat.SENML_JSON, new LwM2mPath(3, 0, 6), model);
+        resource = (LwM2mResource) decoder.decode(new byte[0], ContentFormat.SENML_JSON, rootPath,
+                new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
@@ -1093,7 +1135,7 @@ public class LwM2mNodeDecoderTest {
         resource = null;
         StringBuilder b = new StringBuilder();
         b.append("");
-        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.SENML_JSON,
+        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.SENML_JSON, rootPath,
                 new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
@@ -1103,7 +1145,7 @@ public class LwM2mNodeDecoderTest {
         // empty Array
         b = new StringBuilder();
         b.append("[]");
-        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.SENML_JSON,
+        resource = (LwM2mResource) decoder.decode(b.toString().getBytes(), ContentFormat.SENML_JSON, rootPath,
                 new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
@@ -1111,16 +1153,17 @@ public class LwM2mNodeDecoderTest {
         assertTrue(resource.getInstances().isEmpty());
     }
 
-    @Test
-    public void senml_timestamped_resources() throws CodecException {
+    @TestAllRootPaths
+    public void senml_timestamped_resources(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/1024/0/1\",\"v\":22.9,\"bt\":268500000},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/1024/0/1\",\"v\":22.9,\"bt\":268500000},");
         b.append("{\"v\":22.4,\"t\":-5},");
         b.append("{\"v\":24.1,\"t\":-50}],");
+        String payload = addRooPath(b.toString(), rootPath);
 
-        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.SENML_JSON, new LwM2mPath(1024, 0, 1), model);
+        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(payload.getBytes(),
+                ContentFormat.SENML_JSON, rootPath, new LwM2mPath(1024, 0, 1), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(268500000), timestampedResources.get(0).getTimestamp());
@@ -1131,25 +1174,26 @@ public class LwM2mNodeDecoderTest {
         assertEquals(24.1d, ((LwM2mResource) timestampedResources.get(2).getNode()).getValue());
     }
 
-    @Test
-    public void senml_timestamped_resources_with_several_bn() throws CodecException {
+    @TestAllRootPaths
+    public void senml_timestamped_resources_with_several_bn(String rootPath) throws CodecException {
         // given
         StringBuilder b = new StringBuilder();
         b.append("[");
-        b.append("{\"bn\": \"/3303/0/5700\",");
+        b.append("{\"bn\": \"%%ROOTPATH%%/3303/0/5700\",");
         b.append("\"bt\": 1699877805.766,");
         b.append("\"v\": -128.8");
         b.append("},");
-        b.append("{\"bn\": \"/6/0/0\",");
+        b.append("{\"bn\": \"%%ROOTPATH%%/6/0/0\",");
         b.append("\"t\": 0.101,");
         b.append("\"v\": -39.0");
         b.append("}");
         b.append("]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // when
         Instant baseInstant = Instant.ofEpochSecond(1699877805, 766 * 1000000);
-        TimestampedLwM2mNodes timestampedLwM2mNodes = decoder.decodeTimestampedNodes(b.toString().getBytes(),
-                ContentFormat.SENML_JSON, null, model);
+        TimestampedLwM2mNodes timestampedLwM2mNodes = decoder.decodeTimestampedNodes(payload.getBytes(),
+                ContentFormat.SENML_JSON, rootPath, null, model);
         LwM2mSingleResource resource3303 = (LwM2mSingleResource) timestampedLwM2mNodes.getNodesAt(baseInstant)
                 .get(new LwM2mPath("/3303/0/5700"));
         LwM2mSingleResource resource600 = (LwM2mSingleResource) timestampedLwM2mNodes
@@ -1168,17 +1212,18 @@ public class LwM2mNodeDecoderTest {
         assertEquals(Type.FLOAT, resource600.getType());
     }
 
-    @Test
-    public void senml_timestamped_instances() throws CodecException {
+    @TestAllRootPaths
+    public void senml_timestamped_instances(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/1024/0/\",\"bt\":268600000, \"n\":\"1\", \"v\":22.9},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/1024/0/\",\"bt\":268600000, \"n\":\"1\", \"v\":22.9},");
         b.append("{\"n\":\"1\",\"v\":24.1,\"t\":-50},");
         b.append("{\"bt\":268500000, \"n\":\"0\",\"vs\":\"a string\"},");
         b.append("{\"n\":\"1\",\"v\":22.4}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
-        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.SENML_JSON, new LwM2mPath(1024, 0), model);
+        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(payload.getBytes(),
+                ContentFormat.SENML_JSON, rootPath, new LwM2mPath(1024, 0), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(268600000), timestampedResources.get(0).getTimestamp());
@@ -1194,17 +1239,18 @@ public class LwM2mNodeDecoderTest {
 
     }
 
-    @Test
-    public void senml_timestamped_Object() throws CodecException {
+    @TestAllRootPaths
+    public void senml_timestamped_Object(String rootPath) throws CodecException {
         // json content for instance 0 of device object
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/1024/\",\"bt\":268600000,\"n\":\"0/1\",\"v\":22.9},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/1024/\",\"bt\":268600000,\"n\":\"0/1\",\"v\":22.9},");
         b.append("{\"n\":\"0/0\",\"vs\":\"a string\",\"t\":-50},");
         b.append("{\"n\":\"1/1\",\"v\":23,\"t\":-50},");
         b.append("{\"n\":\"0/1\",\"v\":24.1,\"t\":-5}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
-        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(b.toString().getBytes(),
-                ContentFormat.SENML_JSON, new LwM2mPath(1024), model);
+        List<TimestampedLwM2mNode> timestampedResources = decoder.decodeTimestampedData(payload.getBytes(),
+                ContentFormat.SENML_JSON, rootPath, new LwM2mPath(1024), model);
 
         assertEquals(3, timestampedResources.size());
         assertEquals(Instant.ofEpochSecond(268600000), timestampedResources.get(0).getTimestamp());
@@ -1222,18 +1268,20 @@ public class LwM2mNodeDecoderTest {
                 ((LwM2mObject) timestampedResources.get(2).getNode()).getInstance(0).getResource(0).getValue());
     }
 
-    @Test
-    public void senml_json_decode_resources() {
+    @TestAllRootPaths
+    public void senml_json_decode_resources(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/3/0/0\",\"vs\":\"Open Mobile Alliance\"},");
-        b.append("{\"bn\":\"/3/0/9\",\"v\":95},");
-        b.append("{\"bn\":\"/1/0/1\",\"v\":86400}]");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/3/0/0\",\"vs\":\"Open Mobile Alliance\"},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/3/0/9\",\"v\":95},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/1/0/1\",\"v\":86400}]");
+        String payload = addRooPath(b.toString(), rootPath);
+
         List<LwM2mPath> paths = Arrays.asList(new LwM2mPath("3/0/0"), new LwM2mPath("3/0/9"), new LwM2mPath("1/0/1"));
 
         // Decode
-        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(b.toString().getBytes(), ContentFormat.SENML_JSON, paths,
-                model);
+        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                paths, model);
 
         // Expected result
         Map<LwM2mPath, LwM2mNode> nodes = new HashMap<>();
@@ -1244,23 +1292,24 @@ public class LwM2mNodeDecoderTest {
         assertEquals(nodes, res);
     }
 
-    @Test
-    public void senml_json_decode_mixed_resource_and_instance() {
+    @TestAllRootPaths
+    public void senml_json_decode_mixed_resource_and_instance(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/0\",\"v\":45},");
-        b.append("{\"bn\":\"/4/0/1\",\"v\":30},");
-        b.append("{\"bn\":\"/4/0/2\",\"v\":100},");
-        b.append("{\"bn\":\"/6/0/\",\"n\":\"0\",\"v\":43.918998},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/0\",\"v\":45},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/4/0/1\",\"v\":30},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/4/0/2\",\"v\":100},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/6/0/\",\"n\":\"0\",\"v\":43.918998},");
         b.append("{\"n\":\"1\",\"v\":2.351149},");
         b.append("{\"n\":\"5\",\"v\":1610029880}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         List<LwM2mPath> paths = Arrays.asList(new LwM2mPath("4/0/0"), new LwM2mPath("4/0/1"), new LwM2mPath("4/0/2"),
                 new LwM2mPath("6/0"));
 
         // Decode
-        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(b.toString().getBytes(), ContentFormat.SENML_JSON, paths,
-                model);
+        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                paths, model);
 
         // Expected result
         Map<LwM2mPath, LwM2mNode> nodes = new HashMap<>();
@@ -1275,20 +1324,21 @@ public class LwM2mNodeDecoderTest {
         assertEquals(nodes, res);
     }
 
-    @Test
-    public void senml_json_decode_mixed_resource_without_given_path() {
+    @TestAllRootPaths
+    public void senml_json_decode_mixed_resource_without_given_path(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/0\",\"v\":45},");
-        b.append("{\"bn\":\"/4/0/1\",\"v\":30},");
-        b.append("{\"bn\":\"/4/0/2\",\"v\":100},");
-        b.append("{\"bn\":\"/6/0/\",\"n\":\"0\",\"v\":43.918998},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/0\",\"v\":45},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/4/0/1\",\"v\":30},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/4/0/2\",\"v\":100},");
+        b.append("{\"bn\":\"%%ROOTPATH%%/6/0/\",\"n\":\"0\",\"v\":43.918998},");
         b.append("{\"n\":\"1\",\"v\":2.351149},");
         b.append("{\"n\":\"5\",\"v\":1610029880}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // Decode
-        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(b.toString().getBytes(), ContentFormat.SENML_JSON, null,
-                model);
+        Map<LwM2mPath, LwM2mNode> res = decoder.decodeNodes(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
+                null, model);
 
         // Expected result
         Map<LwM2mPath, LwM2mNode> nodes = new HashMap<>();
@@ -1302,16 +1352,17 @@ public class LwM2mNodeDecoderTest {
         assertEquals(nodes, res);
     }
 
-    @Test
-    public void senml_json_decode_path_using_name() {
+    @TestAllRootPaths
+    public void senml_json_decode_path_using_name(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"n\":\"/4/0/0\"},");
-        b.append("{\"n\":\"/4/0/1\"},");
-        b.append("{\"n\":\"/4/0/2\"}]");
+        b.append("[{\"n\":\"%%ROOTPATH%%/4/0/0\"},");
+        b.append("{\"n\":\"%%ROOTPATH%%/4/0/1\"},");
+        b.append("{\"n\":\"%%ROOTPATH%%/4/0/2\"}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // Decode
-        List<LwM2mPath> res = decoder.decodePaths(b.toString().getBytes(), ContentFormat.SENML_JSON);
+        List<LwM2mPath> res = decoder.decodePaths(payload.getBytes(), ContentFormat.SENML_JSON, rootPath);
 
         // Expected result
         List<LwM2mPath> paths = Arrays.asList( //
@@ -1322,16 +1373,17 @@ public class LwM2mNodeDecoderTest {
         assertEquals(paths, res);
     }
 
-    @Test
-    public void senml_json_decode_path_using_base_name() {
+    @TestAllRootPaths
+    public void senml_json_decode_path_using_base_name(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/\", \"n\":\"0\"},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/\", \"n\":\"0\"},");
         b.append("{\"n\":\"1\"},");
         b.append("{\"n\":\"2\"}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // Decode
-        List<LwM2mPath> res = decoder.decodePaths(b.toString().getBytes(), ContentFormat.SENML_JSON);
+        List<LwM2mPath> res = decoder.decodePaths(payload.getBytes(), ContentFormat.SENML_JSON, rootPath);
 
         // Expected result
         List<LwM2mPath> paths = Arrays.asList( //
@@ -1342,38 +1394,41 @@ public class LwM2mNodeDecoderTest {
         assertEquals(paths, res);
     }
 
-    @Test
-    public void senml_json_decode_invalid_path_with_value() {
+    @TestAllRootPaths
+    public void senml_json_decode_invalid_path_with_value(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/\", \"n\":\"0\"},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/\", \"n\":\"0\"},");
         b.append("{\"n\":\"1\", \"v\":200},");
         b.append("{\"n\":\"2\"}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // Decode
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decodePaths(b.toString().getBytes(), ContentFormat.SENML_JSON);
+            decoder.decodePaths(payload.getBytes(), ContentFormat.SENML_JSON, rootPath);
         });
     }
 
-    @Test
-    public void senml_json_decode_invalid_path_with_timestamp() {
+    @TestAllRootPaths
+    public void senml_json_decode_invalid_path_with_timestamp(String rootPath) {
         // Prepare data to decode
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/\", \"n\":\"0\"},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/\", \"n\":\"0\"},");
         b.append("{\"n\":\"1\", \"t\":20000000},");
         b.append("{\"n\":\"2\"}]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // Decode
         assertThrowsExactly(CodecException.class, () -> {
-            decoder.decodePaths(b.toString().getBytes(), ContentFormat.SENML_JSON);
+            decoder.decodePaths(payload.getBytes(), ContentFormat.SENML_JSON, rootPath);
         });
     }
 
-    @Test
-    public void senml_json_decode_opaque_resource() {
-        byte[] json = "[{\"bn\":\"/0/0/3\",\"vd\":\"q83v\"}]".getBytes(); // q83v is base64 of ABCDE
-        LwM2mResource oResource = (LwM2mResource) decoder.decode(json, ContentFormat.SENML_JSON,
+    @TestAllRootPaths
+    public void senml_json_decode_opaque_resource(String rootPath) {
+        String b = "[{\"bn\":\"%%ROOTPATH%%/0/0/3\",\"vd\":\"q83v\"}]"; // q83v is base64 of ABCDE
+        String payload = addRooPath(b, rootPath);
+        LwM2mResource oResource = (LwM2mResource) decoder.decode(payload.getBytes(), ContentFormat.SENML_JSON, rootPath,
                 new LwM2mPath("/0/0/3"), model);
 
         byte[] bytes = Hex.decodeHex("ABCDEF".toCharArray());
@@ -1384,9 +1439,11 @@ public class LwM2mNodeDecoderTest {
 
     @Test
     public void senml_cbor_decode_opaque_resource() {
+        // TODO we should test root path too but not so easy
+
         // value : [{-2: "/0/0/3", 8: h'ABCDEF'}]
         byte[] cbor = Hex.decodeHex("81a221662f302f302f330843abcdef".toCharArray());
-        LwM2mResource oResource = (LwM2mResource) decoder.decode(cbor, ContentFormat.SENML_CBOR,
+        LwM2mResource oResource = (LwM2mResource) decoder.decode(cbor, ContentFormat.SENML_CBOR, null,
                 new LwM2mPath("/0/0/3"), model);
 
         byte[] bytes = Hex.decodeHex("ABCDEF".toCharArray());
@@ -1395,13 +1452,14 @@ public class LwM2mNodeDecoderTest {
         assertEquals(expected, oResource);
     }
 
-    @Test
-    public void senml_cbor_empty_multi_resource() {
+    @TestAllRootPaths
+    public void senml_cbor_empty_multi_resource(String rootPath) {
         // see : https://github.com/OpenMobileAlliance/OMA_LwM2M_for_Developers/issues/494
 
         // empty byte array
         LwM2mResource resource = null;
-        resource = (LwM2mResource) decoder.decode(new byte[0], ContentFormat.SENML_CBOR, new LwM2mPath(3, 0, 6), model);
+        resource = (LwM2mResource) decoder.decode(new byte[0], ContentFormat.SENML_CBOR, rootPath,
+                new LwM2mPath(3, 0, 6), model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
@@ -1410,26 +1468,28 @@ public class LwM2mNodeDecoderTest {
         // empty Array
         // value : []
         byte[] cbor = Hex.decodeHex("80".toCharArray());
-        resource = (LwM2mResource) decoder.decode(cbor, ContentFormat.SENML_CBOR, new LwM2mPath(3, 0, 6), model);
+        resource = (LwM2mResource) decoder.decode(cbor, ContentFormat.SENML_CBOR, rootPath, new LwM2mPath(3, 0, 6),
+                model);
         assertNotNull(resource);
         assertTrue(resource instanceof LwM2mMultipleResource);
         assertEquals(6, resource.getId());
         assertTrue(resource.getInstances().isEmpty());
     }
 
-    @Test
-    public void senml_multiple_timestamped_nodes() throws CodecException {
+    @TestAllRootPaths
+    public void senml_multiple_timestamped_nodes(String rootPath) throws CodecException {
         // given
         StringBuilder b = new StringBuilder();
-        b.append("[{\"bn\":\"/4/0/\",\"bt\":268600000,\"n\":\"0\",\"v\":1,\"t\":1},");
+        b.append("[{\"bn\":\"%%ROOTPATH%%/4/0/\",\"bt\":268600000,\"n\":\"0\",\"v\":1,\"t\":1},");
         b.append("{\"n\":\"1\",\"v\":2,\"t\":2},");
         b.append("{\"n\":\"1\",\"v\":3,\"t\":3},");
-        b.append("{\"bn\":\"/3/0/7/\",\"n\":\"0\",\"v\":3800}");
+        b.append("{\"bn\":\"%%ROOTPATH%%/3/0/7/\",\"n\":\"0\",\"v\":3800}");
         b.append("]");
+        String payload = addRooPath(b.toString(), rootPath);
 
         // when
-        TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(b.toString().getBytes(), ContentFormat.SENML_JSON,
-                null, model);
+        TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(payload.getBytes(), ContentFormat.SENML_JSON,
+                rootPath, null, model);
 
         // then
         Instant timestamp = Instant.ofEpochSecond(268600000);
@@ -1442,4 +1502,21 @@ public class LwM2mNodeDecoderTest {
         assertEquals(expectedResult.build(), data);
     }
 
+    private final String ROOTPATH = "%%ROOTPATH%%";
+
+    private String addRooPath(String payload, String rootPath) {
+        return payload.replace(ROOTPATH, normalizedRootPath(rootPath));
+    }
+
+    protected String normalizedRootPath(String rootPath) {
+        if (rootPath == null)
+            return "";
+        if (rootPath.equals("/")) {
+            return "";
+        }
+        if (rootPath.endsWith("/")) {
+            return rootPath.substring(0, rootPath.length() - 1);
+        }
+        return rootPath;
+    }
 }

--- a/leshan-tl-cf-bsserver-coap/src/main/java/org/eclipse/leshan/transport/californium/bsserver/request/CoapRequestBuilder.java
+++ b/leshan-tl-cf-bsserver-coap/src/main/java/org/eclipse/leshan/transport/californium/bsserver/request/CoapRequestBuilder.java
@@ -68,7 +68,7 @@ public class CoapRequestBuilder implements DownlinkBootstrapRequestVisitor {
         coapRequest.setConfirmable(true);
         ContentFormat format = request.getContentFormat();
         coapRequest.getOptions().setContentFormat(format.getCode());
-        coapRequest.setPayload(encoder.encode(request.getNode(), format, request.getPath(), model));
+        coapRequest.setPayload(encoder.encode(request.getNode(), format, null, request.getPath(), model));
         setURI(coapRequest, request.getPath());
         setSecurityContext(coapRequest);
     }

--- a/leshan-tl-cf-bsserver-coap/src/main/java/org/eclipse/leshan/transport/californium/bsserver/request/LwM2mResponseBuilder.java
+++ b/leshan-tl-cf-bsserver-coap/src/main/java/org/eclipse/leshan/transport/californium/bsserver/request/LwM2mResponseBuilder.java
@@ -186,7 +186,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkBo
 
         // Decode payload
         try {
-            return decoder.decode(coapResponse.getPayload(), contentFormat, path, model);
+            return decoder.decode(coapResponse.getPayload(), contentFormat, null, path, model);
         } catch (CodecException e) {
             if (LOG.isDebugEnabled()) {
                 byte[] payload = coapResponse.getPayload() == null ? new byte[0] : coapResponse.getPayload();

--- a/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/RootResource.java
+++ b/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/RootResource.java
@@ -115,7 +115,7 @@ public class RootResource extends LwM2mClientCoapResource {
             return;
         }
         ContentFormat requestContentFormat = ContentFormat.fromCode(exchange.getRequestOptions().getContentFormat());
-        List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(coapRequest.getPayload(), requestContentFormat);
+        List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(coapRequest.getPayload(), requestContentFormat, null);
 
         if (exchange.getRequestOptions().hasObserve()) {
             // Manage Observe Composite request
@@ -130,7 +130,7 @@ public class RootResource extends LwM2mClientCoapResource {
                 return;
             } else {
                 exchange.respond(toCoapResponseCode(response.getCode()), toolbox.getEncoder()
-                        .encodeNodes(response.getContent(), responseContentFormat, toolbox.getModel()),
+                        .encodeNodes(response.getContent(), responseContentFormat, null, toolbox.getModel()),
                         responseContentFormat.getCode());
                 return;
             }
@@ -146,7 +146,7 @@ public class RootResource extends LwM2mClientCoapResource {
                 // TODO we could maybe face some race condition if an objectEnabler is removed from LwM2mObjectTree
                 // between rootEnabler.read() and rootEnabler.getModel()
                 exchange.respond(toCoapResponseCode(response.getCode()), toolbox.getEncoder()
-                        .encodeNodes(response.getContent(), responseContentFormat, toolbox.getModel()),
+                        .encodeNodes(response.getContent(), responseContentFormat, null, toolbox.getModel()),
                         responseContentFormat.getCode());
             }
             return;
@@ -164,7 +164,7 @@ public class RootResource extends LwM2mClientCoapResource {
 
     @Override
     public void handleIPATCH(CoapExchange exchange) {
-        // Manage Read Composite request
+        // Manage Write Composite request
         Request coapRequest = exchange.advanced().getRequest();
         LwM2mServer server = getServerOrRejectRequest(exchange, coapRequest);
         if (server == null)
@@ -178,7 +178,7 @@ public class RootResource extends LwM2mClientCoapResource {
         }
 
         Map<LwM2mPath, LwM2mNode> nodes = toolbox.getDecoder().decodeNodes(coapRequest.getPayload(), contentFormat,
-                null, toolbox.getModel());
+                null, null, toolbox.getModel());
 
         WriteCompositeResponse response = requestReceiver
                 .requestReceived(server, new WriteCompositeRequest(contentFormat, nodes, coapRequest)).getResponse();

--- a/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/object/ObjectResource.java
+++ b/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/object/ObjectResource.java
@@ -212,7 +212,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
 
                         // send response
                         exchange.respond(ResponseCode.CONTENT,
-                                toolbox.getEncoder().encode(content, format, path, toolbox.getModel()),
+                                toolbox.getEncoder().encode(content, format, null, path, toolbox.getModel()),
                                 format.getCode());
                     } else {
                         exchange.respond(toCoapResponseCode(response.getCode()), response.getErrorMessage());
@@ -235,7 +235,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
                         LwM2mNode content = response.getContent();
                         ContentFormat format = getContentFormat(readRequest, requestedContentFormat);
                         exchange.respond(ResponseCode.CONTENT,
-                                toolbox.getEncoder().encode(content, format, path, toolbox.getModel()),
+                                toolbox.getEncoder().encode(content, format, null, path, toolbox.getModel()),
                                 format.getCode());
                         return;
                     } else {
@@ -251,7 +251,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
                         LwM2mNode content = response.getContent();
                         ContentFormat format = getContentFormat(readRequest, requestedContentFormat);
                         exchange.respond(ResponseCode.CONTENT,
-                                toolbox.getEncoder().encode(content, format, path, toolbox.getModel()),
+                                toolbox.getEncoder().encode(content, format, null, path, toolbox.getModel()),
                                 format.getCode());
                         return;
                     } else {
@@ -275,8 +275,8 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
                             LwM2mNode content = response.getContent();
                             ContentFormat format = getContentFormat(observeRequest, requestedContentFormat);
                             Response coapResponse = new Response(ResponseCode.CONTENT);
-                            coapResponse
-                                    .setPayload(toolbox.getEncoder().encode(content, format, path, toolbox.getModel()));
+                            coapResponse.setPayload(
+                                    toolbox.getEncoder().encode(content, format, null, path, toolbox.getModel()));
                             coapResponse.getOptions().setContentFormat(format.getCode());
                             exchange.respond(coapResponse);
                             return true;
@@ -356,7 +356,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
             }
             LwM2mNode lwM2mNode;
             try {
-                lwM2mNode = toolbox.getDecoder().decode(coapExchange.getRequestPayload(), contentFormat, path,
+                lwM2mNode = toolbox.getDecoder().decode(coapExchange.getRequestPayload(), contentFormat, null, path,
                         toolbox.getModel());
                 if (identity.isLwm2mBootstrapServer()) {
                     BootstrapWriteResponse response = requestReceiver
@@ -434,8 +434,8 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
         // manage partial update of multi-instance resource
         if (path.isResource()) {
             try {
-                LwM2mNode lwM2mNode = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat, path,
-                        toolbox.getModel());
+                LwM2mNode lwM2mNode = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat, null,
+                        path, toolbox.getModel());
                 WriteResponse response = requestReceiver
                         .requestReceived(identity,
                                 new WriteRequest(Mode.UPDATE, contentFormat, URI, lwM2mNode, coapRequest))
@@ -453,8 +453,8 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
         // Manage Update Instance
         if (path.isObjectInstance()) {
             try {
-                LwM2mNode lwM2mNode = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat, path,
-                        toolbox.getModel());
+                LwM2mNode lwM2mNode = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat, null,
+                        path, toolbox.getModel());
                 WriteResponse response = requestReceiver
                         .requestReceived(identity,
                                 new WriteRequest(Mode.UPDATE, contentFormat, URI, lwM2mNode, coapRequest))
@@ -473,7 +473,7 @@ public class ObjectResource extends LwM2mClientCoapResource implements ObjectLis
         // Manage Create Request
         try {
             // decode the payload as an instance
-            LwM2mObject object = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat,
+            LwM2mObject object = toolbox.getDecoder().decode(exchange.getRequestPayload(), contentFormat, null,
                     new LwM2mPath(path.getObjectId()), toolbox.getModel(), LwM2mObject.class);
 
             CreateRequest createRequest;

--- a/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/request/CoapRequestBuilder.java
+++ b/leshan-tl-cf-client-coap/src/main/java/org/eclipse/leshan/transport/californium/client/request/CoapRequestBuilder.java
@@ -166,7 +166,7 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
 
         ContentFormat format = request.getFormat();
         coapRequest.getOptions().setContentFormat(format.getCode());
-        coapRequest.setPayload(encoder.encodeTimestampedNodes(request.getTimestampedNodes(), format, model));
+        coapRequest.setPayload(encoder.encodeTimestampedNodes(request.getTimestampedNodes(), format, null, model));
     }
 
     public Request getRequest() {

--- a/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/ServerCoapMessageTranslator.java
+++ b/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/ServerCoapMessageTranslator.java
@@ -70,7 +70,8 @@ public class ServerCoapMessageTranslator {
             ServerEndpointToolbox toolbox) {
 
         LwM2mResponseBuilder<T> builder = new LwM2mResponseBuilder<T>(coapRequest, coapResponse,
-                clientProfile.getEndpoint(), clientProfile.getModel(), toolbox.getDecoder(), toolbox.getLinkParser());
+                clientProfile.getEndpoint(), clientProfile.getRootPath(), clientProfile.getModel(),
+                toolbox.getDecoder(), toolbox.getLinkParser());
         lwm2mRequest.accept(builder);
         return builder.getResponse();
     }
@@ -104,7 +105,8 @@ public class ServerCoapMessageTranslator {
                             coapResponse);
                 } else {
                     List<TimestampedLwM2mNode> timestampedNodes = toolbox.getDecoder().decodeTimestampedData(
-                            coapResponse.getPayload(), contentFormat, singleObservation.getPath(), profile.getModel());
+                            coapResponse.getPayload(), contentFormat, profile.getRootPath(),
+                            singleObservation.getPath(), profile.getModel());
 
                     // create lwm2m response
                     if (timestampedNodes.size() == 1 && !timestampedNodes.get(0).isTimestamped()) {
@@ -124,8 +126,8 @@ public class ServerCoapMessageTranslator {
                             coapResponse.getPayloadString(), coapResponse);
                 } else {
                     TimestampedLwM2mNodes timestampedNodes = toolbox.getDecoder().decodeTimestampedNodes(
-                            coapResponse.getPayload(), contentFormat, compositeObservation.getPaths(),
-                            profile.getModel());
+                            coapResponse.getPayload(), contentFormat, profile.getRootPath(),
+                            compositeObservation.getPaths(), profile.getModel());
 
                     if (timestampedNodes.getTimestamps().size() == 1
                             && timestampedNodes.getTimestamps().iterator().next() == null) {

--- a/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/request/CoapRequestBuilder.java
+++ b/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/request/CoapRequestBuilder.java
@@ -114,7 +114,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
         coapRequest = request.isReplaceRequest() ? Request.newPut() : Request.newPost();
         ContentFormat format = request.getContentFormat();
         coapRequest.getOptions().setContentFormat(format.getCode());
-        coapRequest.setPayload(encoder.encode(request.getNode(), format, request.getPath(), model));
+        coapRequest.setPayload(encoder.encode(request.getNode(), format, rootPath, request.getPath(), model));
         setURI(coapRequest, request.getPath());
         setSecurityContext(coapRequest);
         applyLowerLayerConfig(coapRequest);
@@ -155,7 +155,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
         } else {
             node = new LwM2mObject(request.getPath().getObjectId(), request.getObjectInstances());
         }
-        coapRequest.setPayload(encoder.encode(node, request.getContentFormat(), request.getPath(), model));
+        coapRequest.setPayload(encoder.encode(node, request.getContentFormat(), rootPath, request.getPath(), model));
         setURI(coapRequest, request.getPath());
         setSecurityContext(coapRequest);
         applyLowerLayerConfig(coapRequest);
@@ -199,7 +199,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
     public void visit(ReadCompositeRequest request) {
         coapRequest = Request.newFetch();
         coapRequest.getOptions().setContentFormat(request.getRequestContentFormat().getCode());
-        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()));
+        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath));
         if (request.getResponseContentFormat() != null)
             coapRequest.getOptions().setAccept(request.getResponseContentFormat().getCode());
         setURI(coapRequest, LwM2mPath.ROOTPATH);
@@ -213,7 +213,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
 
         coapRequest.getOptions().setContentFormat(request.getRequestContentFormat().getCode());
 
-        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()));
+        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath));
 
         if (request.getResponseContentFormat() != null) {
             coapRequest.getOptions().setAccept(request.getResponseContentFormat().getCode());
@@ -235,7 +235,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
         coapRequest.setToken(request.getObservation().getId().getBytes());
 
         coapRequest.getOptions().setContentFormat(request.getRequestContentFormat().getCode());
-        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()));
+        coapRequest.setPayload(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath));
         if (request.getResponseContentFormat() != null) {
             coapRequest.getOptions().setAccept(request.getResponseContentFormat().getCode());
         }
@@ -249,7 +249,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
     public void visit(WriteCompositeRequest request) {
         coapRequest = Request.newIPatch();
         coapRequest.getOptions().setContentFormat(request.getContentFormat().getCode());
-        coapRequest.setPayload(encoder.encodeNodes(request.getNodes(), request.getContentFormat(), model));
+        coapRequest.setPayload(encoder.encodeNodes(request.getNodes(), request.getContentFormat(), rootPath, model));
         setURI(coapRequest, LwM2mPath.ROOTPATH);
         setSecurityContext(coapRequest);
         applyLowerLayerConfig(coapRequest);

--- a/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/request/LwM2mResponseBuilder.java
+++ b/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/request/LwM2mResponseBuilder.java
@@ -91,15 +91,17 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
     private final Request coapRequest;
     private final Response coapResponse;
     private final String clientEndpoint;
+    private final String rootPath;
     private final LwM2mModel model;
     private final LwM2mDecoder decoder;
     private final LwM2mLinkParser linkParser;
 
-    public LwM2mResponseBuilder(Request coapRequest, Response coapResponse, String clientEndpoint, LwM2mModel model,
-            LwM2mDecoder decoder, LwM2mLinkParser linkParser) {
+    public LwM2mResponseBuilder(Request coapRequest, Response coapResponse, String clientEndpoint, String rootPath,
+            LwM2mModel model, LwM2mDecoder decoder, LwM2mLinkParser linkParser) {
         this.coapRequest = coapRequest;
         this.coapResponse = coapResponse;
         this.clientEndpoint = clientEndpoint;
+        this.rootPath = rootPath;
         this.model = model;
         this.decoder = decoder;
         this.linkParser = linkParser;
@@ -378,7 +380,8 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
     private Map<LwM2mPath, LwM2mNode> decodeCompositeCoapResponse(List<LwM2mPath> paths, Response coapResponse,
             LwM2mRequest<?> request, String endpoint) {
         try {
-            return decoder.decodeNodes(coapResponse.getPayload(), getContentFormat(coapResponse), paths, model);
+            return decoder.decodeNodes(coapResponse.getPayload(), getContentFormat(coapResponse), rootPath, paths,
+                    model);
         } catch (CodecException e) {
             handleCodecException(e, request, coapResponse, endpoint);
             return null; // should not happen as handleCodecException raise exception
@@ -388,8 +391,8 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
     private TimestampedLwM2mNodes decodeTimestampedCompositeCoapResponse(List<LwM2mPath> paths, Response coapResponse,
             LwM2mRequest<?> request, String endpoint) {
         try {
-            return decoder.decodeTimestampedNodes(coapResponse.getPayload(), getContentFormat(coapResponse), paths,
-                    model);
+            return decoder.decodeTimestampedNodes(coapResponse.getPayload(), getContentFormat(coapResponse), rootPath,
+                    paths, model);
         } catch (CodecException e) {
             handleCodecException(e, request, coapResponse, endpoint);
             return null; // should not happen as handleCodecException raise exception
@@ -401,7 +404,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
         List<TimestampedLwM2mNode> timestampedNodes = null;
         try {
             timestampedNodes = decoder.decodeTimestampedData(coapResponse.getPayload(), getContentFormat(coapResponse),
-                    path, model);
+                    rootPath, path, model);
             if (timestampedNodes.size() != 1) {
                 throw new InvalidResponseException(
                         "Unable to decode response payload of request [%s] from client [%s] : should receive only 1 timestamped node but received %s",

--- a/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/send/SendResource.java
+++ b/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/send/SendResource.java
@@ -78,8 +78,8 @@ public class SendResource extends LwM2mCoapResource {
                 return;
             }
 
-            TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(payload, contentFormat, null,
-                    clientProfile.getModel());
+            TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(payload, contentFormat,
+                    clientProfile.getRootPath(), null, clientProfile.getModel());
 
             // Handle "send op request
             SendRequest sendRequest = new SendRequest(contentFormat, data, coapRequest);

--- a/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/DummyDecoder.java
+++ b/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/DummyDecoder.java
@@ -33,32 +33,32 @@ import org.eclipse.leshan.core.request.ContentFormat;
 
 public class DummyDecoder implements LwM2mDecoder {
     @Override
-    public LwM2mNode decode(byte[] content, ContentFormat format, LwM2mPath path, LwM2mModel model)
+    public LwM2mNode decode(byte[] content, ContentFormat format, String rootPath, LwM2mPath path, LwM2mModel model)
             throws CodecException {
         return LwM2mSingleResource.newResource(15, "Example");
     }
 
     @Override
-    public <T extends LwM2mNode> T decode(byte[] content, ContentFormat format, LwM2mPath path, LwM2mModel model,
-            Class<T> nodeClass) throws CodecException {
+    public <T extends LwM2mNode> T decode(byte[] content, ContentFormat format, String rootPath, LwM2mPath path,
+            LwM2mModel model, Class<T> nodeClass) throws CodecException {
         return null;
     }
 
     @Override
-    public Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, ContentFormat format, List<LwM2mPath> paths,
-            LwM2mModel model) throws CodecException {
+    public Map<LwM2mPath, LwM2mNode> decodeNodes(byte[] content, ContentFormat format, String rootPath,
+            List<LwM2mPath> paths, LwM2mModel model) throws CodecException {
         return null;
     }
 
     @Override
-    public List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, ContentFormat format, LwM2mPath path,
-            LwM2mModel model) throws CodecException {
-        return Collections.singletonList(new TimestampedLwM2mNode(null, decode(null, null, null, null)));
+    public List<TimestampedLwM2mNode> decodeTimestampedData(byte[] content, ContentFormat format, String rootPath,
+            LwM2mPath path, LwM2mModel model) throws CodecException {
+        return Collections.singletonList(new TimestampedLwM2mNode(null, decode(null, null, null, null, null)));
     }
 
     @Override
-    public TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, ContentFormat format, List<LwM2mPath> paths,
-            LwM2mModel model) throws CodecException {
+    public TimestampedLwM2mNodes decodeTimestampedNodes(byte[] content, ContentFormat format, String rootPath,
+            List<LwM2mPath> paths, LwM2mModel model) throws CodecException {
         Builder builder = new TimestampedLwM2mNodes.Builder(paths);
         for (LwM2mPath path : paths) {
             builder.put(path, null);
@@ -67,7 +67,7 @@ public class DummyDecoder implements LwM2mDecoder {
     }
 
     @Override
-    public List<LwM2mPath> decodePaths(byte[] content, ContentFormat format) throws CodecException {
+    public List<LwM2mPath> decodePaths(byte[] content, ContentFormat format, String rootPath) throws CodecException {
         return null;
     }
 

--- a/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/request/LwM2mResponseBuilderTest.java
+++ b/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/request/LwM2mResponseBuilderTest.java
@@ -62,7 +62,7 @@ public class LwM2mResponseBuilderTest {
         coapResponse.getOptions().setObserve(1);
 
         LwM2mResponseBuilder<ObserveResponse> responseBuilder = new LwM2mResponseBuilder<>(coapRequest, coapResponse,
-                null, null, decoder, linkParser);
+                null, null, null, decoder, linkParser);
         // when
         responseBuilder.visit(observeRequest);
 
@@ -93,7 +93,7 @@ public class LwM2mResponseBuilderTest {
         coapResponse.getOptions().setObserve(1);
 
         LwM2mResponseBuilder<ObserveCompositeResponse> responseBuilder = new LwM2mResponseBuilder<>(coapRequest,
-                coapResponse, null, null, decoder, linkParser);
+                coapResponse, null, null, null, decoder, linkParser);
         // when
         responseBuilder.visit(observeRequest);
 

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/AbstractJavaCoapClientEndpointsProvider.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/endpoint/AbstractJavaCoapClientEndpointsProvider.java
@@ -118,7 +118,7 @@ public abstract class AbstractJavaCoapClientEndpointsProvider implements LwM2mCl
                     ContentFormat requestContentFormat = ContentFormat
                             .fromCode(observeRequest.options().getContentFormat());
                     List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(observeRequest.getPayload().getBytes(),
-                            requestContentFormat);
+                            requestContentFormat, null);
 
                     // optimization for LWM2M Composite Observe : to not decode LWM2M paths each time
                     TransportContext extendedContext = observeRequest.getTransContext() //

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/CoapRequestBuilder.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/request/CoapRequestBuilder.java
@@ -168,7 +168,7 @@ public class CoapRequestBuilder implements UplinkRequestVisitor {
     @Override
     public void visit(SendRequest request) {
         ContentFormat format = request.getFormat();
-        Opaque payload = Opaque.of(encoder.encodeTimestampedNodes(request.getTimestampedNodes(), format, model));
+        Opaque payload = Opaque.of(encoder.encodeTimestampedNodes(request.getTimestampedNodes(), format, null, model));
 
         coapRequestBuilder = CoapRequest.post("/dp") //
                 .payload(payload) //

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/ObjectResource.java
@@ -189,7 +189,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
                     CompletableFuture<CoapResponse> coapResponse = responseWithPayload( //
                             response.getCode(), //
                             format, //
-                            toolbox.getEncoder().encode(response.getContent(), format, getPath(URI),
+                            toolbox.getEncoder().encode(response.getContent(), format, null, getPath(URI),
                                     toolbox.getModel()));
 
                     // store observation relation if this is not a active observe cancellation
@@ -228,7 +228,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
                         return responseWithPayload( //
                                 response.getCode(), //
                                 format, //
-                                toolbox.getEncoder().encode(response.getContent(), format, getPath(URI),
+                                toolbox.getEncoder().encode(response.getContent(), format, null, getPath(URI),
                                         toolbox.getModel()));
                     } else {
                         return errorMessage(response.getCode(), response.getErrorMessage());
@@ -242,7 +242,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
                         return responseWithPayload( //
                                 response.getCode(), //
                                 format, //
-                                toolbox.getEncoder().encode(response.getContent(), format, getPath(URI),
+                                toolbox.getEncoder().encode(response.getContent(), format, null, getPath(URI),
                                         toolbox.getModel()));
                     } else {
                         return errorMessage(response.getCode(), response.getErrorMessage());
@@ -320,7 +320,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
             }
             LwM2mNode lwM2mNode;
             try {
-                lwM2mNode = toolbox.getDecoder().decode(coapRequest.getPayload().getBytes(), contentFormat, path,
+                lwM2mNode = toolbox.getDecoder().decode(coapRequest.getPayload().getBytes(), contentFormat, null, path,
                         toolbox.getModel());
                 if (identity.isLwm2mBootstrapServer()) {
                     BootstrapWriteResponse response = requestReceiver
@@ -394,7 +394,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
         if (path.isResource()) {
             try {
                 LwM2mNode lwM2mNode = toolbox.getDecoder().decode(coapRequest.getPayload().getBytes(), contentFormat,
-                        path, toolbox.getModel());
+                        null, path, toolbox.getModel());
                 WriteResponse response = requestReceiver
                         .requestReceived(identity,
                                 new WriteRequest(Mode.UPDATE, contentFormat, URI, lwM2mNode, coapRequest))
@@ -412,7 +412,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
         if (path.isObjectInstance()) {
             try {
                 LwM2mNode lwM2mNode = toolbox.getDecoder().decode(coapRequest.getPayload().getBytes(), contentFormat,
-                        path, toolbox.getModel());
+                        null, path, toolbox.getModel());
                 WriteResponse response = requestReceiver
                         .requestReceived(identity,
                                 new WriteRequest(Mode.UPDATE, contentFormat, URI, lwM2mNode, coapRequest))
@@ -431,7 +431,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
         try {
             // decode the payload as an instance
             Opaque payload = coapRequest.getPayload();
-            LwM2mObject object = toolbox.getDecoder().decode(payload.getBytes(), contentFormat,
+            LwM2mObject object = toolbox.getDecoder().decode(payload.getBytes(), contentFormat, null,
                     new LwM2mPath(path.getObjectId()), toolbox.getModel(), LwM2mObject.class);
 
             CreateRequest createRequest;
@@ -508,7 +508,7 @@ public class ObjectResource extends LwM2mClientCoapResource {
                             CompletableFuture<CoapResponse> coapResponse = responseWithPayload( //
                                     response.getCode(), //
                                     format, //
-                                    toolbox.getEncoder().encode(response.getContent(), format,
+                                    toolbox.getEncoder().encode(response.getContent(), format, null,
                                             getPath(coapRequest.options().getUriPath()), toolbox.getModel()));
 
                             // store observation relation

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RootResource.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RootResource.java
@@ -104,7 +104,7 @@ public class RootResource extends LwM2mClientCoapResource {
         }
         ContentFormat requestContentFormat = ContentFormat.fromCode(coapRequest.options().getContentFormat());
         List<LwM2mPath> paths = toolbox.getDecoder().decodePaths(coapRequest.getPayload().getBytes(),
-                requestContentFormat);
+                requestContentFormat, null);
 
         if (coapRequest.options().getObserve() != null) {
             // TODO ideally we would like to to attach paths to the coapRequest to avoid to decode it twice :/
@@ -118,7 +118,7 @@ public class RootResource extends LwM2mClientCoapResource {
                 return responseWithPayload( //
                         response.getCode(), //
                         responseContentFormat, //
-                        toolbox.getEncoder().encodeNodes(response.getContent(), responseContentFormat,
+                        toolbox.getEncoder().encodeNodes(response.getContent(), responseContentFormat, null,
                                 toolbox.getModel()));
             } else {
                 return errorMessage(response.getCode(), response.getErrorMessage());
@@ -133,7 +133,7 @@ public class RootResource extends LwM2mClientCoapResource {
                 return responseWithPayload( //
                         response.getCode(), //
                         responseContentFormat, //
-                        toolbox.getEncoder().encodeNodes(response.getContent(), responseContentFormat,
+                        toolbox.getEncoder().encodeNodes(response.getContent(), responseContentFormat, null,
                                 toolbox.getModel()));
             } else {
                 return errorMessage(response.getCode(), response.getErrorMessage());
@@ -157,7 +157,7 @@ public class RootResource extends LwM2mClientCoapResource {
         }
 
         Map<LwM2mPath, LwM2mNode> nodes = toolbox.getDecoder().decodeNodes(coapRequest.getPayload().getBytes(),
-                contentFormat, null, toolbox.getModel());
+                contentFormat, null, null, toolbox.getModel());
         WriteCompositeResponse response = requestReceiver
                 .requestReceived(identity, new WriteCompositeRequest(contentFormat, nodes, coapRequest)).getResponse();
         if (response.getCode().isError()) {

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ServerCoapMessageTranslator.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/endpoint/ServerCoapMessageTranslator.java
@@ -49,7 +49,8 @@ public class ServerCoapMessageTranslator {
             ServerEndpointToolbox toolbox) {
 
         LwM2mResponseBuilder<T> builder = new LwM2mResponseBuilder<T>(coapResponse, coapRequest,
-                clientProfile.getEndpoint(), clientProfile.getModel(), toolbox.getDecoder(), toolbox.getLinkParser());
+                clientProfile.getEndpoint(), clientProfile.getRootPath(), clientProfile.getModel(),
+                toolbox.getDecoder(), toolbox.getLinkParser());
         lwm2mRequest.accept(builder);
         return builder.getResponse();
     }

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/observation/CoapNotificationReceiver.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/observation/CoapNotificationReceiver.java
@@ -150,8 +150,8 @@ public class CoapNotificationReceiver implements NotificationsReceiver {
 
             ContentFormat contentFormat = ContentFormat.fromCode(coapResponse.options().getContentFormat());
             List<TimestampedLwM2mNode> timestampedNodes = decoder.decodeTimestampedData(
-                    coapResponse.getPayload().getBytes(), contentFormat, singleObservation.getPath(),
-                    profile.getModel());
+                    coapResponse.getPayload().getBytes(), contentFormat, profile.getRootPath(),
+                    singleObservation.getPath(), profile.getModel());
 
             // create lwm2m response
             if (timestampedNodes.size() == 1 && !timestampedNodes.get(0).isTimestamped()) {
@@ -166,8 +166,8 @@ public class CoapNotificationReceiver implements NotificationsReceiver {
 
             ContentFormat contentFormat = ContentFormat.fromCode(coapResponse.options().getContentFormat());
             TimestampedLwM2mNodes timestampedNodes = decoder.decodeTimestampedNodes(
-                    coapResponse.getPayload().getBytes(), contentFormat, compositeObservation.getPaths(),
-                    profile.getModel());
+                    coapResponse.getPayload().getBytes(), contentFormat, profile.getRootPath(),
+                    compositeObservation.getPaths(), profile.getModel());
 
             if (timestampedNodes.getTimestamps().size() == 1
                     && timestampedNodes.getTimestamps().iterator().next() == null) {

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/CoapRequestBuilder.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/CoapRequestBuilder.java
@@ -111,7 +111,7 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
         ContentFormat format = request.getContentFormat();
         coapRequestBuilder //
                 .contentFormat((short) format.getCode()) //
-                .payload(Opaque.of(encoder.encode(request.getNode(), format, request.getPath(), model)));
+                .payload(Opaque.of(encoder.encode(request.getNode(), format, rootPath, request.getPath(), model)));
 
     }
 
@@ -145,7 +145,8 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
 
         coapRequestBuilder = CoapRequest.post(getURI(request.getPath())) //
                 .contentFormat((short) request.getContentFormat().getCode()) //
-                .payload(Opaque.of(encoder.encode(node, request.getContentFormat(), request.getPath(), model)));
+                .payload(Opaque
+                        .of(encoder.encode(node, request.getContentFormat(), rootPath, request.getPath(), model)));
         addDefaultContext(coapRequestBuilder);
     }
 
@@ -196,7 +197,8 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
     public void visit(ReadCompositeRequest request) {
         coapRequestBuilder = CoapRequest.fetch(getURI(LwM2mPath.ROOTPATH)) //
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
-                .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat())));
+                .payload(Opaque
+                        .of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath)));
         addDefaultContext(coapRequestBuilder);
 
         if (request.getResponseContentFormat() != null) {
@@ -208,7 +210,8 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
     public void visit(ObserveCompositeRequest request) {
         coapRequestBuilder = CoapRequest.fetch(getURI(LwM2mPath.ROOTPATH)) //
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
-                .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()))) //
+                .payload(
+                        Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath))) //
                 .observe();
         addDefaultContext(coapRequestBuilder);
 
@@ -234,7 +237,8 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
         coapRequestBuilder = CoapRequest.fetch(getURI(LwM2mPath.ROOTPATH)) //
                 .token(Opaque.of(request.getObservation().getId().getBytes())) //
                 .contentFormat((short) request.getRequestContentFormat().getCode()) //
-                .payload(Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat()))) //
+                .payload(
+                        Opaque.of(encoder.encodePaths(request.getPaths(), request.getRequestContentFormat(), rootPath))) //
                 .deregisterObserve(); //
         addDefaultContext(coapRequestBuilder);
 
@@ -247,7 +251,8 @@ public class CoapRequestBuilder implements DownlinkDeviceManagementRequestVisito
     public void visit(WriteCompositeRequest request) {
         coapRequestBuilder = CoapRequest.iPatch(getURI(LwM2mPath.ROOTPATH)) //
                 .contentFormat((short) request.getContentFormat().getCode()) //
-                .payload(Opaque.of(encoder.encodeNodes(request.getNodes(), request.getContentFormat(), model)));
+                .payload(Opaque
+                        .of(encoder.encodeNodes(request.getNodes(), request.getContentFormat(), rootPath, model)));
         addDefaultContext(coapRequestBuilder);
 
     }

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/LwM2mResponseBuilder.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/request/LwM2mResponseBuilder.java
@@ -91,16 +91,18 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
     private final CoapRequest coapRequest;
 
     private final String clientEndpoint;
+    private final String rootPath;
     private final LwM2mModel model;
     private final LwM2mDecoder decoder;
     private final LwM2mLinkParser linkParser;
 
     public LwM2mResponseBuilder(CoapResponse coapResponse, CoapRequest coapRequest, String clientEndpoint,
-            LwM2mModel model, LwM2mDecoder decoder, LwM2mLinkParser linkParser) {
+            String rootPath, LwM2mModel model, LwM2mDecoder decoder, LwM2mLinkParser linkParser) {
         this.coapResponse = coapResponse;
         this.coapRequest = coapRequest;
 
         this.clientEndpoint = clientEndpoint;
+        this.rootPath = rootPath;
 
         this.model = model;
         this.decoder = decoder;
@@ -492,8 +494,8 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
     private Map<LwM2mPath, LwM2mNode> decodeCompositeCoapResponse(List<LwM2mPath> paths, CoapResponse coapResponse,
             LwM2mRequest<?> request, String endpoint) {
         try {
-            return decoder.decodeNodes(coapResponse.getPayload().getBytes(), getContentFormat(coapResponse), paths,
-                    model);
+            return decoder.decodeNodes(coapResponse.getPayload().getBytes(), getContentFormat(coapResponse), rootPath,
+                    paths, model);
         } catch (CodecException e) {
             handleCodecException(e, request, coapResponse, endpoint);
             return null; // should not happen as handleCodecException raise exception
@@ -504,7 +506,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
             CoapResponse coapResponse, LwM2mRequest<?> request, String endpoint) {
         try {
             return decoder.decodeTimestampedNodes(coapResponse.getPayload().getBytes(), getContentFormat(coapResponse),
-                    paths, model);
+                    rootPath, paths, model);
         } catch (CodecException e) {
             handleCodecException(e, request, coapResponse, endpoint);
             return null; // should not happen as handleCodecException raise exception
@@ -517,7 +519,7 @@ public class LwM2mResponseBuilder<T extends LwM2mResponse> implements DownlinkDe
         try {
 
             timestampedNodes = decoder.decodeTimestampedData(coapResponse.getPayload().getBytes(),
-                    getContentFormat(coapResponse), path, model);
+                    getContentFormat(coapResponse), rootPath, path, model);
             if (timestampedNodes.size() != 1) {
                 throw new InvalidResponseException(
                         "Unable to decode response payload of request [%s] from client [%s] : should receive only 1 timestamped node but received %s",

--- a/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/SendResource.java
+++ b/leshan-tl-jc-server-coap/src/main/java/org/eclipse/leshan/transport/javacoap/server/resource/SendResource.java
@@ -90,8 +90,8 @@ public class SendResource extends LwM2mCoapResource {
                 return errorMessage(ResponseCode.BAD_REQUEST, "Unsupported content format");
             }
 
-            TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(payload, contentFormat, null,
-                    clientProfile.getModel());
+            TimestampedLwM2mNodes data = decoder.decodeTimestampedNodes(payload, contentFormat,
+                    clientProfile.getRootPath(), null, clientProfile.getModel());
 
             // Handle "send op request
             SendRequest sendRequest = new SendRequest(contentFormat, data, coapRequest);


### PR DESCRIPTION
This aims to implement https://github.com/eclipse-leshan/leshan/issues/1438.

That means that when a device use [an alternate path](https://www.openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/HTML-Version/OMA-TS-LightweightM2M_Transport-V1_1_1-20190617-A.html#6-4-1-0-641-Alternate-Path), it MUST be added to path in SenML (JSON or CBOR) payload.

So if alternate path is `/lwm2m`, it will looks like : 
```javascript
[
  { "n":"/lwm2m/3/0/0", "vs":"Open Mobile Alliance" }
]
```

Before this PR, it was : 
```javascript
[
  { "n":"/3/0/0", "vs":"Open Mobile Alliance" }
]
```

(This PR need probably some cleaning before to integrate in `master`)