### PR TITLE
Equals&hashCode fixup

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
@@ -75,14 +75,15 @@ public class WriteCompositeTest {
         Object[][] transports = new Object[][] {
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 { Protocol.COAP, "Californium", "Californium" }, //
-                { Protocol.COAP, "Californium", "java-coap" }, //
-                { Protocol.COAP, "java-coap", "Californium" }, //
-                { Protocol.COAP, "java-coap", "java-coap" }, //
-                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
+                // { Protocol.COAP, "Californium", "java-coap" }, //
+                // { Protocol.COAP, "java-coap", "Californium" }, //
+                // { Protocol.COAP, "java-coap", "java-coap" }, //
+                // { Protocol.COAP_TCP, "java-coap", "java-coap" }
+        };
 
         Object[] contentFormats = new Object[] { //
-                ContentFormat.SENML_JSON, //
-                ContentFormat.SENML_CBOR //
+                ContentFormat.SENML_JSON// , //
+                // ContentFormat.SENML_CBOR //
         };
 
         // for each transport, create 1 test by format.

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/write/WriteCompositeTest.java
@@ -75,15 +75,14 @@ public class WriteCompositeTest {
         Object[][] transports = new Object[][] {
                 // ProtocolUsed - Client Endpoint Provider - Server Endpoint Provider
                 { Protocol.COAP, "Californium", "Californium" }, //
-                // { Protocol.COAP, "Californium", "java-coap" }, //
-                // { Protocol.COAP, "java-coap", "Californium" }, //
-                // { Protocol.COAP, "java-coap", "java-coap" }, //
-                // { Protocol.COAP_TCP, "java-coap", "java-coap" }
-        };
+                { Protocol.COAP, "Californium", "java-coap" }, //
+                { Protocol.COAP, "java-coap", "Californium" }, //
+                { Protocol.COAP, "java-coap", "java-coap" }, //
+                { Protocol.COAP_TCP, "java-coap", "java-coap" } };
 
         Object[] contentFormats = new Object[] { //
-                ContentFormat.SENML_JSON// , //
-                // ContentFormat.SENML_CBOR //
+                ContentFormat.SENML_JSON, //
+                ContentFormat.SENML_CBOR //
         };
 
         // for each transport, create 1 test by format.

--- a/leshan-lwm2m-bsserver/pom.xml
+++ b/leshan-lwm2m-bsserver/pom.xml
@@ -56,9 +56,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-bsserver/pom.xml
+++ b/leshan-lwm2m-bsserver/pom.xml
@@ -56,5 +56,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
+++ b/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
@@ -115,8 +115,10 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
 
         @Override
         public final boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof PskByServer)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof PskByServer))
+                return false;
             PskByServer that = (PskByServer) o;
             return Objects.equals(serverUrl, that.serverUrl) && Objects.equals(identity, that.identity);
         }

--- a/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
+++ b/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
@@ -105,8 +105,8 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
     }
 
     protected static class PskByServer {
-        public String serverUrl;
-        public String identity;
+        public final String serverUrl;
+        public final String identity;
 
         public PskByServer(String serverUrl, String identity) {
             this.serverUrl = serverUrl;

--- a/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
+++ b/leshan-lwm2m-bsserver/src/main/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStore.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.bsserver;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.leshan.bsserver.BootstrapConfig.ServerSecurity;
@@ -113,34 +114,16 @@ public class InMemoryBootstrapConfigStore implements EditableBootstrapConfigStor
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((identity == null) ? 0 : identity.hashCode());
-            result = prime * result + ((serverUrl == null) ? 0 : serverUrl.hashCode());
-            return result;
+        public final boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof PskByServer)) return false;
+            PskByServer that = (PskByServer) o;
+            return Objects.equals(serverUrl, that.serverUrl) && Objects.equals(identity, that.identity);
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            PskByServer other = (PskByServer) obj;
-            if (identity == null) {
-                if (other.identity != null)
-                    return false;
-            } else if (!identity.equals(other.identity))
-                return false;
-            if (serverUrl == null) {
-                if (other.serverUrl != null)
-                    return false;
-            } else if (!serverUrl.equals(other.serverUrl))
-                return false;
-            return true;
+        public final int hashCode() {
+            return Objects.hash(serverUrl, identity);
         }
     }
 }

--- a/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
+++ b/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
@@ -1,12 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.bsserver;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class InMemoryBootstrapConfigStoreTest {
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(InMemoryBootstrapConfigStore.PskByServer.class).suppress(Warning.NONFINAL_FIELDS).verify();
+        EqualsVerifier.forClass(InMemoryBootstrapConfigStore.PskByServer.class).suppress(Warning.NONFINAL_FIELDS)
+                .verify();
     }
 }

--- a/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
+++ b/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
@@ -18,12 +18,10 @@ package org.eclipse.leshan.bsserver;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 class InMemoryBootstrapConfigStoreTest {
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(InMemoryBootstrapConfigStore.PskByServer.class).suppress(Warning.NONFINAL_FIELDS)
-                .verify();
+        EqualsVerifier.forClass(InMemoryBootstrapConfigStore.PskByServer.class).verify();
     }
 }

--- a/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
+++ b/leshan-lwm2m-bsserver/src/test/java/org/eclipse/leshan/bsserver/InMemoryBootstrapConfigStoreTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.bsserver;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class InMemoryBootstrapConfigStoreTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(InMemoryBootstrapConfigStore.PskByServer.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-client/pom.xml
+++ b/leshan-lwm2m-client/pom.xml
@@ -47,9 +47,9 @@ Contributors:
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-client/pom.xml
+++ b/leshan-lwm2m-client/pom.xml
@@ -47,5 +47,9 @@ Contributors:
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
+++ b/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
@@ -128,8 +128,10 @@ public class LwM2mServer {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mServer)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mServer))
+            return false;
         LwM2mServer that = (LwM2mServer) o;
         return Objects.equals(transportData, that.transportData) && Objects.equals(id, that.id) && role == that.role;
     }

--- a/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
+++ b/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.client.servers;
 
 import java.net.URI;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.peer.LwM2mPeer;
 
@@ -126,36 +127,15 @@ public class LwM2mServer {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((transportData == null) ? 0 : transportData.hashCode());
-        result = prime * result + ((role == null) ? 0 : role.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mServer)) return false;
+        LwM2mServer that = (LwM2mServer) o;
+        return Objects.equals(transportData, that.transportData) && Objects.equals(id, that.id) && role == that.role;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mServer other = (LwM2mServer) obj;
-        if (id == null) {
-            if (other.id != null)
-                return false;
-        } else if (!id.equals(other.id))
-            return false;
-        if (transportData == null) {
-            if (other.transportData != null)
-                return false;
-        } else if (!transportData.equals(other.transportData))
-            return false;
-        if (role != other.role)
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(transportData, id, role);
     }
 }

--- a/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
+++ b/leshan-lwm2m-client/src/main/java/org/eclipse/leshan/client/servers/LwM2mServer.java
@@ -30,6 +30,22 @@ public class LwM2mServer {
      */
     public final static LwM2mServer SYSTEM = new LwM2mServer(null, null, Role.SYSTEM, null);
 
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mServer))
+            return false;
+        LwM2mServer that = (LwM2mServer) o;
+        return Objects.equals(transportData, that.transportData) && Objects.equals(id, that.id) && role == that.role
+                && Objects.equals(uri, that.uri);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(transportData, id, role, uri);
+    }
+
     public enum Role {
         /**
          * Indicate internal call. Enables the "system" to read protected resources (e.g. resources of the security
@@ -126,18 +142,4 @@ public class LwM2mServer {
         return null;
     }
 
-    @Override
-    public final boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (!(o instanceof LwM2mServer))
-            return false;
-        LwM2mServer that = (LwM2mServer) o;
-        return Objects.equals(transportData, that.transportData) && Objects.equals(id, that.id) && role == that.role;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(transportData, id, role);
-    }
 }

--- a/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
+++ b/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
@@ -22,6 +22,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 class LwM2mServerTest {
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(LwM2mServer.class).withIgnoredFields("uri").verify();
+        EqualsVerifier.forClass(LwM2mServer.class).verify();
     }
 }

--- a/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
+++ b/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
@@ -1,0 +1,16 @@
+package org.eclipse.leshan.client.servers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+class LwM2mServerTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mServer.class).withIgnoredFields("uri").verify();
+    }
+
+}

--- a/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
+++ b/leshan-lwm2m-client/src/test/java/org/eclipse/leshan/client/servers/LwM2mServerTest.java
@@ -1,8 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.client.servers;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -12,5 +24,4 @@ class LwM2mServerTest {
     public void assertEqualsHashcode() {
         EqualsVerifier.forClass(LwM2mServer.class).withIgnoredFields("uri").verify();
     }
-
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
+import java.util.Objects;
+
 public interface LwM2m {
 
     /**
@@ -64,25 +66,20 @@ public interface LwM2m {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = super.hashCode();
-            result = prime * result + (supported ? 1231 : 1237);
-            return result;
+        public boolean equals(Object o) {
+            if (!(o instanceof LwM2mVersion)) return false;
+            if (!super.equals(o)) return false;
+            LwM2mVersion that = (LwM2mVersion) o;
+            return that.canEqual(this) && supported == that.supported;
+        }
+
+        public boolean canEqual(Object o) {
+            return (o instanceof LwM2mVersion);
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (!super.equals(obj))
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            LwM2mVersion other = (LwM2mVersion) obj;
-            if (supported != other.supported)
-                return false;
-            return true;
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), supported);
         }
     }
 
@@ -169,31 +166,6 @@ public interface LwM2m {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + major;
-            result = prime * result + minor;
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            Version other = (Version) obj;
-            if (major != other.major)
-                return false;
-            if (minor != other.minor)
-                return false;
-            return true;
-        }
-
-        @Override
         public int compareTo(Version other) {
             if (major != other.major)
                 return major - other.major;
@@ -210,6 +182,23 @@ public interface LwM2m {
 
         public boolean newerThan(String version) {
             return newerThan(new Version(version));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Version)) return false;
+            Version that = (Version) o;
+            return that.canEqual(this) && major == that.major && minor == that.minor;
+        }
+
+        public boolean canEqual(Object o) {
+            return (o instanceof Version);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(major, minor);
         }
     }
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -68,6 +68,8 @@ public interface LwM2m {
 
         @Override
         public boolean equals(Object o) {
+            if (this == o)
+                return true;
             if (!(o instanceof LwM2mVersion))
                 return false;
             if (!super.equals(o))

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/LwM2m.java
@@ -22,6 +22,7 @@ public interface LwM2m {
     /**
      * Version of LWM2M specification.
      */
+
     public class LwM2mVersion extends Version {
 
         public static final LwM2mVersion V1_0 = new LwM2mVersion("1.0", true);
@@ -67,8 +68,10 @@ public interface LwM2m {
 
         @Override
         public boolean equals(Object o) {
-            if (!(o instanceof LwM2mVersion)) return false;
-            if (!super.equals(o)) return false;
+            if (!(o instanceof LwM2mVersion))
+                return false;
+            if (!super.equals(o))
+                return false;
             LwM2mVersion that = (LwM2mVersion) o;
             return that.canEqual(this) && supported == that.supported;
         }
@@ -186,8 +189,10 @@ public interface LwM2m {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Version)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof Version))
+                return false;
             Version that = (Version) o;
             return that.canEqual(this) && major == that.major && minor == that.minor;
         }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
@@ -15,9 +15,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.core;
 
-import org.eclipse.leshan.core.util.Validate;
-
 import java.util.Objects;
+
+import org.eclipse.leshan.core.util.Validate;
 
 /**
  * Response codes defined for LWM2M enabler
@@ -148,8 +148,10 @@ public class ResponseCode {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ResponseCode)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ResponseCode))
+            return false;
         ResponseCode that = (ResponseCode) o;
         return code == that.code && Objects.equals(name, that.name);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
@@ -17,6 +17,8 @@ package org.eclipse.leshan.core;
 
 import org.eclipse.leshan.core.util.Validate;
 
+import java.util.Objects;
+
 /**
  * Response codes defined for LWM2M enabler
  */
@@ -145,24 +147,15 @@ public class ResponseCode {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + code;
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ResponseCode)) return false;
+        ResponseCode that = (ResponseCode) o;
+        return code == that.code && Objects.equals(name, that.name);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ResponseCode other = (ResponseCode) obj;
-        if (code != other.code)
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(code, name);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
@@ -87,7 +87,7 @@ public class ResponseCode {
             INTERNAL_SERVER_ERROR };
 
     private final int code;
-    private String name;
+    private final String name;
 
     public ResponseCode(int code, String name) {
         Validate.notNull(name);

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/ResponseCode.java
@@ -86,7 +86,7 @@ public class ResponseCode {
             REQUEST_ENTITY_INCOMPLETE, PRECONDITION_FAILED, REQUEST_ENTITY_TOO_LARGE, UNSUPPORTED_CONTENT_FORMAT,
             INTERNAL_SERVER_ERROR };
 
-    private int code;
+    private final int code;
     private String name;
 
     public ResponseCode(int code, String name) {
@@ -153,11 +153,11 @@ public class ResponseCode {
         if (!(o instanceof ResponseCode))
             return false;
         ResponseCode that = (ResponseCode) o;
-        return code == that.code && Objects.equals(name, that.name);
+        return code == that.code;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(code, name);
+        return Objects.hash(code);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
@@ -59,8 +59,10 @@ public class Protocol {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Protocol)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Protocol))
+            return false;
         Protocol protocol = (Protocol) o;
         return Objects.equals(name, protocol.name);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/endpoint/Protocol.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.endpoint;
 
+import java.util.Objects;
+
 public class Protocol {
 
     public static final Protocol COAP = new Protocol("COAP", "coap");
@@ -42,31 +44,6 @@ public class Protocol {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Protocol other = (Protocol) obj;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return getName();
     }
@@ -78,5 +55,18 @@ public class Protocol {
             }
         }
         return null;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Protocol)) return false;
+        Protocol protocol = (Protocol) o;
+        return Objects.equals(name, protocol.name);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(name);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonArrayEntry.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonArrayEntry.java
@@ -127,21 +127,24 @@ public class JsonArrayEntry {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof JsonArrayEntry)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof JsonArrayEntry))
+            return false;
         JsonArrayEntry that = (JsonArrayEntry) o;
 
         boolean comparablyEqual = (time == null && that.time == null)
-                || (time != null && that.time != null
-                && time.compareTo(that.time) == 0);
+                || (time != null && that.time != null && time.compareTo(that.time) == 0);
 
         return Objects.equals(name, that.name) && Objects.equals(floatValue, that.floatValue)
-                && Objects.equals(booleanValue, that.booleanValue) && Objects.equals(objectLinkValue, that.objectLinkValue)
+                && Objects.equals(booleanValue, that.booleanValue)
+                && Objects.equals(objectLinkValue, that.objectLinkValue)
                 && Objects.equals(stringValue, that.stringValue) && comparablyEqual;
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(name, floatValue, booleanValue, objectLinkValue, stringValue, time != null ? time.stripTrailingZeros() : null);
+        return Objects.hash(name, floatValue, booleanValue, objectLinkValue, stringValue,
+                time != null ? time.stripTrailingZeros() : null);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonArrayEntry.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonArrayEntry.java
@@ -18,6 +18,7 @@
 package org.eclipse.leshan.core.json;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.model.ResourceModel;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -118,65 +119,29 @@ public class JsonArrayEntry {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((booleanValue == null) ? 0 : booleanValue.hashCode());
-        result = prime * result + ((floatValue == null) ? 0 : floatValue.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((objectLinkValue == null) ? 0 : objectLinkValue.hashCode());
-        result = prime * result + ((stringValue == null) ? 0 : stringValue.hashCode());
-        result = prime * result + ((time == null) ? 0 : time.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        JsonArrayEntry other = (JsonArrayEntry) obj;
-        if (booleanValue == null) {
-            if (other.booleanValue != null)
-                return false;
-        } else if (!booleanValue.equals(other.booleanValue))
-            return false;
-        if (floatValue == null) {
-            if (other.floatValue != null)
-                return false;
-        } else if (!floatValue.equals(other.floatValue))
-            return false;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        if (objectLinkValue == null) {
-            if (other.objectLinkValue != null)
-                return false;
-        } else if (!objectLinkValue.equals(other.objectLinkValue))
-            return false;
-        if (stringValue == null) {
-            if (other.stringValue != null)
-                return false;
-        } else if (!stringValue.equals(other.stringValue))
-            return false;
-        if (time == null) {
-            if (other.time != null)
-                return false;
-        } else if (!time.equals(other.time))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format(
                 "JsonArrayEntry [name=%s, floatValue=%s, booleanValue=%s, objectLinkValue=%s, stringValue=%s, time=%s]",
                 name, floatValue, booleanValue, objectLinkValue, stringValue, time);
     }
 
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JsonArrayEntry)) return false;
+        JsonArrayEntry that = (JsonArrayEntry) o;
+
+        boolean comparablyEqual = (time == null && that.time == null)
+                || (time != null && that.time != null
+                && time.compareTo(that.time) == 0);
+
+        return Objects.equals(name, that.name) && Objects.equals(floatValue, that.floatValue)
+                && Objects.equals(booleanValue, that.booleanValue) && Objects.equals(objectLinkValue, that.objectLinkValue)
+                && Objects.equals(stringValue, that.stringValue) && comparablyEqual;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(name, floatValue, booleanValue, objectLinkValue, stringValue, time != null ? time.stripTrailingZeros() : null);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonRootObject.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonRootObject.java
@@ -70,16 +70,16 @@ public class JsonRootObject {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof JsonRootObject)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof JsonRootObject))
+            return false;
         JsonRootObject that = (JsonRootObject) o;
 
         boolean comparablyEqual = (baseTime == null && that.baseTime == null)
-                || (baseTime != null && that.baseTime != null
-                && baseTime.compareTo(that.baseTime) == 0);
+                || (baseTime != null && that.baseTime != null && baseTime.compareTo(that.baseTime) == 0);
 
-        return Objects.equals(baseName, that.baseName) && Objects.equals(jsonArray, that.jsonArray)
-                && comparablyEqual;
+        return Objects.equals(baseName, that.baseName) && Objects.equals(jsonArray, that.jsonArray) && comparablyEqual;
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonRootObject.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/json/JsonRootObject.java
@@ -20,6 +20,7 @@ package org.eclipse.leshan.core.json;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The class representing the JSON format of LWM2M
@@ -62,46 +63,27 @@ public class JsonRootObject {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((baseName == null) ? 0 : baseName.hashCode());
-        result = prime * result + ((baseTime == null) ? 0 : baseTime.hashCode());
-        result = prime * result + ((jsonArray == null) ? 0 : jsonArray.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        JsonRootObject other = (JsonRootObject) obj;
-        if (baseName == null) {
-            if (other.baseName != null)
-                return false;
-        } else if (!baseName.equals(other.baseName))
-            return false;
-        if (baseTime == null) {
-            if (other.baseTime != null)
-                return false;
-        } else if (!baseTime.equals(other.baseTime))
-            return false;
-        if (jsonArray == null) {
-            if (other.jsonArray != null)
-                return false;
-        } else if (!jsonArray.equals(other.jsonArray))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("LwM2mJsonElement [baseName=%s, baseTime=%s, resourceList=%s]", baseName, baseTime,
                 jsonArray);
     }
 
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof JsonRootObject)) return false;
+        JsonRootObject that = (JsonRootObject) o;
+
+        boolean comparablyEqual = (baseTime == null && that.baseTime == null)
+                || (baseTime != null && that.baseTime != null
+                && baseTime.compareTo(that.baseTime) == 0);
+
+        return Objects.equals(baseName, that.baseName) && Objects.equals(jsonArray, that.jsonArray)
+                && comparablyEqual;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(baseName, jsonArray, baseTime != null ? baseTime.stripTrailingZeros() : null);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
@@ -121,6 +121,8 @@ public class Link {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o)
+            return true;
         if (!(o instanceof Link))
             return false;
         Link that = (Link) o;

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
@@ -17,6 +17,7 @@
 package org.eclipse.leshan.core.link;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.link.attributes.AttributeSet;
@@ -119,33 +120,18 @@ public class Link {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
-        result = prime * result + ((uriReference == null) ? 0 : uriReference.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (!(o instanceof Link)) return false;
+        Link that = (Link) o;
+        return that.canEqual(this) && Objects.equals(uriReference, that.uriReference) && Objects.equals(attributes, that.attributes);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof Link);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Link other = (Link) obj;
-        if (attributes == null) {
-            if (other.attributes != null)
-                return false;
-        } else if (!attributes.equals(other.attributes))
-            return false;
-        if (uriReference == null) {
-            if (other.uriReference != null)
-                return false;
-        } else if (!uriReference.equals(other.uriReference))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(uriReference, attributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/Link.java
@@ -121,9 +121,11 @@ public class Link {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Link)) return false;
+        if (!(o instanceof Link))
+            return false;
         Link that = (Link) o;
-        return that.canEqual(this) && Objects.equals(uriReference, that.uriReference) && Objects.equals(attributes, that.attributes);
+        return that.canEqual(this) && Objects.equals(uriReference, that.uriReference)
+                && Objects.equals(attributes, that.attributes);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/AttributeSet.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/AttributeSet.java
@@ -15,9 +15,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
-import org.eclipse.leshan.core.node.LwM2mPath;
-
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * A set of {@link Attribute}
@@ -71,25 +74,6 @@ public class AttributeSet implements Iterable<Attribute> {
     }
 
     @Override
-    public boolean equals(Object o) {
-        boolean result = false;
-        if (o instanceof AttributeSet) {
-            AttributeSet that = (AttributeSet) o;
-            result = that.canEqual(this) && Objects.equals(attributes, that.attributes);
-        }
-        return result;
-    }
-
-    public boolean canEqual(Object o) {
-        return (o instanceof AttributeSet);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(attributes);
-    }
-
-    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         for (Attribute attr : attributes.values()) {
@@ -110,5 +94,24 @@ public class AttributeSet implements Iterable<Attribute> {
 
         }
         return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof AttributeSet))
+            return false;
+        AttributeSet that = (AttributeSet) o;
+        return that.canEqual(this) && Objects.equals(attributes, that.attributes);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof AttributeSet);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(attributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/AttributeSet.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/AttributeSet.java
@@ -15,11 +15,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import org.eclipse.leshan.core.node.LwM2mPath;
+
+import java.util.*;
 
 /**
  * A set of {@link Attribute}
@@ -73,28 +71,22 @@ public class AttributeSet implements Iterable<Attribute> {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (o instanceof AttributeSet) {
+            AttributeSet that = (AttributeSet) o;
+            result = that.canEqual(this) && Objects.equals(attributes, that.attributes);
+        }
         return result;
     }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof AttributeSet);
+    }
+
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AttributeSet other = (AttributeSet) obj;
-        if (attributes == null) {
-            if (other.attributes != null)
-                return false;
-        } else if (!attributes.equals(other.attributes))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hashCode(attributes);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/BaseAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/BaseAttribute.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.eclipse.leshan.core.util.Validate;
@@ -26,8 +27,8 @@ public abstract class BaseAttribute implements Attribute {
 
     private static final Pattern parnamePattern = Pattern.compile("[!#$&+\\-.^_`|~a-zA-Z0-9]+");
 
-    private String name;
-    private Object value;
+    private final String name;
+    private final Object value;
 
     public BaseAttribute(String name, Object value, boolean validate) {
         this.name = name;
@@ -66,38 +67,26 @@ public abstract class BaseAttribute implements Attribute {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((value == null) ? 0 : value.hashCode());
+    public String toString() {
+        return String.format("%s=%s", name, value);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (o instanceof BaseAttribute) {
+            BaseAttribute that = (BaseAttribute) o;
+            result = that.canEqual(this) && Objects.equals(name, that.name) && Objects.equals(value, that.value);
+        }
         return result;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        BaseAttribute other = (BaseAttribute) obj;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+    public boolean canEqual(Object o) {
+        return (o instanceof BaseAttribute);
     }
 
     @Override
-    public String toString() {
-        return String.format("%s=%s", name, value);
+    public int hashCode() {
+        return Objects.hash(name, value);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/BaseAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/BaseAttribute.java
@@ -73,12 +73,12 @@ public abstract class BaseAttribute implements Attribute {
 
     @Override
     public boolean equals(Object o) {
-        boolean result = false;
-        if (o instanceof BaseAttribute) {
-            BaseAttribute that = (BaseAttribute) o;
-            result = that.canEqual(this) && Objects.equals(name, that.name) && Objects.equals(value, that.value);
-        }
-        return result;
+        if (this == o)
+            return true;
+        if (!(o instanceof BaseAttribute))
+            return false;
+        BaseAttribute that = (BaseAttribute) o;
+        return that.canEqual(this) && Objects.equals(name, that.name) && Objects.equals(value, that.value);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/ValuelessAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/ValuelessAttribute.java
@@ -15,9 +15,9 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
-import org.eclipse.leshan.core.util.Validate;
-
 import java.util.Objects;
+
+import org.eclipse.leshan.core.util.Validate;
 
 /**
  * An attribute without value
@@ -63,8 +63,10 @@ public class ValuelessAttribute implements Attribute {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ValuelessAttribute)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ValuelessAttribute))
+            return false;
         ValuelessAttribute that = (ValuelessAttribute) o;
         return Objects.equals(name, that.name);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/ValuelessAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/attributes/ValuelessAttribute.java
@@ -17,12 +17,14 @@ package org.eclipse.leshan.core.link.attributes;
 
 import org.eclipse.leshan.core.util.Validate;
 
+import java.util.Objects;
+
 /**
  * An attribute without value
  */
 public class ValuelessAttribute implements Attribute {
 
-    private String name;
+    private final String name;
 
     public ValuelessAttribute(String name) {
         Validate.notNull(name);
@@ -60,27 +62,15 @@ public class ValuelessAttribute implements Attribute {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ValuelessAttribute)) return false;
+        ValuelessAttribute that = (ValuelessAttribute) o;
+        return Objects.equals(name, that.name);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ValuelessAttribute other = (ValuelessAttribute) obj;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hashCode(name);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/MixedLwM2mLink.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/MixedLwM2mLink.java
@@ -80,9 +80,12 @@ public class MixedLwM2mLink extends Link {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof MixedLwM2mLink)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof MixedLwM2mLink))
+            return false;
+        if (!super.equals(o))
+            return false;
         MixedLwM2mLink that = (MixedLwM2mLink) o;
         return that.canEqual(this) && Objects.equals(path, that.path) && Objects.equals(rootPath, that.rootPath);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/MixedLwM2mLink.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/MixedLwM2mLink.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.link.lwm2m;
 
 import java.util.Collection;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.link.attributes.Attribute;
@@ -31,8 +32,8 @@ import org.eclipse.leshan.core.util.Validate;
  */
 public class MixedLwM2mLink extends Link {
 
-    private LwM2mPath path;
-    private String rootPath;
+    private final LwM2mPath path;
+    private final String rootPath;
 
     public MixedLwM2mLink(String rootPath, LwM2mPath path, Attribute... attributes) {
         this(rootPath, path, new MixedLwM2mAttributeSet(attributes));
@@ -78,33 +79,20 @@ public class MixedLwM2mLink extends Link {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((path == null) ? 0 : path.hashCode());
-        result = prime * result + ((rootPath == null) ? 0 : rootPath.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MixedLwM2mLink)) return false;
+        if (!super.equals(o)) return false;
+        MixedLwM2mLink that = (MixedLwM2mLink) o;
+        return that.canEqual(this) && Objects.equals(path, that.path) && Objects.equals(rootPath, that.rootPath);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof MixedLwM2mLink);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        MixedLwM2mLink other = (MixedLwM2mLink) obj;
-        if (path == null) {
-            if (other.path != null)
-                return false;
-        } else if (!path.equals(other.path))
-            return false;
-        if (rootPath == null) {
-            if (other.rootPath != null)
-                return false;
-        } else if (!rootPath.equals(other.rootPath))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), path, rootPath);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttribute.java
@@ -19,6 +19,8 @@ package org.eclipse.leshan.core.link.lwm2m.attributes;
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.util.Validate;
 
+import java.util.Objects;
+
 /**
  * Represents an LwM2m Attribute that can be attached to an object, instance or resource.
  *
@@ -135,34 +137,15 @@ public class LwM2mAttribute<T> implements Attribute {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((model == null) ? 0 : model.hashCode());
-        result = prime * result + ((value == null) ? 0 : value.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mAttribute)) return false;
+        LwM2mAttribute<?> that = (LwM2mAttribute<?>) o;
+        return Objects.equals(model, that.model) && Objects.equals(value, that.value);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mAttribute<?> other = (LwM2mAttribute<?>) obj;
-        if (model == null) {
-            if (other.model != null)
-                return false;
-        } else if (!model.equals(other.model))
-            return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(model, value);
     }
-
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttribute.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttribute.java
@@ -16,10 +16,10 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link.lwm2m.attributes;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.util.Validate;
-
-import java.util.Objects;
 
 /**
  * Represents an LwM2m Attribute that can be attached to an object, instance or resource.
@@ -138,8 +138,10 @@ public class LwM2mAttribute<T> implements Attribute {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mAttribute)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mAttribute))
+            return false;
         LwM2mAttribute<?> that = (LwM2mAttribute<?>) o;
         return Objects.equals(model, that.model) && Objects.equals(value, that.value);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
@@ -35,8 +35,8 @@ public class LwM2mModelRepository {
     private static final Logger LOG = LoggerFactory.getLogger(LwM2mModelRepository.class);
 
     static class Key implements Comparable<Key> {
-        Integer id;
-        Version version;
+        final Integer id;
+        final Version version;
 
         public Key(Integer id, Version version) {
             this.id = id;

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
@@ -15,7 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.model;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
 
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.node.LwM2mNodeUtil;
@@ -63,8 +67,10 @@ public class LwM2mModelRepository {
 
         @Override
         public final boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Key)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof Key))
+                return false;
             Key that = (Key) o;
             return Objects.equals(id, that.id) && Objects.equals(version, that.version);
         }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class LwM2mModelRepository {
     private static final Logger LOG = LoggerFactory.getLogger(LwM2mModelRepository.class);
 
-    private static class Key implements Comparable<Key> {
+    static class Key implements Comparable<Key> {
         Integer id;
         Version version;
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/model/LwM2mModelRepository.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.model;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.NavigableMap;
-import java.util.TreeMap;
+import java.util.*;
 
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.node.LwM2mNodeUtil;
@@ -60,41 +57,22 @@ public class LwM2mModelRepository {
         }
 
         @Override
-        public int hashCode() {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((id == null) ? 0 : id.hashCode());
-            result = prime * result + ((version == null) ? 0 : version.hashCode());
-            return result;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            Key other = (Key) obj;
-            if (id == null) {
-                if (other.id != null)
-                    return false;
-            } else if (!id.equals(other.id))
-                return false;
-            if (version == null) {
-                if (other.version != null)
-                    return false;
-            } else if (!version.equals(other.version))
-                return false;
-            return true;
-        }
-
-        @Override
         public String toString() {
             return String.format("key[%s/%s]", id, version);
         }
 
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Key)) return false;
+            Key that = (Key) o;
+            return Objects.equals(id, that.id) && Objects.equals(version, that.version);
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(id, version);
+        }
     }
 
     // This map contains all the object models available. Different version could be used.

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mIncompletePath.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mIncompletePath.java
@@ -114,4 +114,8 @@ public class LwM2mIncompletePath extends LwM2mPath {
         }
         return b.toString();
     }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof LwM2mIncompletePath);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
@@ -15,8 +15,16 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.TreeMap;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -254,8 +262,10 @@ public class LwM2mMultipleResource implements LwM2mResource {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mMultipleResource)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mMultipleResource))
+            return false;
         LwM2mMultipleResource that = (LwM2mMultipleResource) o;
         return id == that.id && Objects.equals(instances, that.instances) && type == that.type;
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mMultipleResource.java
@@ -15,15 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
-import java.util.TreeMap;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -227,37 +220,6 @@ public class LwM2mMultipleResource implements LwM2mResource {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + id;
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        result = prime * result + ((instances == null) ? 0 : instances.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mMultipleResource other = (LwM2mMultipleResource) obj;
-        if (id != other.id)
-            return false;
-        if (type != other.type)
-            return false;
-        if (instances == null) {
-            if (other.instances != null)
-                return false;
-        } else if (!instances.equals(other.instances))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("LwM2mMultipleResource [id=%s, values=%s, type=%s]", id, instances, type);
     }
@@ -288,5 +250,18 @@ public class LwM2mMultipleResource implements LwM2mResource {
             }
         }
         return b;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mMultipleResource)) return false;
+        LwM2mMultipleResource that = (LwM2mMultipleResource) o;
+        return id == that.id && Objects.equals(instances, that.instances) && type == that.type;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id, instances, type);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObject.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObject.java
@@ -15,8 +15,14 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.TreeMap;
 
 /**
  * The top level element in the LWM2M resource tree.
@@ -115,8 +121,10 @@ public class LwM2mObject implements LwM2mChildNode {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mObject)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mObject))
+            return false;
         LwM2mObject that = (LwM2mObject) o;
         return id == that.id && Objects.equals(instances, that.instances);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObject.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObject.java
@@ -15,13 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 /**
  * The top level element in the LWM2M resource tree.
@@ -119,37 +114,16 @@ public class LwM2mObject implements LwM2mChildNode {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + id;
-        result = prime * result + ((instances == null) ? 0 : instances.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mObject)) return false;
+        LwM2mObject that = (LwM2mObject) o;
+        return id == that.id && Objects.equals(instances, that.instances);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        LwM2mObject other = (LwM2mObject) obj;
-        if (id != other.id) {
-            return false;
-        }
-        if (instances == null) {
-            if (other.instances != null) {
-                return false;
-            }
-        } else if (!instances.equals(other.instances)) {
-            return false;
-        }
-        return true;
+    public final int hashCode() {
+        return Objects.hash(id, instances);
     }
 
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
@@ -15,8 +15,14 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.TreeMap;
 
 import org.eclipse.leshan.core.node.codec.tlv.LwM2mNodeTlvDecoder;
 import org.eclipse.leshan.core.util.Validate;
@@ -144,8 +150,10 @@ public class LwM2mObjectInstance implements LwM2mChildNode {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mObjectInstance)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mObjectInstance))
+            return false;
         LwM2mObjectInstance that = (LwM2mObjectInstance) o;
         return id == that.id && Objects.equals(resources, that.resources);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mObjectInstance.java
@@ -15,13 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 import org.eclipse.leshan.core.node.codec.tlv.LwM2mNodeTlvDecoder;
 import org.eclipse.leshan.core.util.Validate;
@@ -120,40 +115,6 @@ public class LwM2mObjectInstance implements LwM2mChildNode {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + id;
-        result = prime * result + ((resources == null) ? 0 : resources.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        LwM2mObjectInstance other = (LwM2mObjectInstance) obj;
-        if (id != other.id) {
-            return false;
-        }
-        if (resources == null) {
-            if (other.resources != null) {
-                return false;
-            }
-        } else if (!resources.equals(other.resources)) {
-            return false;
-        }
-        return true;
-    }
-
-    @Override
     public String toPrettyString(LwM2mPath path) {
         return appendPrettyNode(new StringBuilder(), path).toString();
     }
@@ -179,5 +140,18 @@ public class LwM2mObjectInstance implements LwM2mChildNode {
             }
         }
         return b;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mObjectInstance)) return false;
+        LwM2mObjectInstance that = (LwM2mObjectInstance) o;
+        return id == that.id && Objects.equals(resources, that.resources);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id, resources);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
@@ -385,17 +385,19 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mPath other = (LwM2mPath) obj;
-        return Objects.equals(objectId, other.objectId) && Objects.equals(objectInstanceId, other.objectInstanceId)
-                && Objects.equals(resourceId, other.resourceId)
-                && Objects.equals(resourceInstanceId, other.resourceInstanceId);
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (o instanceof LwM2mPath) {
+            LwM2mPath that = (LwM2mPath) o;
+            result = (that.canEqual(this) && Objects.equals(objectId, that.objectId) && Objects.equals(objectInstanceId, that.objectInstanceId)
+                    && Objects.equals(resourceId, that.resourceId)
+                    && Objects.equals(resourceInstanceId, that.resourceInstanceId));
+        }
+        return result;
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof LwM2mPath);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mPath.java
@@ -380,27 +380,6 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(objectId, objectInstanceId, resourceId, resourceInstanceId);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        boolean result = false;
-        if (o instanceof LwM2mPath) {
-            LwM2mPath that = (LwM2mPath) o;
-            result = (that.canEqual(this) && Objects.equals(objectId, that.objectId) && Objects.equals(objectInstanceId, that.objectInstanceId)
-                    && Objects.equals(resourceId, that.resourceId)
-                    && Objects.equals(resourceInstanceId, that.resourceInstanceId));
-        }
-        return result;
-    }
-
-    public boolean canEqual(Object o) {
-        return (o instanceof LwM2mPath);
-    }
-
-    @Override
     public int compareTo(LwM2mPath o) {
         int res = compareInteger(this.objectId, o.objectId);
         if (res != 0 || this.objectId == null)
@@ -490,5 +469,27 @@ public class LwM2mPath implements Comparable<LwM2mPath> {
                 }
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mPath))
+            return false;
+        LwM2mPath that = (LwM2mPath) o;
+        return that.canEqual(this) && Objects.equals(objectId, that.objectId)
+                && Objects.equals(objectInstanceId, that.objectInstanceId)
+                && Objects.equals(resourceId, that.resourceId)
+                && Objects.equals(resourceInstanceId, that.resourceInstanceId);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof LwM2mPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(objectId, objectInstanceId, resourceId, resourceInstanceId);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
@@ -182,7 +182,7 @@ public class LwM2mResourceInstance implements LwM2mChildNode {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         final int prime = 31;
         int result = 1;
         result = prime * result + id;
@@ -200,13 +200,10 @@ public class LwM2mResourceInstance implements LwM2mChildNode {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
+        if (!(obj instanceof LwM2mResourceInstance)) return false;
         LwM2mResourceInstance other = (LwM2mResourceInstance) obj;
         if (id != other.id)
             return false;

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mResourceInstance.java
@@ -203,7 +203,8 @@ public class LwM2mResourceInstance implements LwM2mChildNode {
     public final boolean equals(Object obj) {
         if (this == obj)
             return true;
-        if (!(obj instanceof LwM2mResourceInstance)) return false;
+        if (!(obj instanceof LwM2mResourceInstance))
+            return false;
         LwM2mResourceInstance other = (LwM2mResourceInstance) obj;
         if (id != other.id)
             return false;

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mRoot.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mRoot.java
@@ -15,7 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 public class LwM2mRoot implements LwM2mNode {
     private final Map<Integer, LwM2mObject> objects;
@@ -49,8 +53,10 @@ public class LwM2mRoot implements LwM2mNode {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mRoot)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof LwM2mRoot))
+            return false;
         LwM2mRoot lwM2mRoot = (LwM2mRoot) o;
         return Objects.equals(objects, lwM2mRoot.objects);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mRoot.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mRoot.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class LwM2mRoot implements LwM2mNode {
     private final Map<Integer, LwM2mObject> objects;
@@ -46,32 +43,20 @@ public class LwM2mRoot implements LwM2mNode {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((objects == null) ? 0 : objects.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mRoot other = (LwM2mRoot) obj;
-        if (objects == null) {
-            if (other.objects != null)
-                return false;
-        } else if (!objects.equals(other.objects))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("LwM2mRoot [objects=%s]", objects);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mRoot)) return false;
+        LwM2mRoot lwM2mRoot = (LwM2mRoot) o;
+        return Objects.equals(objects, lwM2mRoot.objects);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(objects);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
@@ -15,7 +15,10 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+import java.util.NoSuchElementException;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -40,6 +43,51 @@ public class LwM2mSingleResource implements LwM2mResource {
         this.id = id;
         this.value = value;
         this.type = type;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof LwM2mSingleResource))
+            return false;
+        LwM2mSingleResource other = (LwM2mSingleResource) obj;
+        if (id != other.id)
+            return false;
+        if (type != other.type)
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else {
+            // Custom equals to handle arrays
+            if (type == Type.OPAQUE) {
+                return Arrays.equals((byte[]) value, (byte[]) other.value);
+            } else if (type == Type.CORELINK) {
+                return Arrays.equals((Link[]) value, (Link[]) other.value);
+            } else {
+                return value.equals(other.value);
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public final int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + id;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+
+        // Custom hashcode to handle arrays
+        if (type == Type.OPAQUE) {
+            result = prime * result + ((value == null) ? 0 : Arrays.hashCode((byte[]) value));
+        } else if (type == Type.CORELINK) {
+            result = prime * result + ((value == null) ? 0 : Arrays.hashCode((Link[]) value));
+        } else {
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+        }
+        return result;
     }
 
     public static LwM2mSingleResource newResource(int id, Object value) {
@@ -265,16 +313,4 @@ public class LwM2mSingleResource implements LwM2mResource {
         return b;
     }
 
-    @Override
-    public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof LwM2mSingleResource)) return false;
-        LwM2mSingleResource that = (LwM2mSingleResource) o;
-        return id == that.id && Objects.equals(value, that.value) && type == that.type;
-    }
-
-    @Override
-    public final int hashCode() {
-        return Objects.hash(id, value, type);
-    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/LwM2mSingleResource.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -243,53 +240,6 @@ public class LwM2mSingleResource implements LwM2mResource {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + id;
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-
-        // Custom hashcode to handle arrays
-        if (type == Type.OPAQUE) {
-            result = prime * result + ((value == null) ? 0 : Arrays.hashCode((byte[]) value));
-        } else if (type == Type.CORELINK) {
-            result = prime * result + ((value == null) ? 0 : Arrays.hashCode((Link[]) value));
-        } else {
-            result = prime * result + ((value == null) ? 0 : value.hashCode());
-        }
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        LwM2mSingleResource other = (LwM2mSingleResource) obj;
-        if (id != other.id)
-            return false;
-        if (type != other.type)
-            return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else {
-            // Custom equals to handle arrays
-            if (type == Type.OPAQUE) {
-                return Arrays.equals((byte[]) value, (byte[]) other.value);
-            } else if (type == Type.CORELINK) {
-                return Arrays.equals((Link[]) value, (Link[]) other.value);
-            } else {
-                return value.equals(other.value);
-            }
-        }
-        return true;
-    }
-
-    @Override
     public String toString() {
         // We don't print OPAQUE value as this could be credentials one.
         // Not ideal but didn't find better way for now.
@@ -313,5 +263,18 @@ public class LwM2mSingleResource implements LwM2mResource {
         LwM2mNodeUtil.valueToPrettyString(b, value, type);
 
         return b;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof LwM2mSingleResource)) return false;
+        LwM2mSingleResource that = (LwM2mSingleResource) o;
+        return id == that.id && Objects.equals(value, that.value) && type == that.type;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id, value, type);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/ObjectLink.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/ObjectLink.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.node;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Validate;
 
@@ -104,32 +105,20 @@ public class ObjectLink {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + objectId;
-        result = prime * result + objectInstanceId;
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ObjectLink other = (ObjectLink) obj;
-        if (objectId != other.objectId)
-            return false;
-        if (objectInstanceId != other.objectInstanceId)
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("/%d/%d", objectId, objectInstanceId);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObjectLink)) return false;
+        ObjectLink that = (ObjectLink) o;
+        return objectId == that.objectId && objectInstanceId == that.objectInstanceId;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(objectId, objectInstanceId);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/ObjectLink.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/ObjectLink.java
@@ -111,8 +111,10 @@ public class ObjectLink {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ObjectLink)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ObjectLink))
+            return false;
         ObjectLink that = (ObjectLink) o;
         return objectId == that.objectId && objectInstanceId == that.objectInstanceId;
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNode.java
@@ -51,8 +51,10 @@ public class TimestampedLwM2mNode {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TimestampedLwM2mNode)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof TimestampedLwM2mNode))
+            return false;
         TimestampedLwM2mNode that = (TimestampedLwM2mNode) o;
         return Objects.equals(timestamp, that.timestamp) && Objects.equals(node, that.node);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNode.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNode.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.node;
 
 import java.time.Instant;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Validate;
 
@@ -44,38 +45,20 @@ public class TimestampedLwM2mNode {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((node == null) ? 0 : node.hashCode());
-        result = prime * result + ((timestamp == null) ? 0 : timestamp.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        TimestampedLwM2mNode other = (TimestampedLwM2mNode) obj;
-        if (node == null) {
-            if (other.node != null)
-                return false;
-        } else if (!node.equals(other.node))
-            return false;
-        if (timestamp == null) {
-            if (other.timestamp != null)
-                return false;
-        } else if (!timestamp.equals(other.timestamp))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("TimestampedLwM2mNode [timestamp=%s, node=%s]", timestamp, node);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TimestampedLwM2mNode)) return false;
+        TimestampedLwM2mNode that = (TimestampedLwM2mNode) o;
+        return Objects.equals(timestamp, that.timestamp) && Objects.equals(node, that.node);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(timestamp, node);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodes.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodes.java
@@ -16,8 +16,16 @@
 package org.eclipse.leshan.core.node;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * A container for nodes {@link LwM2mNode} with path {@link LwM2mPath} and optional timestamp information.
@@ -82,8 +90,10 @@ public class TimestampedLwM2mNodes {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof TimestampedLwM2mNodes)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof TimestampedLwM2mNodes))
+            return false;
         TimestampedLwM2mNodes that = (TimestampedLwM2mNodes) o;
         return Objects.equals(timestampedPathNodesMap, that.timestampedPathNodesMap);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodes.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodes.java
@@ -16,15 +16,8 @@
 package org.eclipse.leshan.core.node;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
-import java.util.TreeMap;
 
 /**
  * A container for nodes {@link LwM2mNode} with path {@link LwM2mPath} and optional timestamp information.
@@ -79,37 +72,25 @@ public class TimestampedLwM2mNodes {
         return String.format("TimestampedLwM2mNodes [%s]", timestampedPathNodesMap);
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((timestampedPathNodesMap == null) ? 0 : timestampedPathNodesMap.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        TimestampedLwM2mNodes other = (TimestampedLwM2mNodes) obj;
-        if (timestampedPathNodesMap == null) {
-            if (other.timestampedPathNodesMap != null)
-                return false;
-        } else if (!timestampedPathNodesMap.equals(other.timestampedPathNodesMap))
-            return false;
-        return true;
-    }
-
     public static Builder builder() {
         return new Builder();
     }
 
     public static Builder builder(List<LwM2mPath> paths) {
         return new Builder(paths);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TimestampedLwM2mNodes)) return false;
+        TimestampedLwM2mNodes that = (TimestampedLwM2mNodes) o;
+        return Objects.equals(timestampedPathNodesMap, that.timestampedPathNodesMap);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(timestampedPathNodesMap);
     }
 
     public static class Builder {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/CompositeObservation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/CompositeObservation.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.core.observation;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
@@ -81,41 +82,25 @@ public class CompositeObservation extends Observation {
                 paths, id, requestContentFormat, responseContentFormat, registrationId, context);
     }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof CompositeObservation);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (!super.equals(o))
+            return false;
+        if (o instanceof CompositeObservation) {
+            CompositeObservation that = (CompositeObservation) o;
+            result = that.canEqual(this) && Objects.equals(paths, that.paths) && Objects.equals(requestContentFormat, that.requestContentFormat) && Objects.equals(responseContentFormat, that.responseContentFormat);
+        }
+        return result;
+
+    }
+
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((paths == null) ? 0 : paths.hashCode());
-        result = prime * result + ((requestContentFormat == null) ? 0 : requestContentFormat.hashCode());
-        result = prime * result + ((responseContentFormat == null) ? 0 : responseContentFormat.hashCode());
-        return result;
+        return Objects.hash(super.hashCode(), paths, requestContentFormat, responseContentFormat);
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CompositeObservation other = (CompositeObservation) obj;
-        if (paths == null) {
-            if (other.paths != null)
-                return false;
-        } else if (!paths.equals(other.paths))
-            return false;
-        if (requestContentFormat == null) {
-            if (other.requestContentFormat != null)
-                return false;
-        } else if (!requestContentFormat.equals(other.requestContentFormat))
-            return false;
-        if (responseContentFormat == null) {
-            if (other.responseContentFormat != null)
-                return false;
-        } else if (!responseContentFormat.equals(other.responseContentFormat))
-            return false;
-        return true;
-    }
-
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/CompositeObservation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/CompositeObservation.java
@@ -82,21 +82,22 @@ public class CompositeObservation extends Observation {
                 paths, id, requestContentFormat, responseContentFormat, registrationId, context);
     }
 
-    public boolean canEqual(Object o) {
-        return (o instanceof CompositeObservation);
-    }
-
     @Override
     public boolean equals(Object o) {
-        boolean result = false;
+        if (this == o)
+            return true;
+        if (!(o instanceof CompositeObservation))
+            return false;
         if (!super.equals(o))
             return false;
-        if (o instanceof CompositeObservation) {
-            CompositeObservation that = (CompositeObservation) o;
-            result = that.canEqual(this) && Objects.equals(paths, that.paths) && Objects.equals(requestContentFormat, that.requestContentFormat) && Objects.equals(responseContentFormat, that.responseContentFormat);
-        }
-        return result;
+        CompositeObservation that = (CompositeObservation) o;
+        return that.canEqual(this) && Objects.equals(paths, that.paths)
+                && Objects.equals(requestContentFormat, that.requestContentFormat)
+                && Objects.equals(responseContentFormat, that.responseContentFormat);
+    }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof CompositeObservation);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
@@ -17,9 +17,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.observation;
 
+import org.eclipse.leshan.core.node.LwM2mPath;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * An abstract class for observation of a resource provided by a LWM2M Client.
@@ -84,39 +87,22 @@ public abstract class Observation {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((context == null) ? 0 : context.hashCode());
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((registrationId == null) ? 0 : registrationId.hashCode());
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (o instanceof Observation) {
+            Observation that = (Observation) o;
+            result = that.canEqual(this) && Objects.equals(id, that.id) && Objects.equals(registrationId, that.registrationId) && Objects.equals(context, that.context) && Objects.equals(protocolData, that.protocolData);
+        };
+
         return result;
     }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof Observation);
+    }
+
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Observation other = (Observation) obj;
-        if (context == null) {
-            if (other.context != null)
-                return false;
-        } else if (!context.equals(other.context))
-            return false;
-        if (id == null) {
-            if (other.id != null)
-                return false;
-        } else if (!id.equals(other.id))
-            return false;
-        if (registrationId == null) {
-            if (other.registrationId != null)
-                return false;
-        } else if (!registrationId.equals(other.registrationId))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(id, registrationId, context, protocolData);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
@@ -17,8 +17,6 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.observation;
 
-import org.eclipse.leshan.core.node.LwM2mPath;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,13 +86,13 @@ public abstract class Observation {
 
     @Override
     public boolean equals(Object o) {
-        boolean result = false;
-        if (o instanceof Observation) {
-            Observation that = (Observation) o;
-            result = that.canEqual(this) && Objects.equals(id, that.id) && Objects.equals(registrationId, that.registrationId) && Objects.equals(context, that.context) && Objects.equals(protocolData, that.protocolData);
-        };
-
-        return result;
+        if (this == o)
+            return true;
+        if (!(o instanceof Observation))
+            return false;
+        Observation that = (Observation) o;
+        return that.canEqual(this) && Objects.equals(id, that.id) && Objects.equals(registrationId, that.registrationId)
+                && Objects.equals(context, that.context) && Objects.equals(protocolData, that.protocolData);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/Observation.java
@@ -92,7 +92,7 @@ public abstract class Observation {
             return false;
         Observation that = (Observation) o;
         return that.canEqual(this) && Objects.equals(id, that.id) && Objects.equals(registrationId, that.registrationId)
-                && Objects.equals(context, that.context) && Objects.equals(protocolData, that.protocolData);
+                && Objects.equals(context, that.context);
     }
 
     public boolean canEqual(Object o) {
@@ -101,6 +101,6 @@ public abstract class Observation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, registrationId, context, protocolData);
+        return Objects.hash(id, registrationId, context);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.observation;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Hex;
 
@@ -52,24 +53,15 @@ public class ObservationIdentifier {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(bytes);
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObservationIdentifier)) return false;
+        ObservationIdentifier that = (ObservationIdentifier) o;
+        return Objects.deepEquals(bytes, that.bytes);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ObservationIdentifier other = (ObservationIdentifier) obj;
-        if (!Arrays.equals(bytes, other.bytes))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Arrays.hashCode(bytes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
@@ -54,8 +54,10 @@ public class ObservationIdentifier {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ObservationIdentifier)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ObservationIdentifier))
+            return false;
         ObservationIdentifier that = (ObservationIdentifier) o;
         return Objects.deepEquals(bytes, that.bytes);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/ObservationIdentifier.java
@@ -16,7 +16,6 @@
 package org.eclipse.leshan.core.observation;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Hex;
 
@@ -59,7 +58,7 @@ public class ObservationIdentifier {
         if (!(o instanceof ObservationIdentifier))
             return false;
         ObservationIdentifier that = (ObservationIdentifier) o;
-        return Objects.deepEquals(bytes, that.bytes);
+        return Arrays.equals(bytes, that.bytes);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/SingleObservation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/SingleObservation.java
@@ -18,6 +18,7 @@
 package org.eclipse.leshan.core.observation;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.ContentFormat;
@@ -72,33 +73,20 @@ public class SingleObservation extends Observation {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((contentFormat == null) ? 0 : contentFormat.hashCode());
-        result = prime * result + ((path == null) ? 0 : path.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SingleObservation)) return false;
+        if (!super.equals(o)) return false;
+        SingleObservation that = (SingleObservation) o;
+        return that.canEqual(this) && Objects.equals(path, that.path) && Objects.equals(contentFormat, that.contentFormat);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof SingleObservation);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SingleObservation other = (SingleObservation) obj;
-        if (contentFormat == null) {
-            if (other.contentFormat != null)
-                return false;
-        } else if (!contentFormat.equals(other.contentFormat))
-            return false;
-        if (path == null) {
-            if (other.path != null)
-                return false;
-        } else if (!path.equals(other.path))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), path, contentFormat);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/SingleObservation.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/observation/SingleObservation.java
@@ -74,11 +74,15 @@ public class SingleObservation extends Observation {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SingleObservation)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SingleObservation))
+            return false;
+        if (!super.equals(o))
+            return false;
         SingleObservation that = (SingleObservation) o;
-        return that.canEqual(this) && Objects.equals(path, that.path) && Objects.equals(contentFormat, that.contentFormat);
+        return that.canEqual(this) && Objects.equals(path, that.path)
+                && Objects.equals(contentFormat, that.contentFormat);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
@@ -115,8 +115,10 @@ public class AeadAlgorithm implements Serializable {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof AeadAlgorithm)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof AeadAlgorithm))
+            return false;
         AeadAlgorithm that = (AeadAlgorithm) o;
         return value == that.value && nonceSize == that.nonceSize && Objects.equals(name, that.name);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/AeadAlgorithm.java
@@ -16,6 +16,7 @@ package org.eclipse.leshan.core.oscore;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.datatype.NumberUtil;
 
@@ -113,33 +114,15 @@ public class AeadAlgorithm implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + nonceSize;
-        result = prime * result + value;
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AeadAlgorithm)) return false;
+        AeadAlgorithm that = (AeadAlgorithm) o;
+        return value == that.value && nonceSize == that.nonceSize && Objects.equals(name, that.name);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AeadAlgorithm other = (AeadAlgorithm) obj;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        if (nonceSize != other.nonceSize)
-            return false;
-        if (value != other.value)
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(name, value, nonceSize);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.core.oscore;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.core.util.Validate;
@@ -99,45 +100,15 @@ public class OscoreSetting implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((aeadAlgorithm == null) ? 0 : aeadAlgorithm.hashCode());
-        result = prime * result + ((hkdfAlgorithm == null) ? 0 : hkdfAlgorithm.hashCode());
-        result = prime * result + Arrays.hashCode(masterSalt);
-        result = prime * result + Arrays.hashCode(masterSecret);
-        result = prime * result + Arrays.hashCode(recipientId);
-        result = prime * result + Arrays.hashCode(senderId);
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OscoreSetting)) return false;
+        OscoreSetting that = (OscoreSetting) o;
+        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId) && Objects.deepEquals(masterSecret, that.masterSecret) && Objects.equals(aeadAlgorithm, that.aeadAlgorithm) && Objects.equals(hkdfAlgorithm, that.hkdfAlgorithm) && Objects.deepEquals(masterSalt, that.masterSalt);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        OscoreSetting other = (OscoreSetting) obj;
-        if (aeadAlgorithm == null) {
-            if (other.aeadAlgorithm != null)
-                return false;
-        } else if (!aeadAlgorithm.equals(other.aeadAlgorithm))
-            return false;
-        if (hkdfAlgorithm == null) {
-            if (other.hkdfAlgorithm != null)
-                return false;
-        } else if (!hkdfAlgorithm.equals(other.hkdfAlgorithm))
-            return false;
-        if (!Arrays.equals(masterSalt, other.masterSalt))
-            return false;
-        if (!Arrays.equals(masterSecret, other.masterSecret))
-            return false;
-        if (!Arrays.equals(recipientId, other.recipientId))
-            return false;
-        if (!Arrays.equals(senderId, other.senderId))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret), aeadAlgorithm, hkdfAlgorithm, Arrays.hashCode(masterSalt));
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
@@ -101,14 +101,20 @@ public class OscoreSetting implements Serializable {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof OscoreSetting)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof OscoreSetting))
+            return false;
         OscoreSetting that = (OscoreSetting) o;
-        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId) && Objects.deepEquals(masterSecret, that.masterSecret) && Objects.equals(aeadAlgorithm, that.aeadAlgorithm) && Objects.equals(hkdfAlgorithm, that.hkdfAlgorithm) && Objects.deepEquals(masterSalt, that.masterSalt);
+        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId)
+                && Objects.deepEquals(masterSecret, that.masterSecret)
+                && Objects.equals(aeadAlgorithm, that.aeadAlgorithm)
+                && Objects.equals(hkdfAlgorithm, that.hkdfAlgorithm) && Objects.deepEquals(masterSalt, that.masterSalt);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret), aeadAlgorithm, hkdfAlgorithm, Arrays.hashCode(masterSalt));
+        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret),
+                aeadAlgorithm, hkdfAlgorithm, Arrays.hashCode(masterSalt));
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/oscore/OscoreSetting.java
@@ -106,10 +106,9 @@ public class OscoreSetting implements Serializable {
         if (!(o instanceof OscoreSetting))
             return false;
         OscoreSetting that = (OscoreSetting) o;
-        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId)
-                && Objects.deepEquals(masterSecret, that.masterSecret)
-                && Objects.equals(aeadAlgorithm, that.aeadAlgorithm)
-                && Objects.equals(hkdfAlgorithm, that.hkdfAlgorithm) && Objects.deepEquals(masterSalt, that.masterSalt);
+        return Arrays.equals(senderId, that.senderId) && Arrays.equals(recipientId, that.recipientId)
+                && Arrays.equals(masterSecret, that.masterSecret) && Objects.equals(aeadAlgorithm, that.aeadAlgorithm)
+                && Objects.equals(hkdfAlgorithm, that.hkdfAlgorithm) && Arrays.equals(masterSalt, that.masterSalt);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/IpPeer.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/IpPeer.java
@@ -84,17 +84,15 @@ public class IpPeer implements LwM2mPeer {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IpPeer)) return false;
         IpPeer ipPeer = (IpPeer) o;
-        return peerAddress.equals(ipPeer.peerAddress) && Objects.equals(identity, ipPeer.identity);
+        return Objects.equals(peerAddress, ipPeer.peerAddress) && Objects.equals(identity, ipPeer.identity);
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() {
         return Objects.hash(peerAddress, identity);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/IpPeer.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/IpPeer.java
@@ -85,8 +85,10 @@ public class IpPeer implements LwM2mPeer {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof IpPeer)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof IpPeer))
+            return false;
         IpPeer ipPeer = (IpPeer) o;
         return Objects.equals(peerAddress, ipPeer.peerAddress) && Objects.equals(identity, ipPeer.identity);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
@@ -47,8 +47,10 @@ public class OscoreIdentity implements LwM2mIdentity {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof OscoreIdentity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof OscoreIdentity))
+            return false;
         OscoreIdentity that = (OscoreIdentity) o;
         return Objects.deepEquals(RecipientId, that.RecipientId);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
@@ -16,7 +16,6 @@
 package org.eclipse.leshan.core.peer;
 
 import java.util.Arrays;
-import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Validate;
 
@@ -52,7 +51,7 @@ public class OscoreIdentity implements LwM2mIdentity {
         if (!(o instanceof OscoreIdentity))
             return false;
         OscoreIdentity that = (OscoreIdentity) o;
-        return Objects.deepEquals(RecipientId, that.RecipientId);
+        return Arrays.equals(RecipientId, that.RecipientId);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/OscoreIdentity.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.peer;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Validate;
 
@@ -45,23 +46,15 @@ public class OscoreIdentity implements LwM2mIdentity {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(RecipientId);
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OscoreIdentity)) return false;
+        OscoreIdentity that = (OscoreIdentity) o;
+        return Objects.deepEquals(RecipientId, that.RecipientId);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        OscoreIdentity other = (OscoreIdentity) obj;
-        return Arrays.equals(RecipientId, other.RecipientId);
+    public final int hashCode() {
+        return Arrays.hashCode(RecipientId);
     }
-
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/PskIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/PskIdentity.java
@@ -44,20 +44,15 @@ public class PskIdentity implements LwM2mIdentity {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((pskIdentity == null) ? 0 : pskIdentity.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PskIdentity)) return false;
+        PskIdentity that = (PskIdentity) o;
+        return Objects.equals(pskIdentity, that.pskIdentity);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        PskIdentity that = (PskIdentity) o;
-        return Objects.equals(pskIdentity, that.pskIdentity);
+    public final int hashCode() {
+        return Objects.hashCode(pskIdentity);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/PskIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/PskIdentity.java
@@ -45,8 +45,10 @@ public class PskIdentity implements LwM2mIdentity {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof PskIdentity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof PskIdentity))
+            return false;
         PskIdentity that = (PskIdentity) o;
         return Objects.equals(pskIdentity, that.pskIdentity);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/RpkIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/RpkIdentity.java
@@ -45,8 +45,10 @@ public class RpkIdentity implements LwM2mIdentity {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RpkIdentity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof RpkIdentity))
+            return false;
         RpkIdentity that = (RpkIdentity) o;
         return Objects.equals(rawPublicKey, that.rawPublicKey);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/RpkIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/RpkIdentity.java
@@ -44,20 +44,15 @@ public class RpkIdentity implements LwM2mIdentity {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RpkIdentity)) return false;
+        RpkIdentity that = (RpkIdentity) o;
+        return Objects.equals(rawPublicKey, that.rawPublicKey);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        RpkIdentity that = (RpkIdentity) o;
-        return Objects.equals(rawPublicKey, that.rawPublicKey);
+    public final int hashCode() {
+        return Objects.hashCode(rawPublicKey);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/SocketIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/SocketIdentity.java
@@ -44,20 +44,15 @@ public class SocketIdentity implements LwM2mIdentity {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((peerAddress == null) ? 0 : peerAddress.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SocketIdentity)) return false;
+        SocketIdentity that = (SocketIdentity) o;
+        return Objects.equals(peerAddress, that.peerAddress);
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        SocketIdentity that = (SocketIdentity) o;
-        return Objects.equals(peerAddress, that.peerAddress);
+    public final int hashCode() {
+        return Objects.hashCode(peerAddress);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/SocketIdentity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/SocketIdentity.java
@@ -45,8 +45,10 @@ public class SocketIdentity implements LwM2mIdentity {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SocketIdentity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SocketIdentity))
+            return false;
         SocketIdentity that = (SocketIdentity) o;
         return Objects.equals(peerAddress, that.peerAddress);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/X509Identity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/X509Identity.java
@@ -45,8 +45,10 @@ public class X509Identity implements LwM2mIdentity {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof X509Identity)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof X509Identity))
+            return false;
         X509Identity that = (X509Identity) o;
         return Objects.equals(x509CommonName, that.x509CommonName);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/X509Identity.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/peer/X509Identity.java
@@ -44,21 +44,15 @@ public class X509Identity implements LwM2mIdentity {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((x509CommonName == null) ? 0 : x509CommonName.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof X509Identity)) return false;
         X509Identity that = (X509Identity) o;
         return Objects.equals(x509CommonName, that.x509CommonName);
     }
 
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(x509CommonName);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequest.java
@@ -15,12 +15,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.LwM2mResponse;
-
-import java.util.Objects;
 
 /**
  * A base class for concrete LWM2M Downlink request types.
@@ -91,12 +91,12 @@ public abstract class AbstractSimpleDownlinkRequest<T extends LwM2mResponse> ext
 
     @Override
     public boolean equals(Object o) {
-        boolean result = false;
-        if (o instanceof AbstractSimpleDownlinkRequest) {
-            AbstractSimpleDownlinkRequest<?> that = (AbstractSimpleDownlinkRequest<?>) o;
-            result = that.canEqual(this) && Objects.equals(path, that.path);
-        }
-        return result;
+        if (this == o)
+            return true;
+        if (!(o instanceof AbstractSimpleDownlinkRequest))
+            return false;
+        AbstractSimpleDownlinkRequest<?> that = (AbstractSimpleDownlinkRequest<?>) o;
+        return that.canEqual(this) && Objects.equals(path, that.path);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequest.java
@@ -20,6 +20,8 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.LwM2mResponse;
 
+import java.util.Objects;
+
 /**
  * A base class for concrete LWM2M Downlink request types.
  *
@@ -44,31 +46,6 @@ public abstract class AbstractSimpleDownlinkRequest<T extends LwM2mResponse> ext
     @Override
     public LwM2mPath getPath() {
         return this.path;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((path == null) ? 0 : path.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        AbstractSimpleDownlinkRequest<?> other = (AbstractSimpleDownlinkRequest<?>) obj;
-        if (path == null) {
-            if (other.path != null)
-                return false;
-        } else if (!path.equals(other.path))
-            return false;
-        return true;
     }
 
     protected static LwM2mPath newPath(Integer objectId) {
@@ -112,4 +89,22 @@ public abstract class AbstractSimpleDownlinkRequest<T extends LwM2mResponse> ext
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        boolean result = false;
+        if (o instanceof AbstractSimpleDownlinkRequest) {
+            AbstractSimpleDownlinkRequest<?> that = (AbstractSimpleDownlinkRequest<?>) o;
+            result = that.canEqual(this) && Objects.equals(path, that.path);
+        }
+        return result;
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof AbstractSimpleDownlinkRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(path);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDeleteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDeleteRequest.java
@@ -99,4 +99,8 @@ public class BootstrapDeleteRequest extends AbstractSimpleDownlinkRequest<Bootst
         return String.format("BootstrapDeleteRequest [%s]", getPath());
     }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof BootstrapDeleteRequest);
+    }
+
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDiscoverRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapDiscoverRequest.java
@@ -87,4 +87,8 @@ public class BootstrapDiscoverRequest extends AbstractSimpleDownlinkRequest<Boot
     public void accept(DownlinkBootstrapRequestVisitor visitor) {
         visitor.visit(this);
     }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof BootstrapDiscoverRequest);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapReadRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapReadRequest.java
@@ -19,6 +19,8 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.BootstrapReadResponse;
 
+import java.util.Objects;
+
 /**
  * A Lightweight M2M request for retrieving the values of resources from a LWM2M Client.
  *
@@ -146,24 +148,20 @@ public class BootstrapReadRequest extends AbstractSimpleDownlinkRequest<Bootstra
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((format == null) ? 0 : format.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BootstrapReadRequest)) return false;
+        if (!super.equals(o)) return false;
+        BootstrapReadRequest that = (BootstrapReadRequest) o;
+        return that.canEqual(this) && Objects.equals(format, that.format);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof BootstrapReadRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        BootstrapReadRequest other = (BootstrapReadRequest) obj;
-        if (format != other.format)
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), format);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapReadRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapReadRequest.java
@@ -15,11 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.BootstrapReadResponse;
-
-import java.util.Objects;
 
 /**
  * A Lightweight M2M request for retrieving the values of resources from a LWM2M Client.
@@ -149,9 +149,12 @@ public class BootstrapReadRequest extends AbstractSimpleDownlinkRequest<Bootstra
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BootstrapReadRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof BootstrapReadRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         BootstrapReadRequest that = (BootstrapReadRequest) o;
         return that.canEqual(this) && Objects.equals(format, that.format);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapRequest.java
@@ -107,10 +107,14 @@ public class BootstrapRequest extends AbstractLwM2mRequest<BootstrapResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof BootstrapRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof BootstrapRequest))
+            return false;
         BootstrapRequest that = (BootstrapRequest) o;
-        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName) && Objects.equals(additionalAttributes, that.additionalAttributes) && Objects.equals(preferredContentFormat, that.preferredContentFormat);
+        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName)
+                && Objects.equals(additionalAttributes, that.additionalAttributes)
+                && Objects.equals(preferredContentFormat, that.preferredContentFormat);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapRequest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.core.request;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.BootstrapResponse;
@@ -105,39 +106,19 @@ public class BootstrapRequest extends AbstractLwM2mRequest<BootstrapResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((additionalAttributes == null) ? 0 : additionalAttributes.hashCode());
-        result = prime * result + ((endpointName == null) ? 0 : endpointName.hashCode());
-        result = prime * result + ((preferredContentFormat == null) ? 0 : preferredContentFormat.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BootstrapRequest)) return false;
+        BootstrapRequest that = (BootstrapRequest) o;
+        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName) && Objects.equals(additionalAttributes, that.additionalAttributes) && Objects.equals(preferredContentFormat, that.preferredContentFormat);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof BootstrapRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        BootstrapRequest other = (BootstrapRequest) obj;
-        if (additionalAttributes == null) {
-            if (other.additionalAttributes != null)
-                return false;
-        } else if (!additionalAttributes.equals(other.additionalAttributes))
-            return false;
-        if (endpointName == null) {
-            if (other.endpointName != null)
-                return false;
-        } else if (!endpointName.equals(other.endpointName))
-            return false;
-        if (preferredContentFormat == null) {
-            if (other.preferredContentFormat != null)
-                return false;
-        } else if (!preferredContentFormat.equals(other.preferredContentFormat))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(endpointName, additionalAttributes, preferredContentFormat);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapWriteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/BootstrapWriteRequest.java
@@ -125,4 +125,8 @@ public class BootstrapWriteRequest extends AbstractSimpleDownlinkRequest<Bootstr
         return String.format("BootstrapWriteRequest [path=%s, node=%s, contentFormat=%s]", getPath(), node,
                 contentFormat);
     }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof BootstrapWriteRequest);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
@@ -15,13 +15,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import org.eclipse.leshan.core.node.LwM2mPath;
+import java.util.Objects;
+
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.CancelObservationResponse;
-
-import java.util.Objects;
 
 /**
  * A Lightweight M2M request for actively cancel an observation.
@@ -70,13 +69,14 @@ public class CancelObservationRequest extends AbstractSimpleDownlinkRequest<Canc
 
     @Override
     public boolean equals(Object o) {
-        if (!super.equals(o)) return false;
-        boolean result = false;
-        if (o instanceof CancelObservationRequest) {
-            CancelObservationRequest that = (CancelObservationRequest) o;
-            result = that.canEqual(this) && Objects.equals(observation, that.observation);
-        }
-        return result;
+        if (this == o)
+            return true;
+        if (!(o instanceof CancelObservationRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
+        CancelObservationRequest that = (CancelObservationRequest) o;
+        return that.canEqual(this) && Objects.equals(observation, that.observation);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CancelObservationRequest.java
@@ -15,10 +15,13 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.CancelObservationResponse;
+
+import java.util.Objects;
 
 /**
  * A Lightweight M2M request for actively cancel an observation.
@@ -66,27 +69,22 @@ public class CancelObservationRequest extends AbstractSimpleDownlinkRequest<Canc
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((observation == null) ? 0 : observation.hashCode());
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        boolean result = false;
+        if (o instanceof CancelObservationRequest) {
+            CancelObservationRequest that = (CancelObservationRequest) o;
+            result = that.canEqual(this) && Objects.equals(observation, that.observation);
+        }
         return result;
     }
 
+    public boolean canEqual(Object o) {
+        return (o instanceof CancelObservationRequest);
+    }
+
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CancelObservationRequest other = (CancelObservationRequest) obj;
-        if (observation == null) {
-            if (other.observation != null)
-                return false;
-        } else if (!observation.equals(other.observation))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), observation);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
@@ -15,7 +15,14 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 
@@ -184,8 +191,10 @@ public class ContentFormat implements Comparable<ContentFormat> {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ContentFormat)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ContentFormat))
+            return false;
         ContentFormat that = (ContentFormat) o;
         return code == that.code;
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ContentFormat.java
@@ -15,13 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 
@@ -165,28 +159,6 @@ public class ContentFormat implements Comparable<ContentFormat> {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + code;
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ContentFormat other = (ContentFormat) obj;
-        if (code != other.code)
-            return false;
-        return true;
-    }
-
-    @Override
     public int compareTo(ContentFormat ct) {
         return Integer.compare(this.code, ct.code);
     }
@@ -208,5 +180,18 @@ public class ContentFormat implements Comparable<ContentFormat> {
             }
         }
         return optionalFormat;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ContentFormat)) return false;
+        ContentFormat that = (ContentFormat) o;
+        return code == that.code;
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(code);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
@@ -315,39 +312,19 @@ public class CreateRequest extends AbstractSimpleDownlinkRequest<CreateResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((contentFormat == null) ? 0 : contentFormat.hashCode());
-        result = prime * result + ((instances == null) ? 0 : instances.hashCode());
-        result = prime * result + ((resources == null) ? 0 : resources.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (!super.equals(o)) return false;
+        if (!(o instanceof CreateRequest)) return false;
+        CreateRequest that = (CreateRequest) o;
+        return that.canEqual(this) && Objects.equals(resources, that.resources) && Objects.equals(instances, that.instances) && Objects.equals(contentFormat, that.contentFormat);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof CreateRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        CreateRequest other = (CreateRequest) obj;
-        if (contentFormat == null) {
-            if (other.contentFormat != null)
-                return false;
-        } else if (!contentFormat.equals(other.contentFormat))
-            return false;
-        if (instances == null) {
-            if (other.instances != null)
-                return false;
-        } else if (!instances.equals(other.instances))
-            return false;
-        if (resources == null) {
-            if (other.resources != null)
-                return false;
-        } else if (!resources.equals(other.resources))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), resources, instances, contentFormat);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
@@ -317,6 +317,8 @@ public class CreateRequest extends AbstractSimpleDownlinkRequest<CreateResponse>
 
     @Override
     public boolean equals(Object o) {
+        if (this == o)
+            return true;
         if (!super.equals(o))
             return false;
         if (!(o instanceof CreateRequest))

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/CreateRequest.java
@@ -15,7 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mObjectInstance;
 import org.eclipse.leshan.core.node.LwM2mPath;
@@ -313,10 +317,13 @@ public class CreateRequest extends AbstractSimpleDownlinkRequest<CreateResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (!super.equals(o)) return false;
-        if (!(o instanceof CreateRequest)) return false;
+        if (!super.equals(o))
+            return false;
+        if (!(o instanceof CreateRequest))
+            return false;
         CreateRequest that = (CreateRequest) o;
-        return that.canEqual(this) && Objects.equals(resources, that.resources) && Objects.equals(instances, that.instances) && Objects.equals(contentFormat, that.contentFormat);
+        return that.canEqual(this) && Objects.equals(resources, that.resources)
+                && Objects.equals(instances, that.instances) && Objects.equals(contentFormat, that.contentFormat);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeleteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeleteRequest.java
@@ -90,4 +90,8 @@ public class DeleteRequest extends AbstractSimpleDownlinkRequest<DeleteResponse>
     public final String toString() {
         return String.format("DeleteRequest [%s]", getPath());
     }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof DeleteRequest);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeregisterRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeregisterRequest.java
@@ -15,10 +15,10 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.DeregisterResponse;
-
-import java.util.Objects;
 
 /**
  * A Lightweight M2M request for removing the registration information from the LWM2M Server.
@@ -75,8 +75,10 @@ public class DeregisterRequest extends AbstractLwM2mRequest<DeregisterResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof DeregisterRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof DeregisterRequest))
+            return false;
         DeregisterRequest that = (DeregisterRequest) o;
         return that.canEqual(this) && Objects.equals(registrationId, that.registrationId);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeregisterRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DeregisterRequest.java
@@ -18,13 +18,15 @@ package org.eclipse.leshan.core.request;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.DeregisterResponse;
 
+import java.util.Objects;
+
 /**
  * A Lightweight M2M request for removing the registration information from the LWM2M Server.
  */
 public class DeregisterRequest extends AbstractLwM2mRequest<DeregisterResponse>
         implements UplinkDeviceManagementRequest<DeregisterResponse> {
 
-    private String registrationId = null;
+    private final String registrationId;
 
     /**
      * Creates a request for removing the registration information from the LWM2M Server.
@@ -67,32 +69,24 @@ public class DeregisterRequest extends AbstractLwM2mRequest<DeregisterResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((registrationId == null) ? 0 : registrationId.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        DeregisterRequest other = (DeregisterRequest) obj;
-        if (registrationId == null) {
-            if (other.registrationId != null)
-                return false;
-        } else if (!registrationId.equals(other.registrationId))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("DeregisterRequest [registrationId=%s]", registrationId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DeregisterRequest)) return false;
+        DeregisterRequest that = (DeregisterRequest) o;
+        return that.canEqual(this) && Objects.equals(registrationId, that.registrationId);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof DeregisterRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(registrationId);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/DiscoverRequest.java
@@ -100,4 +100,8 @@ public class DiscoverRequest extends AbstractSimpleDownlinkRequest<DiscoverRespo
     public final String toString() {
         return String.format("DiscoverRequest [%s]", getPath());
     }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof DiscoverRequest);
+    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ExecuteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ExecuteRequest.java
@@ -15,13 +15,13 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.argument.Arguments;
 import org.eclipse.leshan.core.request.argument.InvalidArgumentException;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.ExecuteResponse;
-
-import java.util.Objects;
 
 /**
  * A Lightweight M2M request for initiate some action, it can only be performed on individual Resources.
@@ -168,9 +168,12 @@ public class ExecuteRequest extends AbstractSimpleDownlinkRequest<ExecuteRespons
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ExecuteRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ExecuteRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         ExecuteRequest that = (ExecuteRequest) o;
         return that.canEqual(this) && Objects.equals(arguments, that.arguments);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ExecuteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ExecuteRequest.java
@@ -21,6 +21,8 @@ import org.eclipse.leshan.core.request.argument.InvalidArgumentException;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.ExecuteResponse;
 
+import java.util.Objects;
+
 /**
  * A Lightweight M2M request for initiate some action, it can only be performed on individual Resources.
  */
@@ -165,27 +167,20 @@ public class ExecuteRequest extends AbstractSimpleDownlinkRequest<ExecuteRespons
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((arguments == null) ? 0 : arguments.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExecuteRequest)) return false;
+        if (!super.equals(o)) return false;
+        ExecuteRequest that = (ExecuteRequest) o;
+        return that.canEqual(this) && Objects.equals(arguments, that.arguments);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof ExecuteRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ExecuteRequest other = (ExecuteRequest) obj;
-        if (arguments == null) {
-            if (other.arguments != null)
-                return false;
-        } else if (!arguments.equals(other.arguments))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), arguments);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveCompositeRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveCompositeRequest.java
@@ -15,7 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mNodeException;
@@ -148,8 +152,10 @@ public class ObserveCompositeRequest extends AbstractLwM2mRequest<ObserveComposi
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ObserveCompositeRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ObserveCompositeRequest))
+            return false;
         ObserveCompositeRequest that = (ObserveCompositeRequest) o;
         return that.canEqual(this) && Objects.equals(requestContentFormat, that.requestContentFormat)
                 && Objects.equals(responseContentFormat, that.responseContentFormat)

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveCompositeRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveCompositeRequest.java
@@ -15,10 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mNodeException;
@@ -150,37 +147,21 @@ public class ObserveCompositeRequest extends AbstractLwM2mRequest<ObserveComposi
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((paths == null) ? 0 : paths.hashCode());
-        result = prime * result + ((requestContentFormat == null) ? 0 : requestContentFormat.hashCode());
-        result = prime * result + ((responseContentFormat == null) ? 0 : responseContentFormat.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObserveCompositeRequest)) return false;
+        ObserveCompositeRequest that = (ObserveCompositeRequest) o;
+        return that.canEqual(this) && Objects.equals(requestContentFormat, that.requestContentFormat)
+                && Objects.equals(responseContentFormat, that.responseContentFormat)
+                && Objects.equals(paths, that.paths);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof ObserveCompositeRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ObserveCompositeRequest other = (ObserveCompositeRequest) obj;
-        if (paths == null) {
-            if (other.paths != null)
-                return false;
-        } else if (!paths.equals(other.paths))
-            return false;
-        if (requestContentFormat == null) {
-            if (other.requestContentFormat != null)
-                return false;
-        } else if (!requestContentFormat.equals(other.requestContentFormat))
-            return false;
-        if (responseContentFormat == null) {
-            return other.responseContentFormat == null;
-        } else
-            return responseContentFormat.equals(other.responseContentFormat);
+    public int hashCode() {
+        return Objects.hash(requestContentFormat, responseContentFormat, paths);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.core.request;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.observation.Observation;
@@ -221,24 +222,20 @@ public class ObserveRequest extends AbstractSimpleDownlinkRequest<ObserveRespons
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((format == null) ? 0 : format.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ObserveRequest)) return false;
+        if (!super.equals(o)) return false;
+        ObserveRequest that = (ObserveRequest) o;
+        return that.canEqual(this) && Objects.equals(format, that.format) && Objects.equals(context, that.context);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof ObserveRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ObserveRequest other = (ObserveRequest) obj;
-        if (format != other.format)
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), format, context);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ObserveRequest.java
@@ -223,9 +223,12 @@ public class ObserveRequest extends AbstractSimpleDownlinkRequest<ObserveRespons
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ObserveRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ObserveRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         ObserveRequest that = (ObserveRequest) o;
         return that.canEqual(this) && Objects.equals(format, that.format) && Objects.equals(context, that.context);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadCompositeRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadCompositeRequest.java
@@ -132,10 +132,14 @@ public class ReadCompositeRequest extends AbstractLwM2mRequest<ReadCompositeResp
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ReadCompositeRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ReadCompositeRequest))
+            return false;
         ReadCompositeRequest that = (ReadCompositeRequest) o;
-        return that.canEqual(this) && Objects.equals(paths, that.paths) && Objects.equals(requestContentFormat, that.requestContentFormat) && Objects.equals(responseContentFormat, that.responseContentFormat);
+        return that.canEqual(this) && Objects.equals(paths, that.paths)
+                && Objects.equals(requestContentFormat, that.requestContentFormat)
+                && Objects.equals(responseContentFormat, that.responseContentFormat);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadCompositeRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadCompositeRequest.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.core.request;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mNodeException;
@@ -130,40 +131,19 @@ public class ReadCompositeRequest extends AbstractLwM2mRequest<ReadCompositeResp
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((paths == null) ? 0 : paths.hashCode());
-        result = prime * result + ((requestContentFormat == null) ? 0 : requestContentFormat.hashCode());
-        result = prime * result + ((responseContentFormat == null) ? 0 : responseContentFormat.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ReadCompositeRequest)) return false;
+        ReadCompositeRequest that = (ReadCompositeRequest) o;
+        return that.canEqual(this) && Objects.equals(paths, that.paths) && Objects.equals(requestContentFormat, that.requestContentFormat) && Objects.equals(responseContentFormat, that.responseContentFormat);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof ReadCompositeRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReadCompositeRequest other = (ReadCompositeRequest) obj;
-        if (paths == null) {
-            if (other.paths != null)
-                return false;
-        } else if (!paths.equals(other.paths))
-            return false;
-        if (requestContentFormat == null) {
-            if (other.requestContentFormat != null)
-                return false;
-        } else if (!requestContentFormat.equals(other.requestContentFormat))
-            return false;
-        if (responseContentFormat == null) {
-            if (other.responseContentFormat != null)
-                return false;
-        } else if (!responseContentFormat.equals(other.responseContentFormat))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(paths, requestContentFormat, responseContentFormat);
     }
-
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
@@ -15,11 +15,11 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.ReadResponse;
-
-import java.util.Objects;
 
 /**
  * A Lightweight M2M request for retrieving the values of resources from a LWM2M Client.
@@ -197,9 +197,12 @@ public class ReadRequest extends AbstractSimpleDownlinkRequest<ReadResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ReadRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ReadRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         ReadRequest that = (ReadRequest) o;
         return that.canEqual(this) && Objects.equals(format, that.format);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/ReadRequest.java
@@ -19,6 +19,8 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.ReadResponse;
 
+import java.util.Objects;
+
 /**
  * A Lightweight M2M request for retrieving the values of resources from a LWM2M Client.
  *
@@ -194,24 +196,20 @@ public class ReadRequest extends AbstractSimpleDownlinkRequest<ReadResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((format == null) ? 0 : format.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ReadRequest)) return false;
+        if (!super.equals(o)) return false;
+        ReadRequest that = (ReadRequest) o;
+        return that.canEqual(this) && Objects.equals(format, that.format);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof ReadRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReadRequest other = (ReadRequest) obj;
-        if (format != other.format)
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), format);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -16,7 +16,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
@@ -174,16 +179,19 @@ public class RegisterRequest extends AbstractLwM2mRequest<RegisterResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RegisterRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof RegisterRequest))
+            return false;
         RegisterRequest that = (RegisterRequest) o;
-        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName) && Objects.equals(lifetime, that.lifetime)
-                && Objects.equals(lwVersion, that.lwVersion) && Objects.equals(bindingMode, that.bindingMode)
-                && Objects.equals(queueMode, that.queueMode) && Objects.equals(smsNumber, that.smsNumber)
-                && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(additionalAttributes, that.additionalAttributes);
+        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName)
+                && Objects.equals(lifetime, that.lifetime) && Objects.equals(lwVersion, that.lwVersion)
+                && Objects.equals(bindingMode, that.bindingMode) && Objects.equals(queueMode, that.queueMode)
+                && Objects.equals(smsNumber, that.smsNumber) && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(additionalAttributes, that.additionalAttributes);
     }
 
-    public boolean canEqual(Object o){
+    public boolean canEqual(Object o) {
         return (o instanceof RegisterRequest);
     }
 

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/RegisterRequest.java
@@ -16,11 +16,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
@@ -177,63 +173,23 @@ public class RegisterRequest extends AbstractLwM2mRequest<RegisterResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((additionalAttributes == null) ? 0 : additionalAttributes.hashCode());
-        result = prime * result + ((bindingMode == null) ? 0 : bindingMode.hashCode());
-        result = prime * result + ((endpointName == null) ? 0 : endpointName.hashCode());
-        result = prime * result + ((lifetime == null) ? 0 : lifetime.hashCode());
-        result = prime * result + ((lwVersion == null) ? 0 : lwVersion.hashCode());
-        result = prime * result + Arrays.hashCode(objectLinks);
-        result = prime * result + ((queueMode == null) ? 0 : queueMode.hashCode());
-        result = prime * result + ((smsNumber == null) ? 0 : smsNumber.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RegisterRequest)) return false;
+        RegisterRequest that = (RegisterRequest) o;
+        return that.canEqual(this) && Objects.equals(endpointName, that.endpointName) && Objects.equals(lifetime, that.lifetime)
+                && Objects.equals(lwVersion, that.lwVersion) && Objects.equals(bindingMode, that.bindingMode)
+                && Objects.equals(queueMode, that.queueMode) && Objects.equals(smsNumber, that.smsNumber)
+                && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(additionalAttributes, that.additionalAttributes);
+    }
+
+    public boolean canEqual(Object o){
+        return (o instanceof RegisterRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        RegisterRequest other = (RegisterRequest) obj;
-        if (additionalAttributes == null) {
-            if (other.additionalAttributes != null)
-                return false;
-        } else if (!additionalAttributes.equals(other.additionalAttributes))
-            return false;
-        if (bindingMode != other.bindingMode)
-            return false;
-        if (endpointName == null) {
-            if (other.endpointName != null)
-                return false;
-        } else if (!endpointName.equals(other.endpointName))
-            return false;
-        if (lifetime == null) {
-            if (other.lifetime != null)
-                return false;
-        } else if (!lifetime.equals(other.lifetime))
-            return false;
-        if (lwVersion == null) {
-            if (other.lwVersion != null)
-                return false;
-        } else if (!lwVersion.equals(other.lwVersion))
-            return false;
-        if (!Arrays.equals(objectLinks, other.objectLinks))
-            return false;
-        if (queueMode == null) {
-            if (other.queueMode != null)
-                return false;
-        } else if (!queueMode.equals(other.queueMode))
-            return false;
-        if (smsNumber == null) {
-            if (other.smsNumber != null)
-                return false;
-        } else if (!smsNumber.equals(other.smsNumber))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(endpointName, lifetime, lwVersion, bindingMode, queueMode, smsNumber,
+                Arrays.hashCode(objectLinks), additionalAttributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/SendRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/SendRequest.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.core.request;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mObject;
@@ -129,33 +130,19 @@ public class SendRequest extends AbstractLwM2mRequest<SendResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((format == null) ? 0 : format.hashCode());
-        result = prime * result + ((timestampedNodes == null) ? 0 : timestampedNodes.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SendRequest)) return false;
+        SendRequest that = (SendRequest) o;
+        return that.canEqual(this) && Objects.equals(format, that.format) && Objects.equals(timestampedNodes, that.timestampedNodes);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof SendRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SendRequest other = (SendRequest) obj;
-        if (format == null) {
-            if (other.format != null)
-                return false;
-        } else if (!format.equals(other.format))
-            return false;
-        if (timestampedNodes == null) {
-            if (other.timestampedNodes != null)
-                return false;
-        } else if (!timestampedNodes.equals(other.timestampedNodes))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(format, timestampedNodes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/SendRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/SendRequest.java
@@ -131,10 +131,13 @@ public class SendRequest extends AbstractLwM2mRequest<SendResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SendRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SendRequest))
+            return false;
         SendRequest that = (SendRequest) o;
-        return that.canEqual(this) && Objects.equals(format, that.format) && Objects.equals(timestampedNodes, that.timestampedNodes);
+        return that.canEqual(this) && Objects.equals(format, that.format)
+                && Objects.equals(timestampedNodes, that.timestampedNodes);
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
@@ -16,11 +16,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.link.Link;
@@ -130,59 +126,29 @@ public class UpdateRequest extends AbstractLwM2mRequest<UpdateResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((additionalAttributes == null) ? 0 : additionalAttributes.hashCode());
-        result = prime * result + ((bindingMode == null) ? 0 : bindingMode.hashCode());
-        result = prime * result + ((lifeTimeInSec == null) ? 0 : lifeTimeInSec.hashCode());
-        result = prime * result + Arrays.hashCode(objectLinks);
-        result = prime * result + ((registrationId == null) ? 0 : registrationId.hashCode());
-        result = prime * result + ((smsNumber == null) ? 0 : smsNumber.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        UpdateRequest other = (UpdateRequest) obj;
-        if (additionalAttributes == null) {
-            if (other.additionalAttributes != null)
-                return false;
-        } else if (!additionalAttributes.equals(other.additionalAttributes))
-            return false;
-        if (bindingMode != other.bindingMode)
-            return false;
-        if (lifeTimeInSec == null) {
-            if (other.lifeTimeInSec != null)
-                return false;
-        } else if (!lifeTimeInSec.equals(other.lifeTimeInSec))
-            return false;
-        if (!Arrays.equals(objectLinks, other.objectLinks))
-            return false;
-        if (registrationId == null) {
-            if (other.registrationId != null)
-                return false;
-        } else if (!registrationId.equals(other.registrationId))
-            return false;
-        if (smsNumber == null) {
-            if (other.smsNumber != null)
-                return false;
-        } else if (!smsNumber.equals(other.smsNumber))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format(
                 "UpdateRequest [registrationId=%s, lifeTimeInSec=%s, smsNumber=%s, bindingMode=%s, objectLinks=%s, additionalAttributes=%s]",
                 registrationId, lifeTimeInSec, smsNumber, bindingMode, Arrays.toString(objectLinks),
                 additionalAttributes);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UpdateRequest)) return false;
+        UpdateRequest that = (UpdateRequest) o;
+        return that.canEqual(this) && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber)
+                && Objects.equals(bindingMode, that.bindingMode) && Objects.equals(registrationId, that.registrationId)
+                && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(additionalAttributes, that.additionalAttributes);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof UpdateRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lifeTimeInSec, smsNumber, bindingMode, registrationId, Arrays.hashCode(objectLinks), additionalAttributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/UpdateRequest.java
@@ -16,7 +16,12 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.link.Link;
@@ -135,12 +140,16 @@ public class UpdateRequest extends AbstractLwM2mRequest<UpdateResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof UpdateRequest)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof UpdateRequest))
+            return false;
         UpdateRequest that = (UpdateRequest) o;
-        return that.canEqual(this) && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber)
-                && Objects.equals(bindingMode, that.bindingMode) && Objects.equals(registrationId, that.registrationId)
-                && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(additionalAttributes, that.additionalAttributes);
+        return that.canEqual(this) && Objects.equals(lifeTimeInSec, that.lifeTimeInSec)
+                && Objects.equals(smsNumber, that.smsNumber) && Objects.equals(bindingMode, that.bindingMode)
+                && Objects.equals(registrationId, that.registrationId)
+                && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(additionalAttributes, that.additionalAttributes);
     }
 
     public boolean canEqual(Object o) {
@@ -149,6 +158,7 @@ public class UpdateRequest extends AbstractLwM2mRequest<UpdateResponse>
 
     @Override
     public int hashCode() {
-        return Objects.hash(lifeTimeInSec, smsNumber, bindingMode, registrationId, Arrays.hashCode(objectLinks), additionalAttributes);
+        return Objects.hash(lifeTimeInSec, smsNumber, bindingMode, registrationId, Arrays.hashCode(objectLinks),
+                additionalAttributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
+import java.util.Objects;
+
 import org.eclipse.leshan.core.link.lwm2m.attributes.AttributeClass;
 import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttribute;
@@ -22,8 +24,6 @@ import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
-
-import java.util.Objects;
 
 public class WriteAttributesRequest extends AbstractSimpleDownlinkRequest<WriteAttributesResponse>
         implements DownlinkDeviceManagementRequest<WriteAttributesResponse> {
@@ -113,9 +113,12 @@ public class WriteAttributesRequest extends AbstractSimpleDownlinkRequest<WriteA
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof WriteAttributesRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof WriteAttributesRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         WriteAttributesRequest that = (WriteAttributesRequest) o;
         return that.canEqual(this) && Objects.equals(attributes, that.attributes);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteAttributesRequest.java
@@ -23,6 +23,8 @@ import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.eclipse.leshan.core.response.WriteAttributesResponse;
 
+import java.util.Objects;
+
 public class WriteAttributesRequest extends AbstractSimpleDownlinkRequest<WriteAttributesResponse>
         implements DownlinkDeviceManagementRequest<WriteAttributesResponse> {
 
@@ -110,27 +112,20 @@ public class WriteAttributesRequest extends AbstractSimpleDownlinkRequest<WriteA
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof WriteAttributesRequest)) return false;
+        if (!super.equals(o)) return false;
+        WriteAttributesRequest that = (WriteAttributesRequest) o;
+        return that.canEqual(this) && Objects.equals(attributes, that.attributes);
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof WriteAttributesRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        WriteAttributesRequest other = (WriteAttributesRequest) obj;
-        if (attributes == null) {
-            if (other.attributes != null)
-                return false;
-        } else if (!attributes.equals(other.attributes))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), attributes);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
@@ -18,6 +18,7 @@ package org.eclipse.leshan.core.request;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.model.ResourceModel.Type;
@@ -527,33 +528,20 @@ public class WriteRequest extends AbstractSimpleDownlinkRequest<WriteResponse>
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + ((contentFormat == null) ? 0 : contentFormat.hashCode());
-        result = prime * result + ((mode == null) ? 0 : mode.hashCode());
-        result = prime * result + ((node == null) ? 0 : node.hashCode());
-        return result;
+    public boolean equals(Object o) {
+        if (!(o instanceof WriteRequest)) return false;
+        if (!super.equals(o)) return false;
+        WriteRequest that = (WriteRequest) o;
+        return that.canEqual(this) && Objects.equals(node, that.node) && Objects.equals(contentFormat, that.contentFormat) && mode == that.mode;
+    }
+
+    public boolean canEqual(Object o) {
+        return (o instanceof WriteRequest);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (!super.equals(obj))
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        WriteRequest other = (WriteRequest) obj;
-        if (contentFormat != other.contentFormat)
-            return false;
-        if (mode != other.mode)
-            return false;
-        if (node == null) {
-            if (other.node != null)
-                return false;
-        } else if (!node.equals(other.node))
-            return false;
-        return true;
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), node, contentFormat, mode);
     }
+
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
@@ -529,6 +529,8 @@ public class WriteRequest extends AbstractSimpleDownlinkRequest<WriteResponse>
 
     @Override
     public boolean equals(Object o) {
+        if (this == o)
+            return true;
         if (!(o instanceof WriteRequest))
             return false;
         if (!super.equals(o))

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/WriteRequest.java
@@ -529,10 +529,13 @@ public class WriteRequest extends AbstractSimpleDownlinkRequest<WriteResponse>
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof WriteRequest)) return false;
-        if (!super.equals(o)) return false;
+        if (!(o instanceof WriteRequest))
+            return false;
+        if (!super.equals(o))
+            return false;
         WriteRequest that = (WriteRequest) o;
-        return that.canEqual(this) && Objects.equals(node, that.node) && Objects.equals(contentFormat, that.contentFormat) && mode == that.mode;
+        return that.canEqual(this) && Objects.equals(node, that.node)
+                && Objects.equals(contentFormat, that.contentFormat) && mode == that.mode;
     }
 
     public boolean canEqual(Object o) {

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Argument.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Argument.java
@@ -95,8 +95,10 @@ public class Argument {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Argument)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Argument))
+            return false;
         Argument argument = (Argument) o;
         return digit == argument.digit && Objects.equals(value, argument.value);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Argument.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Argument.java
@@ -15,6 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request.argument;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -93,30 +94,15 @@ public class Argument {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + digit;
-        result = prime * result + ((value == null) ? 0 : value.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Argument)) return false;
+        Argument argument = (Argument) o;
+        return digit == argument.digit && Objects.equals(value, argument.value);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Argument other = (Argument) obj;
-        if (digit != other.digit)
-            return false;
-        if (value == null) {
-            if (other.value != null)
-                return false;
-        } else if (!value.equals(other.value))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(digit, value);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Arguments.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Arguments.java
@@ -15,14 +15,7 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request.argument;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 /**
  * Arguments for Execute Operation.
@@ -41,31 +34,6 @@ public class Arguments implements Iterable<Argument> {
     @Override
     public String toString() {
         return String.format("Arguments [argumentMap=%s]", argumentMap.toString());
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((argumentMap == null) ? 0 : argumentMap.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Arguments other = (Arguments) obj;
-        if (argumentMap == null) {
-            if (other.argumentMap != null)
-                return false;
-        } else if (!argumentMap.equals(other.argumentMap))
-            return false;
-        return true;
     }
 
     /**
@@ -264,6 +232,19 @@ public class Arguments implements Iterable<Argument> {
      */
     public static Arguments emptyArguments() {
         return new Arguments(Collections.emptyMap());
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Arguments)) return false;
+        Arguments arguments = (Arguments) o;
+        return Objects.equals(argumentMap, arguments.argumentMap);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(argumentMap);
     }
 
     /**

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Arguments.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/request/argument/Arguments.java
@@ -15,7 +15,15 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request.argument;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * Arguments for Execute Operation.
@@ -236,8 +244,10 @@ public class Arguments implements Iterable<Argument> {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Arguments)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Arguments))
+            return false;
         Arguments arguments = (Arguments) o;
         return Objects.equals(argumentMap, arguments.argumentMap);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
@@ -88,7 +88,7 @@ public class Tlv {
             return false;
         Tlv tlv = (Tlv) o;
         return identifier == tlv.identifier && type == tlv.type && Objects.deepEquals(children, tlv.children)
-                && Objects.deepEquals(value, tlv.value);
+                && Arrays.equals(value, tlv.value);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
@@ -68,7 +68,6 @@ public class Tlv {
         return type;
     }
 
-
     public Tlv[] getChildren() {
         return children;
     }
@@ -83,11 +82,13 @@ public class Tlv {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Tlv)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Tlv))
+            return false;
         Tlv tlv = (Tlv) o;
-        return identifier == tlv.identifier && type == tlv.type
-                && Objects.deepEquals(children, tlv.children) && Objects.deepEquals(value, tlv.value);
+        return identifier == tlv.identifier && type == tlv.type && Objects.deepEquals(children, tlv.children)
+                && Objects.deepEquals(value, tlv.value);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/tlv/Tlv.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.tlv;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * A Type-Length-Value container, can contain multiple TLV entries.
@@ -23,15 +24,15 @@ import java.util.Arrays;
 public class Tlv {
 
     // type of TLV, indicate if it's containing a value or TLV containing more TLV or values
-    private TlvType type;
+    private final TlvType type;
 
     // if of type OBJECT_INSTANCE,MULTIPLE_RESOURCE or null
-    private Tlv[] children;
+    private final Tlv[] children;
 
     // if type RESOURCE_VALUE or RESOURCE_INSTANCE => null
-    private byte[] value;
+    private final byte[] value;
 
-    private int identifier;
+    private final int identifier;
 
     /**
      * Creates a TLV container.
@@ -67,32 +68,31 @@ public class Tlv {
         return type;
     }
 
-    public void setType(TlvType type) {
-        this.type = type;
-    }
 
     public Tlv[] getChildren() {
         return children;
-    }
-
-    public void setChildren(Tlv[] children) {
-        this.children = children;
     }
 
     public byte[] getValue() {
         return value;
     }
 
-    public void setValue(byte[] value) {
-        this.value = value;
-    }
-
     public int getIdentifier() {
         return identifier;
     }
 
-    public void setIdentifier(int identifier) {
-        this.identifier = identifier;
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Tlv)) return false;
+        Tlv tlv = (Tlv) o;
+        return identifier == tlv.identifier && type == tlv.type
+                && Objects.deepEquals(children, tlv.children) && Objects.deepEquals(value, tlv.value);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(type, Arrays.hashCode(children), Arrays.hashCode(value), identifier);
     }
 
     public enum TlvType {
@@ -105,34 +105,4 @@ public class Tlv {
                 Arrays.toString(children), Arrays.toString(value), Integer.toString(identifier) });
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(children);
-        result = prime * result + identifier;
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        result = prime * result + Arrays.hashCode(value);
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Tlv other = (Tlv) obj;
-        if (!Arrays.equals(children, other.children))
-            return false;
-        if (identifier != other.identifier)
-            return false;
-        if (type != other.type)
-            return false;
-        if (!Arrays.equals(value, other.value))
-            return false;
-        return true;
-    }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/util/datatype/ULong.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/util/datatype/ULong.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.core.util.datatype;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
 /**
  * The <code>unsigned long</code> type
@@ -174,20 +175,6 @@ public final class ULong extends Number implements Comparable<ULong> {
     }
 
     @Override
-    public int hashCode() {
-
-        return Long.valueOf(value).hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof ULong)
-            return value == ((ULong) obj).value;
-
-        return false;
-    }
-
-    @Override
     public String toString() {
         if (value >= 0)
             return Long.toString(value);
@@ -261,5 +248,18 @@ public final class ULong extends Number implements Comparable<ULong> {
      */
     public BigInteger toBigInteger() {
         return new BigInteger(toString());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ULong)) return false;
+        ULong that = (ULong) o;
+        return value == that.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/util/datatype/ULong.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/core/util/datatype/ULong.java
@@ -252,8 +252,10 @@ public final class ULong extends Number implements Comparable<ULong> {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof ULong)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof ULong))
+            return false;
         ULong that = (ULong) o;
         return value == that.value;
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
@@ -17,6 +17,7 @@ package org.eclipse.leshan.senml;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The class representing the SenML Pack.
@@ -60,32 +61,20 @@ public class SenMLPack {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((records == null) ? 0 : records.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SenMLPack other = (SenMLPack) obj;
-        if (records == null) {
-            if (other.records != null)
-                return false;
-        } else if (!records.equals(other.records))
-            return false;
-        return true;
-    }
-
-    @Override
     public String toString() {
         return String.format("SenMLPack [records=%s]", records);
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SenMLPack)) return false;
+        SenMLPack senMLPack = (SenMLPack) o;
+        return Objects.equals(records, senMLPack.records);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hashCode(records);
     }
 }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLPack.java
@@ -67,8 +67,10 @@ public class SenMLPack {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SenMLPack)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SenMLPack))
+            return false;
         SenMLPack senMLPack = (SenMLPack) o;
         return Objects.equals(records, senMLPack.records);
     }

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
@@ -171,7 +171,7 @@ public class SenMLRecord {
                 && comparablyEqualTime && Objects.equals(numberValue, that.numberValue)
                 && Objects.equals(booleanValue, that.booleanValue)
                 && Objects.equals(objectLinkValue, that.objectLinkValue)
-                && Objects.equals(stringValue, that.stringValue) && Objects.deepEquals(opaqueValue, that.opaqueValue);
+                && Objects.equals(stringValue, that.stringValue) && Arrays.equals(opaqueValue, that.opaqueValue);
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
@@ -155,30 +155,30 @@ public class SenMLRecord {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SenMLRecord)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SenMLRecord))
+            return false;
         SenMLRecord that = (SenMLRecord) o;
 
         boolean comparablyEqualTime = (time == null && that.time == null)
-                || (time != null && that.time != null
-                && time.compareTo(that.time) == 0);
+                || (time != null && that.time != null && time.compareTo(that.time) == 0);
 
         boolean comparablyEqualBaseTime = (baseTime == null && that.baseTime == null)
-                || (baseTime != null && that.baseTime != null
-                && baseTime.compareTo(that.baseTime) == 0);
+                || (baseTime != null && that.baseTime != null && baseTime.compareTo(that.baseTime) == 0);
 
-        return Objects.equals(baseName, that.baseName) && comparablyEqualBaseTime
-                && Objects.equals(name, that.name) && comparablyEqualTime
-                && Objects.equals(numberValue, that.numberValue) && Objects.equals(booleanValue, that.booleanValue)
-                && Objects.equals(objectLinkValue, that.objectLinkValue) && Objects.equals(stringValue, that.stringValue)
-                && Objects.deepEquals(opaqueValue, that.opaqueValue);
+        return Objects.equals(baseName, that.baseName) && comparablyEqualBaseTime && Objects.equals(name, that.name)
+                && comparablyEqualTime && Objects.equals(numberValue, that.numberValue)
+                && Objects.equals(booleanValue, that.booleanValue)
+                && Objects.equals(objectLinkValue, that.objectLinkValue)
+                && Objects.equals(stringValue, that.stringValue) && Objects.deepEquals(opaqueValue, that.opaqueValue);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(baseName, baseTime != null ? baseTime.stripTrailingZeros() : null,
-                name, time != null ? time.stripTrailingZeros() : null, numberValue, booleanValue,
-                objectLinkValue, stringValue, Arrays.hashCode(opaqueValue));
+        return Objects.hash(baseName, baseTime != null ? baseTime.stripTrailingZeros() : null, name,
+                time != null ? time.stripTrailingZeros() : null, numberValue, booleanValue, objectLinkValue,
+                stringValue, Arrays.hashCode(opaqueValue));
     }
 
     @Override

--- a/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
+++ b/leshan-lwm2m-core/src/main/java/org/eclipse/leshan/senml/SenMLRecord.java
@@ -16,6 +16,7 @@ package org.eclipse.leshan.senml;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.util.Hex;
 
@@ -153,84 +154,31 @@ public class SenMLRecord {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((baseName == null) ? 0 : baseName.hashCode());
-        result = prime * result + ((baseTime == null) ? 0 : baseTime.hashCode());
-        result = prime * result + ((booleanValue == null) ? 0 : booleanValue.hashCode());
-        result = prime * result + ((numberValue == null) ? 0 : numberValue.hashCode());
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((objectLinkValue == null) ? 0 : objectLinkValue.hashCode());
-        result = prime * result + ((stringValue == null) ? 0 : stringValue.hashCode());
-        result = prime * result + ((opaqueValue == null) ? 0 : Arrays.hashCode(opaqueValue));
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SenMLRecord)) return false;
+        SenMLRecord that = (SenMLRecord) o;
+
+        boolean comparablyEqualTime = (time == null && that.time == null)
+                || (time != null && that.time != null
+                && time.compareTo(that.time) == 0);
+
+        boolean comparablyEqualBaseTime = (baseTime == null && that.baseTime == null)
+                || (baseTime != null && that.baseTime != null
+                && baseTime.compareTo(that.baseTime) == 0);
+
+        return Objects.equals(baseName, that.baseName) && comparablyEqualBaseTime
+                && Objects.equals(name, that.name) && comparablyEqualTime
+                && Objects.equals(numberValue, that.numberValue) && Objects.equals(booleanValue, that.booleanValue)
+                && Objects.equals(objectLinkValue, that.objectLinkValue) && Objects.equals(stringValue, that.stringValue)
+                && Objects.deepEquals(opaqueValue, that.opaqueValue);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SenMLRecord other = (SenMLRecord) obj;
-
-        if (baseName == null) {
-            if (other.baseName != null)
-                return false;
-        } else if (!baseName.equals(other.baseName))
-            return false;
-        if (baseTime == null) {
-            if (other.baseTime != null)
-                return false;
-        } else if (!baseTime.equals(other.baseTime))
-            return false;
-
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        if (time == null) {
-            if (other.time != null)
-                return false;
-        } else if (!time.equals(other.time))
-            return false;
-
-        if (booleanValue == null) {
-            if (other.booleanValue != null)
-                return false;
-        } else if (!booleanValue.equals(other.booleanValue))
-            return false;
-        if (numberValue == null) {
-            if (other.numberValue != null)
-                return false;
-        } else if (!numberValue.equals(other.numberValue))
-            return false;
-        if (name == null) {
-            if (other.name != null)
-                return false;
-        } else if (!name.equals(other.name))
-            return false;
-        if (objectLinkValue == null) {
-            if (other.objectLinkValue != null)
-                return false;
-        } else if (!objectLinkValue.equals(other.objectLinkValue))
-            return false;
-        if (stringValue == null) {
-            if (other.stringValue != null)
-                return false;
-        } else if (!stringValue.equals(other.stringValue))
-            return false;
-        if (opaqueValue == null) {
-            if (other.opaqueValue != null)
-                return false;
-        } else if (!Arrays.equals(opaqueValue, other.opaqueValue))
-            return false;
-
-        return true;
+    public final int hashCode() {
+        return Objects.hash(baseName, baseTime != null ? baseTime.stripTrailingZeros() : null,
+                name, time != null ? time.stripTrailingZeros() : null, numberValue, booleanValue,
+                objectLinkValue, stringValue, Arrays.hashCode(opaqueValue));
     }
 
     @Override

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
@@ -38,18 +38,8 @@ class LwM2mTest {
                 .withRedefinedSubclass(ExtendedLwM2mVersion.class).verify();
     }
 
-    /*
-     * private class ExtendedVersion extends LwM2m.Version { ExtendedVersion(int major, int minor) {
-     * super(toShortExact(major, "version (%d.%d) major part (%d) is not a valid short", major, minor, major),
-     * toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short", major, minor, minor)); }
-     *
-     * @Override public boolean canEqual(Object obj) { return (obj instanceof ExtendedVersion); } }
-     */
-
     @Test
     public void assertEqualsHashcodeVersion() {
-        // EqualsVerifier.forClass(LwM2m.Version.class).verify();
-        // don't know how to create a constructor for the ExtendedVersion, problem with toShortExact being private, not
-        // fe package-private
+        EqualsVerifier.forClass(LwM2m.Version.class).withRedefinedSubclass(LwM2m.LwM2mVersion.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mTest {
 
@@ -9,6 +25,7 @@ class LwM2mTest {
         ExtendedLwM2mVersion(String version, boolean supported) {
             super(version, supported);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedLwM2mVersion);
@@ -17,24 +34,22 @@ class LwM2mTest {
 
     @Test
     public void assertEqualsHashcodeLwM2mVersion() {
-        EqualsVerifier.forClass(LwM2m.LwM2mVersion.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedLwM2mVersion.class).verify();
+        EqualsVerifier.forClass(LwM2m.LwM2mVersion.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedLwM2mVersion.class).verify();
     }
 
-   /* private class ExtendedVersion extends LwM2m.Version {
-        ExtendedVersion(int major, int minor) {
-            super(toShortExact(major, "version (%d.%d) major part (%d) is not a valid short", major, minor, major),
-                    toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short", major, minor, minor));
-        }
-        @Override
-        public boolean canEqual(Object obj) {
-            return (obj instanceof ExtendedVersion);
-        }
-    }*/
+    /*
+     * private class ExtendedVersion extends LwM2m.Version { ExtendedVersion(int major, int minor) {
+     * super(toShortExact(major, "version (%d.%d) major part (%d) is not a valid short", major, minor, major),
+     * toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short", major, minor, minor)); }
+     *
+     * @Override public boolean canEqual(Object obj) { return (obj instanceof ExtendedVersion); } }
+     */
 
     @Test
     public void assertEqualsHashcodeVersion() {
-        EqualsVerifier.forClass(LwM2m.Version.class).verify();
-        // don't know how to create a constructor for the ExtendedVersion, problem with toShortExact being private, not fe package-private
+        // EqualsVerifier.forClass(LwM2m.Version.class).verify();
+        // don't know how to create a constructor for the ExtendedVersion, problem with toShortExact being private, not
+        // fe package-private
     }
-
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/LwM2mTest.java
@@ -1,0 +1,40 @@
+package org.eclipse.leshan.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mTest {
+
+    private class ExtendedLwM2mVersion extends LwM2m.LwM2mVersion {
+        ExtendedLwM2mVersion(String version, boolean supported) {
+            super(version, supported);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedLwM2mVersion);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcodeLwM2mVersion() {
+        EqualsVerifier.forClass(LwM2m.LwM2mVersion.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedLwM2mVersion.class).verify();
+    }
+
+   /* private class ExtendedVersion extends LwM2m.Version {
+        ExtendedVersion(int major, int minor) {
+            super(toShortExact(major, "version (%d.%d) major part (%d) is not a valid short", major, minor, major),
+                    toShortExact(minor, "version (%d.%d) minor part (%d) is not a valid short", major, minor, minor));
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedVersion);
+        }
+    }*/
+
+    @Test
+    public void assertEqualsHashcodeVersion() {
+        EqualsVerifier.forClass(LwM2m.Version.class).verify();
+        // don't know how to create a constructor for the ExtendedVersion, problem with toShortExact being private, not fe package-private
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.core;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class ResponseCodeTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ResponseCode.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class ResponseCodeTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/ResponseCodeTest.java
@@ -18,11 +18,10 @@ package org.eclipse.leshan.core;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 class ResponseCodeTest {
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ResponseCode.class).suppress(Warning.NONFINAL_FIELDS).verify();
+        EqualsVerifier.forClass(ResponseCode.class).withIgnoredFields("name").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/endpoint/ProtocolTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/endpoint/ProtocolTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.endpoint;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ProtocolTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Protocol.class).withIgnoredFields("uriScheme").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/endpoint/ProtocolTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/endpoint/ProtocolTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.endpoint;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ProtocolTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonArrayEntryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonArrayEntryTest.java
@@ -1,8 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
+
 package org.eclipse.leshan.core.json;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class JsonArrayEntryTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonArrayEntryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonArrayEntryTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.core.json;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class JsonArrayEntryTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(JsonArrayEntry.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonRootObjectTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonRootObjectTest.java
@@ -1,8 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
+
 package org.eclipse.leshan.core.json;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class JsonRootObjectTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonRootObjectTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/json/JsonRootObjectTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.core.json;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class JsonRootObjectTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(JsonRootObject.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
@@ -15,30 +15,14 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.link;
 
-import java.util.Collection;
-
-import org.eclipse.leshan.core.link.attributes.Attribute;
-import org.eclipse.leshan.core.link.attributes.AttributeSet;
+import org.eclipse.leshan.core.link.lwm2m.MixedLwM2mLink;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LinkTest {
-
-    private class ExtendedLink extends Link {
-        public ExtendedLink(String uriReference, Collection<Attribute> attributes) {
-            super(uriReference, new AttributeSet(attributes));
-        }
-
-        @Override
-        public boolean canEqual(Object obj) {
-            return (obj instanceof ExtendedLink);
-        }
-    }
-
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(Link.class).withRedefinedSubclass(ExtendedLink.class).verify();
+        EqualsVerifier.forClass(Link.class).withRedefinedSubclass(MixedLwM2mLink.class).verify();
     }
-
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
@@ -1,11 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.Collection;
+
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.link.attributes.AttributeSet;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LinkTest {
 
@@ -13,6 +29,7 @@ class LinkTest {
         public ExtendedLink(String uriReference, Collection<Attribute> attributes) {
             super(uriReference, new AttributeSet(attributes));
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedLink);

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/LinkTest.java
@@ -1,0 +1,27 @@
+package org.eclipse.leshan.core.link;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.link.attributes.Attribute;
+import org.eclipse.leshan.core.link.attributes.AttributeSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+class LinkTest {
+
+    private class ExtendedLink extends Link {
+        public ExtendedLink(String uriReference, Collection<Attribute> attributes) {
+            super(uriReference, new AttributeSet(attributes));
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedLink);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Link.class).withRedefinedSubclass(ExtendedLink.class).verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/MixedLwM2mLinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/MixedLwM2mLinkTest.java
@@ -17,8 +17,11 @@ package org.eclipse.leshan.core.link;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.link.attributes.ResourceTypeAttribute;
 import org.eclipse.leshan.core.link.lwm2m.MixedLwM2mLink;
+import org.eclipse.leshan.core.link.lwm2m.attributes.MixedLwM2mAttributeSet;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
 
@@ -40,5 +43,20 @@ public class MixedLwM2mLinkTest {
 
         link = new MixedLwM2mLink(null, new LwM2mPath(2));
         assertEquals("/2", link.getUriReference());
+    }
+
+    private class ExtendedMixedLwM2mLink extends MixedLwM2mLink {
+        public ExtendedMixedLwM2mLink(String rootPath, LwM2mPath path, Attribute... attributes) {
+            super(rootPath, path, new MixedLwM2mAttributeSet(attributes));
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedMixedLwM2mLink);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(MixedLwM2mLink.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedMixedLwM2mLink.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/MixedLwM2mLinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/MixedLwM2mLinkTest.java
@@ -17,13 +17,14 @@ package org.eclipse.leshan.core.link;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.link.attributes.Attribute;
 import org.eclipse.leshan.core.link.attributes.ResourceTypeAttribute;
 import org.eclipse.leshan.core.link.lwm2m.MixedLwM2mLink;
 import org.eclipse.leshan.core.link.lwm2m.attributes.MixedLwM2mAttributeSet;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class MixedLwM2mLinkTest {
 
@@ -49,6 +50,7 @@ public class MixedLwM2mLinkTest {
         public ExtendedMixedLwM2mLink(String rootPath, LwM2mPath path, Attribute... attributes) {
             super(rootPath, path, new MixedLwM2mAttributeSet(attributes));
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedMixedLwM2mLink);
@@ -57,6 +59,7 @@ public class MixedLwM2mLinkTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(MixedLwM2mLink.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedMixedLwM2mLink.class).verify();
+        EqualsVerifier.forClass(MixedLwM2mLink.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedMixedLwM2mLink.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import java.util.Collection;
 import java.util.Map;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.link.lwm2m.attributes.DefaultLwM2mAttributeParser;
 import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
@@ -155,5 +156,20 @@ public class AttributeSetTest {
             // OBJECT_VERSION cannot be assigned on resource level
             sut.validate(new LwM2mPath("/3/0/9"));
         });
+    }
+
+    private class ExtendedAttributeSet extends AttributeSet {
+        public ExtendedAttributeSet(Attribute... attributes) {
+            super(attributes);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof AttributeSetTest.ExtendedAttributeSet);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(AttributeSet.class).withRedefinedSubclass(AttributeSetTest.ExtendedAttributeSet.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/AttributeSetTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import java.util.Collection;
 import java.util.Map;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.link.lwm2m.attributes.DefaultLwM2mAttributeParser;
 import org.eclipse.leshan.core.link.lwm2m.attributes.InvalidAttributesException;
@@ -32,6 +31,8 @@ import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
 import org.eclipse.leshan.core.node.InvalidLwM2mPathException;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class AttributeSetTest {
     private static LwM2mAttributeParser parser = new DefaultLwM2mAttributeParser();
@@ -162,6 +163,7 @@ public class AttributeSetTest {
         public ExtendedAttributeSet(Attribute... attributes) {
             super(attributes);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof AttributeSetTest.ExtendedAttributeSet);
@@ -170,6 +172,7 @@ public class AttributeSetTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(AttributeSet.class).withRedefinedSubclass(AttributeSetTest.ExtendedAttributeSet.class).verify();
+        EqualsVerifier.forClass(AttributeSet.class).withRedefinedSubclass(AttributeSetTest.ExtendedAttributeSet.class)
+                .verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/BaseAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/BaseAttributeTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class BaseAttributeTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/BaseAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/BaseAttributeTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.leshan.core.link.attributes;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class BaseAttributeTest {
+
+    private class ExtendedBaseAttribute extends BaseAttribute {
+        public ExtendedBaseAttribute(String name, Object value) {
+            super(name, value, false);
+        }
+
+        @Override
+        public boolean canEqual(Object obj) {
+            return obj instanceof ExtendedBaseAttribute;
+        }
+
+        @Override
+        public String getCoreLinkValue() {
+            Object val = getValue();
+            return val != null ? val.toString() : "";
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(BaseAttribute.class).withRedefinedSubclass(ExtendedBaseAttribute.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/ValuelessAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/ValuelessAttributeTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.link.attributes;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ValuelessAttributeTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ValuelessAttribute.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/ValuelessAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/attributes/ValuelessAttributeTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link.attributes;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ValuelessAttributeTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeTest.java
@@ -1,13 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.link.lwm2m.attributes;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-class LwM2mAttributeTest {
+import nl.jqno.equalsverifier.EqualsVerifier;
 
+class LwM2mAttributeTest {
     @Test
     public void assertEqualsHashcode() {
         EqualsVerifier.forClass(LwM2mAttribute.class).verify();
     }
-
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/link/lwm2m/attributes/LwM2mAttributeTest.java
@@ -1,0 +1,13 @@
+package org.eclipse.leshan.core.link.lwm2m.attributes;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mAttributeTest {
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mAttribute.class).verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
@@ -1,15 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
+
 package org.eclipse.leshan.core.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.Test;
 
 class LwM2mModelRepositoryTest {
     @Test
     public void assertEqualsHashcode() {
-        // EqualsVerifier.forClass(LwM2mModelRepository.Key.class).suppress(Warning.NONFINAL_FIELDS).verify();
-        // Problem with Key class - it is a PRIVATE nested class - cannot access the hash/equals methods
+        // EqualsVerifier.forClass(LwM2mModelRepository.class).suppress(Warning.NONFINAL_FIELDS).verify();
+        // Problem with Key class (it is the one that should be tested) - it is a PRIVATE nested class - cannot access
+        // the hash/equals methods
         // Solution: make Key package-private for this test (it passes then)
     }
-  
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
@@ -18,12 +18,12 @@ package org.eclipse.leshan.core.model;
 
 import org.junit.jupiter.api.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+
 class LwM2mModelRepositoryTest {
     @Test
     public void assertEqualsHashcode() {
-        // EqualsVerifier.forClass(LwM2mModelRepository.class).suppress(Warning.NONFINAL_FIELDS).verify();
-        // Problem with Key class (it is the one that should be tested) - it is a PRIVATE nested class - cannot access
-        // the hash/equals methods
-        // Solution: make Key package-private for this test (it passes then)
+        EqualsVerifier.forClass(LwM2mModelRepository.Key.class).suppress(Warning.NONFINAL_FIELDS).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
@@ -1,0 +1,15 @@
+package org.eclipse.leshan.core.model;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class LwM2mModelRepositoryTest {
+    @Test
+    public void assertEqualsHashcode() {
+        // EqualsVerifier.forClass(LwM2mModelRepository.Key.class).suppress(Warning.NONFINAL_FIELDS).verify();
+        // Problem with Key class - it is a PRIVATE nested class - cannot access the hash/equals methods
+        // Solution: make Key package-private for this test (it passes then)
+    }
+  
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/model/LwM2mModelRepositoryTest.java
@@ -19,11 +19,10 @@ package org.eclipse.leshan.core.model;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 
 class LwM2mModelRepositoryTest {
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(LwM2mModelRepository.Key.class).suppress(Warning.NONFINAL_FIELDS).verify();
+        EqualsVerifier.forClass(LwM2mModelRepository.Key.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mMultipleResourceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mMultipleResourceTest.java
@@ -1,0 +1,13 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mMultipleResourceTest {
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mMultipleResource.class).verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mMultipleResourceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mMultipleResourceTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mMultipleResourceTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectInstanceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectInstanceTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mObjectInstanceTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mObjectInstance.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectInstanceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectInstanceTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mObjectInstanceTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mObjectTest {
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mObject.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mObjectTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mObjectTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
@@ -76,19 +76,8 @@ public class LwM2mPathTest {
 
     }
 
-    private class ExtendedLwM2mPath extends LwM2mPath {
-        public ExtendedLwM2mPath(int objectId) throws InvalidLwM2mPathException {
-            super(objectId);
-        }
-
-        @Override
-        public boolean canEqual(Object obj) {
-            return (obj instanceof ExtendedLwM2mPath);
-        }
-    }
-
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(LwM2mPath.class).withRedefinedSubclass(ExtendedLwM2mPath.class).verify();
+        EqualsVerifier.forClass(LwM2mPath.class).withRedefinedSubclass(LwM2mIncompletePath.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
@@ -76,11 +76,18 @@ public class LwM2mPathTest {
 
     }
 
+    private class ExtendedLwM2mPath extends LwM2mPath {
+        public ExtendedLwM2mPath(int objectId) throws InvalidLwM2mPathException {
+            super(objectId);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedLwM2mPath);
+        }
+    }
+
     @Test
     public void assertEqualsHashcode() {
-        // TODO we should not use EqualsVerifier.simple()
-        // But implement a right hashcode/equals way
-        // see : https://github.com/eclipse-leshan/leshan/issues/1504
-        EqualsVerifier.simple().forClass(LwM2mPath.class).verify();
+        EqualsVerifier.forClass(LwM2mPath.class).withRedefinedSubclass(ExtendedLwM2mPath.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mPathTest.java
@@ -80,6 +80,7 @@ public class LwM2mPathTest {
         public ExtendedLwM2mPath(int objectId) throws InvalidLwM2mPathException {
             super(objectId);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedLwM2mPath);

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mResourceInstanceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mResourceInstanceTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mResourceInstanceTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mResourceInstance.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mResourceInstanceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mResourceInstanceTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mResourceInstanceTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mRootTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mRootTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mRootTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mRoot.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mRootTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mRootTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mRootTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mSingleResourceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mSingleResourceTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class LwM2mSingleResourceTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(LwM2mSingleResource.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mSingleResourceTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/LwM2mSingleResourceTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class LwM2mSingleResourceTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/ObjectLinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/ObjectLinkTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ObjectLinkTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/ObjectLinkTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/ObjectLinkTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ObjectLinkTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ObjectLink.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodeTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.node;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class TimestampedLwM2mNodeTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(TimestampedLwM2mNode.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodeTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodeTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.node;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class TimestampedLwM2mNodeTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodesTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodesTest.java
@@ -28,8 +28,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class TimestampedLwM2mNodesTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodesTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/node/TimestampedLwM2mNodesTest.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 public class TimestampedLwM2mNodesTest {
@@ -221,5 +222,10 @@ public class TimestampedLwM2mNodesTest {
         tsNodes.put(new LwM2mPath("/0/0/2"), LwM2mSingleResource.newIntegerResource(2, 222L));
         tsNodes.put(timestamp_1E9_ms, new LwM2mPath("/0/0/1"), LwM2mSingleResource.newIntegerResource(1, 111L));
         return tsNodes.build();
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(TimestampedLwM2mNodes.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
@@ -43,6 +43,6 @@ class CompositeObservationTest {
     @Test
     public void assertEqualsHashcode() {
         EqualsVerifier.forClass(CompositeObservation.class).withRedefinedSuperclass()
-                .withRedefinedSubclass(ExtendedCompositeObservation.class).verify();
+                .withRedefinedSubclass(ExtendedCompositeObservation.class).withIgnoredFields("protocolData").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
@@ -1,0 +1,31 @@
+package org.eclipse.leshan.core.observation;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+class CompositeObservationTest {
+
+    public class ExtendedCompositeObservation extends CompositeObservation {
+
+        public ExtendedCompositeObservation(ObservationIdentifier id, String registrationId, List<LwM2mPath> paths,
+                                            ContentFormat requestContentFormat, ContentFormat responseContentFormat, Map<String, String> context,
+                                            Map<String, String> protocolData) {
+            super(id, registrationId, paths, requestContentFormat, responseContentFormat, context, protocolData);
+        }
+
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedCompositeObservation);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(CompositeObservation.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedCompositeObservation.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/CompositeObservationTest.java
@@ -1,20 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.observation;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.List;
+import java.util.Map;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class CompositeObservationTest {
 
     public class ExtendedCompositeObservation extends CompositeObservation {
 
         public ExtendedCompositeObservation(ObservationIdentifier id, String registrationId, List<LwM2mPath> paths,
-                                            ContentFormat requestContentFormat, ContentFormat responseContentFormat, Map<String, String> context,
-                                            Map<String, String> protocolData) {
+                ContentFormat requestContentFormat, ContentFormat responseContentFormat, Map<String, String> context,
+                Map<String, String> protocolData) {
             super(id, registrationId, paths, requestContentFormat, responseContentFormat, context, protocolData);
         }
 
@@ -26,6 +42,7 @@ class CompositeObservationTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(CompositeObservation.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedCompositeObservation.class).verify();
+        EqualsVerifier.forClass(CompositeObservation.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedCompositeObservation.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/ObservationIdentifierTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/ObservationIdentifierTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.observation;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ObservationIdentifierTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/ObservationIdentifierTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/ObservationIdentifierTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.observation;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ObservationIdentifierTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ObservationIdentifier.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
@@ -1,26 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.observation;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.Map;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.ContentFormat;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class SingleObservationTest {
 
     private class ExtendedSingleObservation extends SingleObservation {
         ExtendedSingleObservation(ObservationIdentifier id, String registrationId, LwM2mPath path,
-                                  ContentFormat contentFormat, Map<String, String> context, Map<String, String> protocolData) {
+                ContentFormat contentFormat, Map<String, String> context, Map<String, String> protocolData) {
             super(id, registrationId, path, contentFormat, context, protocolData);
         }
+
         @Override
-        public boolean canEqual(Object obj){
+        public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedSingleObservation);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(SingleObservation.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedSingleObservation.class).verify();
+        EqualsVerifier.forClass(SingleObservation.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedSingleObservation.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.leshan.core.observation;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.request.ContentFormat;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class SingleObservationTest {
+
+    private class ExtendedSingleObservation extends SingleObservation {
+        ExtendedSingleObservation(ObservationIdentifier id, String registrationId, LwM2mPath path,
+                                  ContentFormat contentFormat, Map<String, String> context, Map<String, String> protocolData) {
+            super(id, registrationId, path, contentFormat, context, protocolData);
+        }
+        @Override
+        public boolean canEqual(Object obj){
+            return (obj instanceof ExtendedSingleObservation);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SingleObservation.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedSingleObservation.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/observation/SingleObservationTest.java
@@ -40,6 +40,6 @@ class SingleObservationTest {
     @Test
     public void assertEqualsHashcode() {
         EqualsVerifier.forClass(SingleObservation.class).withRedefinedSuperclass()
-                .withRedefinedSubclass(ExtendedSingleObservation.class).verify();
+                .withRedefinedSubclass(ExtendedSingleObservation.class).withIgnoredFields("protocolData").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/AeadAlgorithmTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/AeadAlgorithmTest.java
@@ -1,0 +1,14 @@
+package org.eclipse.leshan.core.oscore;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.observation.ObservationIdentifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AeadAlgorithmTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(AeadAlgorithm.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/AeadAlgorithmTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/AeadAlgorithmTest.java
@@ -1,10 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.oscore;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.eclipse.leshan.core.observation.ObservationIdentifier;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class AeadAlgorithmTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/OscoreSettingTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/OscoreSettingTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.oscore;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class OscoreSettingTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/OscoreSettingTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/oscore/OscoreSettingTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.oscore;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class OscoreSettingTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(OscoreSetting.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/IpPeerTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/IpPeerTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class IpPeerTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(IpPeer.class).withIgnoredFields("virtualHost").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/IpPeerTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/IpPeerTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class IpPeerTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/OscoreIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/OscoreIdentityTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class OscoreIdentityTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(OscoreIdentity.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/OscoreIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/OscoreIdentityTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class OscoreIdentityTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/PskIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/PskIdentityTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class PskIdentityTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/PskIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/PskIdentityTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class PskIdentityTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(PskIdentity.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/RpkIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/RpkIdentityTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class RpkIdentityTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(RpkIdentity.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/RpkIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/RpkIdentityTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class RpkIdentityTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/SocketIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/SocketIdentityTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class SocketIdentityTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SocketIdentity.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/SocketIdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/SocketIdentityTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class SocketIdentityTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/X509IdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/X509IdentityTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.peer;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class X509IdentityTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(X509Identity.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/X509IdentityTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/peer/X509IdentityTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.peer;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class X509IdentityTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
@@ -1,0 +1,27 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.junit.jupiter.api.Test;
+
+class AbstractSimpleDownlinkRequestTest {
+    private class ExtendedAbstractSimpleDownlinkRequest extends AbstractSimpleDownlinkRequest {
+        public ExtendedAbstractSimpleDownlinkRequest(LwM2mPath path, Object coapRequest) {
+            super(path, coapRequest);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedAbstractSimpleDownlinkRequest);
+        }
+
+        @Override
+        public void accept(DownlinkRequestVisitor visitor) {
+
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(ExtendedAbstractSimpleDownlinkRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
@@ -15,32 +15,38 @@
  *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 class AbstractSimpleDownlinkRequestTest {
-    private class ExtendedAbstractSimpleDownlinkRequest extends AbstractSimpleDownlinkRequest {
-        public ExtendedAbstractSimpleDownlinkRequest(LwM2mPath path, Object coapRequest) {
-            super(path, coapRequest);
-        }
-
-        @Override
-        public boolean canEqual(Object obj) {
-            return (obj instanceof ExtendedAbstractSimpleDownlinkRequest);
-        }
-
-        @Override
-        public void accept(DownlinkRequestVisitor visitor) {
-
-        }
-    }
-
     @Test
     public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(CreateRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(BootstrapReadRequest.class)
+                .withIgnoredFields("coapRequest").verify();
         EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class)
-                .withRedefinedSubclass(ExtendedAbstractSimpleDownlinkRequest.class).withIgnoredFields("coapRequest")
-                .verify();
+                .withRedefinedSubclass(CancelObservationRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(ExecuteRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(ObserveRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(ReadRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(WriteAttributesRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(WriteRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(DiscoverRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(BootstrapDeleteRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class)
+                .withRedefinedSubclass(BootstrapDiscoverRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(BootstrapWriteRequest.class)
+                .withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(DeleteRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/AbstractSimpleDownlinkRequestTest.java
@@ -1,14 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class AbstractSimpleDownlinkRequestTest {
     private class ExtendedAbstractSimpleDownlinkRequest extends AbstractSimpleDownlinkRequest {
         public ExtendedAbstractSimpleDownlinkRequest(LwM2mPath path, Object coapRequest) {
             super(path, coapRequest);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedAbstractSimpleDownlinkRequest);
@@ -22,6 +39,8 @@ class AbstractSimpleDownlinkRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class).withRedefinedSubclass(ExtendedAbstractSimpleDownlinkRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(AbstractSimpleDownlinkRequest.class)
+                .withRedefinedSubclass(ExtendedAbstractSimpleDownlinkRequest.class).withIgnoredFields("coapRequest")
+                .verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapReadRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapReadRequestTest.java
@@ -1,0 +1,21 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class BootstrapReadRequestTest {
+
+    private class ExtendedBootstrapReadRequest extends BootstrapReadRequest {
+        ExtendedBootstrapReadRequest(int objectId) {
+            super(null, newPath(objectId), null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedBootstrapReadRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(BootstrapReadRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedBootstrapReadRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapReadRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapReadRequestTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class BootstrapReadRequestTest {
 
@@ -9,13 +25,16 @@ class BootstrapReadRequestTest {
         ExtendedBootstrapReadRequest(int objectId) {
             super(null, newPath(objectId), null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedBootstrapReadRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(BootstrapReadRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedBootstrapReadRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(BootstrapReadRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedBootstrapReadRequest.class).withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapRequestTest.java
@@ -1,0 +1,22 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+class BootstrapRequestTest {
+
+    private class ExtendedBootstrapRequest extends BootstrapRequest {
+        public ExtendedBootstrapRequest(String endpointName) throws InvalidRequestException {
+            super(endpointName, null, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedBootstrapRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(BootstrapRequest.class).withRedefinedSubclass(ExtendedBootstrapRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/BootstrapRequestTest.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class BootstrapRequestTest {
 
@@ -10,13 +26,16 @@ class BootstrapRequestTest {
         public ExtendedBootstrapRequest(String endpointName) throws InvalidRequestException {
             super(endpointName, null, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedBootstrapRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(BootstrapRequest.class).withRedefinedSubclass(ExtendedBootstrapRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(BootstrapRequest.class).withRedefinedSubclass(ExtendedBootstrapRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CancelObservationRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CancelObservationRequestTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.observation.SingleObservation;
+import org.junit.jupiter.api.Test;
+
+
+class CancelObservationRequestTest {
+
+    public class ExtendedCancelObservationRequest extends CancelObservationRequest {
+
+        public ExtendedCancelObservationRequest(SingleObservation observation) {
+            super(observation);
+        }
+
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedCancelObservationRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(CancelObservationRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedCancelObservationRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CancelObservationRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CancelObservationRequestTest.java
@@ -1,9 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.observation.SingleObservation;
 import org.junit.jupiter.api.Test;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class CancelObservationRequestTest {
 
@@ -21,6 +36,8 @@ class CancelObservationRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(CancelObservationRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedCancelObservationRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(CancelObservationRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedCancelObservationRequest.class).withIgnoredFields("coapRequest")
+                .verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ContentFormatTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ContentFormatTest.java
@@ -28,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.junit.jupiter.api.Test;
@@ -50,5 +52,10 @@ public class ContentFormatTest {
 
         assertEquals(Arrays.asList(TLV, JSON, SENML_JSON, SENML_CBOR, CBOR), optionalContentFormat);
 
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ContentFormat.class).withIgnoredFields("name", "mediaType", "mandatoryForClient").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ContentFormatTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ContentFormatTest.java
@@ -28,11 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import nl.jqno.equalsverifier.Warning;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.node.codec.CodecException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ContentFormatTest {
 
@@ -56,6 +56,7 @@ public class ContentFormatTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ContentFormat.class).withIgnoredFields("name", "mediaType", "mandatoryForClient").verify();
+        EqualsVerifier.forClass(ContentFormat.class).withIgnoredFields("name", "mediaType", "mandatoryForClient")
+                .verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CreateRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CreateRequestTest.java
@@ -1,9 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class CreateRequestTest {
 
@@ -21,6 +37,7 @@ class CreateRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(CreateRequest.class).withRedefinedSubclass(ExtendedCreateRequest.class).withRedefinedSuperclass().withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(CreateRequest.class).withRedefinedSubclass(ExtendedCreateRequest.class)
+                .withRedefinedSuperclass().withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CreateRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/CreateRequestTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.LwM2mResource;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+class CreateRequestTest {
+
+    public class ExtendedCreateRequest extends CreateRequest {
+        public ExtendedCreateRequest(ContentFormat contentFormat, int objectId, LwM2mResource... resources)
+                throws InvalidRequestException {
+            super(contentFormat, objectId, resources);
+        }
+
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedCreateRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(CreateRequest.class).withRedefinedSubclass(ExtendedCreateRequest.class).withRedefinedSuperclass().withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/DeregisterRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/DeregisterRequestTest.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class DeregisterRequestTest {
 
@@ -10,13 +26,16 @@ class DeregisterRequestTest {
         public ExtendedDeregisterRequest(String registrationId) throws InvalidRequestException {
             super(registrationId, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedDeregisterRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(DeregisterRequest.class).withRedefinedSubclass(ExtendedDeregisterRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(DeregisterRequest.class).withRedefinedSubclass(ExtendedDeregisterRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/DeregisterRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/DeregisterRequestTest.java
@@ -1,0 +1,22 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+class DeregisterRequestTest {
+
+    private class ExtendedDeregisterRequest extends DeregisterRequest {
+        public ExtendedDeregisterRequest(String registrationId) throws InvalidRequestException {
+            super(registrationId, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedDeregisterRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(DeregisterRequest.class).withRedefinedSubclass(ExtendedDeregisterRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ExecuteRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ExecuteRequestTest.java
@@ -1,9 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.request.argument.Arguments;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ExecuteRequestTest {
 
@@ -11,14 +27,17 @@ class ExecuteRequestTest {
         ExtendedExecuteRequest(String path) throws InvalidRequestException {
             super(path, (Arguments) null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedExecuteRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ExecuteRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedExecuteRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(ExecuteRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedExecuteRequest.class).withIgnoredFields("coapRequest").verify();
     }
 
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ExecuteRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ExecuteRequestTest.java
@@ -1,0 +1,24 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.request.argument.Arguments;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+class ExecuteRequestTest {
+
+    private class ExtendedExecuteRequest extends ExecuteRequest {
+        ExtendedExecuteRequest(String path) throws InvalidRequestException {
+            super(path, (Arguments) null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedExecuteRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ExecuteRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedExecuteRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveCompositeRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveCompositeRequestTest.java
@@ -1,0 +1,26 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.LwM2mPath;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+class ObserveCompositeRequestTest {
+
+    private class ExtendedObserveCompositeRequest extends ObserveCompositeRequest {
+        ExtendedObserveCompositeRequest(ContentFormat requestContentFormat, ContentFormat responseContentFormat,
+                                        List<LwM2mPath> paths) {
+            super(requestContentFormat, responseContentFormat, paths, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedObserveCompositeRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ObserveCompositeRequest.class).withRedefinedSubclass(ExtendedObserveCompositeRequest.class).withIgnoredFields("context", "coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveCompositeRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveCompositeRequestTest.java
@@ -1,26 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.List;
+
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ObserveCompositeRequestTest {
 
     private class ExtendedObserveCompositeRequest extends ObserveCompositeRequest {
         ExtendedObserveCompositeRequest(ContentFormat requestContentFormat, ContentFormat responseContentFormat,
-                                        List<LwM2mPath> paths) {
+                List<LwM2mPath> paths) {
             super(requestContentFormat, responseContentFormat, paths, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedObserveCompositeRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ObserveCompositeRequest.class).withRedefinedSubclass(ExtendedObserveCompositeRequest.class).withIgnoredFields("context", "coapRequest").verify();
+        EqualsVerifier.forClass(ObserveCompositeRequest.class)
+                .withRedefinedSubclass(ExtendedObserveCompositeRequest.class)
+                .withIgnoredFields("context", "coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveRequestTest.java
@@ -1,0 +1,21 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ObserveRequestTest {
+
+    private class ExtendedObserveRequest extends ObserveRequest {
+        public ExtendedObserveRequest(int objectId) {
+            super((String) null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedObserveRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ObserveRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedObserveRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ObserveRequestTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ObserveRequestTest {
 
@@ -9,13 +25,16 @@ class ObserveRequestTest {
         public ExtendedObserveRequest(int objectId) {
             super((String) null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedObserveRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ObserveRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedObserveRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(ObserveRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedObserveRequest.class).withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadCompositeRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadCompositeRequestTest.java
@@ -1,23 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ReadCompositeRequestTest {
     private class ExtendedReadCompositeRequest extends ReadCompositeRequest {
         ExtendedReadCompositeRequest(ContentFormat requestContentFormat, ContentFormat responseContentFormat,
-                                     String... paths) {
+                String... paths) {
             super(null, requestContentFormat, responseContentFormat, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedReadCompositeRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ReadCompositeRequest.class).withRedefinedSubclass(ExtendedReadCompositeRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(ReadCompositeRequest.class).withRedefinedSubclass(ExtendedReadCompositeRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadCompositeRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadCompositeRequestTest.java
@@ -1,0 +1,23 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class ReadCompositeRequestTest {
+    private class ExtendedReadCompositeRequest extends ReadCompositeRequest {
+        ExtendedReadCompositeRequest(ContentFormat requestContentFormat, ContentFormat responseContentFormat,
+                                     String... paths) {
+            super(null, requestContentFormat, responseContentFormat, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedReadCompositeRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ReadCompositeRequest.class).withRedefinedSubclass(ExtendedReadCompositeRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadRequestTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ReadRequestTest {
 
@@ -9,13 +25,16 @@ class ReadRequestTest {
         public ExtendedReadRequest(int objectId) {
             super(null, newPath(objectId), null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedReadRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(ReadRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedReadRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(ReadRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedReadRequest.class).withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/ReadRequestTest.java
@@ -1,0 +1,21 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ReadRequestTest {
+
+    private class ExtendedReadRequest extends ReadRequest {
+        public ExtendedReadRequest(int objectId) {
+            super(null, newPath(objectId), null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedReadRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ReadRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedReadRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/RegisterRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/RegisterRequestTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.link.Link;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+class RegisterRequestTest {
+
+    private class ExtendedRegisterRequest extends RegisterRequest {
+        ExtendedRegisterRequest(String endpointName, Long lifetime, String lwVersion, EnumSet<BindingMode> bindingMode,
+                                Boolean queueMode, String smsNumber, Link[] objectLinks, Map<String, String> additionalAttributes)
+                throws InvalidRequestException {
+            super(endpointName, lifetime, lwVersion, bindingMode, queueMode, smsNumber, objectLinks, additionalAttributes,
+                    null);
+        }
+        @Override
+        public boolean canEqual(Object o){
+            return (o instanceof ExtendedRegisterRequest);
+        }
+    }
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(RegisterRequest.class).withRedefinedSubclass(ExtendedRegisterRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/RegisterRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/RegisterRequestTest.java
@@ -1,29 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.EnumSet;
+import java.util.Map;
+
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
-import java.util.EnumSet;
-import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class RegisterRequestTest {
 
     private class ExtendedRegisterRequest extends RegisterRequest {
         ExtendedRegisterRequest(String endpointName, Long lifetime, String lwVersion, EnumSet<BindingMode> bindingMode,
-                                Boolean queueMode, String smsNumber, Link[] objectLinks, Map<String, String> additionalAttributes)
+                Boolean queueMode, String smsNumber, Link[] objectLinks, Map<String, String> additionalAttributes)
                 throws InvalidRequestException {
-            super(endpointName, lifetime, lwVersion, bindingMode, queueMode, smsNumber, objectLinks, additionalAttributes,
-                    null);
+            super(endpointName, lifetime, lwVersion, bindingMode, queueMode, smsNumber, objectLinks,
+                    additionalAttributes, null);
         }
+
         @Override
-        public boolean canEqual(Object o){
+        public boolean canEqual(Object o) {
             return (o instanceof ExtendedRegisterRequest);
         }
     }
+
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(RegisterRequest.class).withRedefinedSubclass(ExtendedRegisterRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(RegisterRequest.class).withRedefinedSubclass(ExtendedRegisterRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/SendRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/SendRequestTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
@@ -57,4 +58,20 @@ public class SendRequestTest {
             new SendRequest(ContentFormat.SENML_JSON, nodes);
         });
     }
+
+    private class ExtendedSendRequest extends SendRequest {
+        ExtendedSendRequest(ContentFormat format, Map<LwM2mPath, LwM2mNode> nodes) {
+            super(format, nodes, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedSendRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SendRequest.class).withRedefinedSubclass(ExtendedSendRequest.class).withIgnoredFields("coapRequest").verify();
+    }
 }
+

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/SendRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/SendRequestTest.java
@@ -21,12 +21,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.node.LwM2mNode;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.node.LwM2mSingleResource;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class SendRequestTest {
 
@@ -63,6 +64,7 @@ public class SendRequestTest {
         ExtendedSendRequest(ContentFormat format, Map<LwM2mPath, LwM2mNode> nodes) {
             super(format, nodes, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedSendRequest);
@@ -71,7 +73,7 @@ public class SendRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(SendRequest.class).withRedefinedSubclass(ExtendedSendRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(SendRequest.class).withRedefinedSubclass(ExtendedSendRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 }
-

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/UpdateRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/UpdateRequestTest.java
@@ -1,0 +1,29 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.link.Link;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumSet;
+import java.util.Map;
+
+class UpdateRequestTest {
+
+    private class ExtendedUpdateRequest extends UpdateRequest {
+        ExtendedUpdateRequest(String registrationId, Long lifetime, String smsNumber, EnumSet<BindingMode> binding,
+                              Link[] objectLinks, Map<String, String> additionalAttributes) throws InvalidRequestException {
+            super(registrationId, lifetime, smsNumber, binding, objectLinks, additionalAttributes, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedUpdateRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(UpdateRequest.class).withRedefinedSubclass(ExtendedUpdateRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/UpdateRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/UpdateRequestTest.java
@@ -1,20 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
+import java.util.EnumSet;
+import java.util.Map;
+
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
-import java.util.EnumSet;
-import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class UpdateRequestTest {
 
     private class ExtendedUpdateRequest extends UpdateRequest {
         ExtendedUpdateRequest(String registrationId, Long lifetime, String smsNumber, EnumSet<BindingMode> binding,
-                              Link[] objectLinks, Map<String, String> additionalAttributes) throws InvalidRequestException {
+                Link[] objectLinks, Map<String, String> additionalAttributes) throws InvalidRequestException {
             super(registrationId, lifetime, smsNumber, binding, objectLinks, additionalAttributes, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedUpdateRequest);
@@ -23,7 +40,8 @@ class UpdateRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(UpdateRequest.class).withRedefinedSubclass(ExtendedUpdateRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(UpdateRequest.class).withRedefinedSubclass(ExtendedUpdateRequest.class)
+                .withIgnoredFields("coapRequest").verify();
     }
 
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
@@ -17,12 +17,13 @@ package org.eclipse.leshan.core.request;
 
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
 import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class WriteAttributesRequestTest {
 
@@ -106,6 +107,7 @@ public class WriteAttributesRequestTest {
         ExtendedWriteAttributesRequest(LwM2mPath path, LwM2mAttributeSet attributes) {
             super(String.valueOf(path), attributes, null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedWriteAttributesRequest);
@@ -114,6 +116,7 @@ public class WriteAttributesRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(WriteAttributesRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedWriteAttributesRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(WriteAttributesRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedWriteAttributesRequest.class).withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteAttributesRequestTest.java
@@ -17,8 +17,10 @@ package org.eclipse.leshan.core.request;
 
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributeSet;
 import org.eclipse.leshan.core.link.lwm2m.attributes.LwM2mAttributes;
+import org.eclipse.leshan.core.node.LwM2mPath;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
@@ -98,5 +100,20 @@ public class WriteAttributesRequestTest {
         assertThrowsExactly(InvalidRequestException.class, () -> {
             new WriteAttributesRequest(3, 0, 9, sut);
         });
+    }
+
+    public class ExtendedWriteAttributesRequest extends WriteAttributesRequest {
+        ExtendedWriteAttributesRequest(LwM2mPath path, LwM2mAttributeSet attributes) {
+            super(String.valueOf(path), attributes, null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedWriteAttributesRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(WriteAttributesRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedWriteAttributesRequest.class).withIgnoredFields("coapRequest").verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteRequestTest.java
@@ -1,0 +1,28 @@
+package org.eclipse.leshan.core.request;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.leshan.core.node.*;
+import org.eclipse.leshan.core.request.exception.InvalidRequestException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+class WriteRequestTest {
+    private class ExtendedWriteRequest extends WriteRequest {
+        public ExtendedWriteRequest(Mode mode, ContentFormat contentFormat, int objectId, int objectInstanceId,
+                            Collection<LwM2mResource> resources) throws InvalidRequestException {
+            super(mode, contentFormat, newPath(objectId, objectInstanceId), new LwM2mObjectInstance(objectId, resources),
+                    null);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedWriteRequest);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(WriteRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedWriteRequest.class).withIgnoredFields("coapRequest").verify();
+    }
+
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteRequestTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/WriteRequestTest.java
@@ -1,19 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.eclipse.leshan.core.node.*;
+import java.util.Collection;
+
+import org.eclipse.leshan.core.node.LwM2mObjectInstance;
+import org.eclipse.leshan.core.node.LwM2mResource;
 import org.eclipse.leshan.core.request.exception.InvalidRequestException;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class WriteRequestTest {
     private class ExtendedWriteRequest extends WriteRequest {
         public ExtendedWriteRequest(Mode mode, ContentFormat contentFormat, int objectId, int objectInstanceId,
-                            Collection<LwM2mResource> resources) throws InvalidRequestException {
-            super(mode, contentFormat, newPath(objectId, objectInstanceId), new LwM2mObjectInstance(objectId, resources),
-                    null);
+                Collection<LwM2mResource> resources) throws InvalidRequestException {
+            super(mode, contentFormat, newPath(objectId, objectInstanceId),
+                    new LwM2mObjectInstance(objectId, resources), null);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedWriteRequest);
@@ -22,7 +40,8 @@ class WriteRequestTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(WriteRequest.class).withRedefinedSuperclass().withRedefinedSubclass(ExtendedWriteRequest.class).withIgnoredFields("coapRequest").verify();
+        EqualsVerifier.forClass(WriteRequest.class).withRedefinedSuperclass()
+                .withRedefinedSubclass(ExtendedWriteRequest.class).withIgnoredFields("coapRequest").verify();
     }
 
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.request.argument;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ArgumentTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.core.request.argument;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ArgumentTest {
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Argument.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentsTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentsTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
 
 public class ArgumentsTest {
@@ -102,5 +103,10 @@ public class ArgumentsTest {
                     .addArgument(3, "stringValue") //
                     .build();
         });
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Arguments.class).verify();
     }
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentsTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/request/argument/ArgumentsTest.java
@@ -24,8 +24,9 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ArgumentsTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
@@ -24,8 +24,9 @@ class TlvTest {
 
     @Test
     public void assertEqualsHashcode() {
+        byte[] bytes = {1, 2, 3, 4, 5};
         Tlv prefab1 = new Tlv(Tlv.TlvType.OBJECT_INSTANCE, new Tlv[0], null, 1);
-        Tlv prefab2 = new Tlv(Tlv.TlvType.OBJECT_INSTANCE, new Tlv[0], null, 2);
+        Tlv prefab2 = new Tlv(Tlv.TlvType.RESOURCE_VALUE, null, bytes, 2);
 
         EqualsVerifier.forClass(Tlv.class).withPrefabValues(Tlv.class, prefab1, prefab2).verify();
     }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
@@ -24,7 +24,7 @@ class TlvTest {
 
     @Test
     public void assertEqualsHashcode() {
-        byte[] bytes = {1, 2, 3, 4, 5};
+        byte[] bytes = { 1, 2, 3, 4, 5 };
         Tlv prefab1 = new Tlv(Tlv.TlvType.OBJECT_INSTANCE, new Tlv[0], null, 1);
         Tlv prefab2 = new Tlv(Tlv.TlvType.RESOURCE_VALUE, null, bytes, 2);
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
@@ -1,0 +1,15 @@
+package org.eclipse.leshan.core.tlv;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class TlvTest {
+
+    @Test
+    public void assertEqualsHashcode() {
+        Tlv prefab1 = new Tlv(Tlv.TlvType.OBJECT_INSTANCE, new Tlv[0], null, 1);
+        Tlv prefab2 = new Tlv(Tlv.TlvType.OBJECT_INSTANCE, new Tlv[0], null, 2);
+
+        EqualsVerifier.forClass(Tlv.class).withPrefabValues(Tlv.class, prefab1, prefab2).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/tlv/TlvTest.java
@@ -1,7 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
+
 package org.eclipse.leshan.core.tlv;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class TlvTest {
 

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/util/datatype/ULongTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/util/datatype/ULongTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.core.util.datatype;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class ULongTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/util/datatype/ULongTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/core/util/datatype/ULongTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.core.util.datatype;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class ULongTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(ULong.class).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLPackTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLPackTest.java
@@ -1,8 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.senml;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class SenMLPackTest {
     @Test

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLPackTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLPackTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.senml;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class SenMLPackTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SenMLPack.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLRecordTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLRecordTest.java
@@ -1,12 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.senml;
+
+import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-import org.junit.jupiter.api.Test;
 
 class SenMLRecordTest {
     @Test
     public void assertEqualsHashcode() {
         EqualsVerifier.forClass(SenMLRecord.class).suppress(Warning.NONFINAL_FIELDS).verify();
     }
+
 }

--- a/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLRecordTest.java
+++ b/leshan-lwm2m-core/src/test/java/org/eclipse/leshan/senml/SenMLRecordTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.senml;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import nl.jqno.equalsverifier.Warning;
+import org.junit.jupiter.api.Test;
+
+class SenMLRecordTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SenMLRecord.class).suppress(Warning.NONFINAL_FIELDS).verify();
+    }
+}

--- a/leshan-lwm2m-server/pom.xml
+++ b/leshan-lwm2m-server/pom.xml
@@ -56,9 +56,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-server/pom.xml
+++ b/leshan-lwm2m-server/pom.xml
@@ -56,5 +56,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -20,7 +20,17 @@ package org.eclipse.leshan.server.registration;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
@@ -364,25 +374,30 @@ public class Registration {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Registration)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof Registration))
+            return false;
         Registration that = (Registration) o;
         return lifeTimeInSec == that.lifeTimeInSec && Objects.equals(registrationDate, that.registrationDate)
-                && Objects.equals(clientTransportData, that.clientTransportData) && Objects.equals(smsNumber, that.smsNumber)
-                && Objects.equals(lwM2mVersion, that.lwM2mVersion) && Objects.equals(bindingMode, that.bindingMode)
-                && Objects.equals(queueMode, that.queueMode) && Objects.equals(endpoint, that.endpoint)
-                && Objects.equals(id, that.id) && Objects.deepEquals(objectLinks, that.objectLinks)
-                && Objects.equals(additionalRegistrationAttributes, that.additionalRegistrationAttributes) && Objects.equals(rootPath, that.rootPath)
-                && Objects.equals(supportedContentFormats, that.supportedContentFormats) && Objects.equals(supportedObjects, that.supportedObjects)
-                && Objects.equals(availableInstances, that.availableInstances) && Objects.equals(lastUpdate, that.lastUpdate)
-                && Objects.equals(applicationData, that.applicationData);
+                && Objects.equals(clientTransportData, that.clientTransportData)
+                && Objects.equals(smsNumber, that.smsNumber) && Objects.equals(lwM2mVersion, that.lwM2mVersion)
+                && Objects.equals(bindingMode, that.bindingMode) && Objects.equals(queueMode, that.queueMode)
+                && Objects.equals(endpoint, that.endpoint) && Objects.equals(id, that.id)
+                && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(additionalRegistrationAttributes, that.additionalRegistrationAttributes)
+                && Objects.equals(rootPath, that.rootPath)
+                && Objects.equals(supportedContentFormats, that.supportedContentFormats)
+                && Objects.equals(supportedObjects, that.supportedObjects)
+                && Objects.equals(availableInstances, that.availableInstances)
+                && Objects.equals(lastUpdate, that.lastUpdate) && Objects.equals(applicationData, that.applicationData);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(registrationDate, clientTransportData, lifeTimeInSec, smsNumber, lwM2mVersion,
-                bindingMode, queueMode, endpoint, id, Arrays.hashCode(objectLinks), additionalRegistrationAttributes,
-                rootPath, supportedContentFormats, supportedObjects, availableInstances, lastUpdate, applicationData);
+        return Objects.hash(registrationDate, clientTransportData, lifeTimeInSec, smsNumber, lwM2mVersion, bindingMode,
+                queueMode, endpoint, id, Arrays.hashCode(objectLinks), additionalRegistrationAttributes, rootPath,
+                supportedContentFormats, supportedObjects, availableInstances, lastUpdate, applicationData);
     }
 
     public static class Builder {

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -20,16 +20,7 @@ package org.eclipse.leshan.server.registration;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
@@ -372,119 +363,26 @@ public class Registration {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result
-                + ((additionalRegistrationAttributes == null) ? 0 : additionalRegistrationAttributes.hashCode());
-        result = prime * result + ((applicationData == null) ? 0 : applicationData.hashCode());
-        result = prime * result + ((availableInstances == null) ? 0 : availableInstances.hashCode());
-        result = prime * result + ((bindingMode == null) ? 0 : bindingMode.hashCode());
-        result = prime * result + ((endpoint == null) ? 0 : endpoint.hashCode());
-        result = prime * result + ((id == null) ? 0 : id.hashCode());
-        result = prime * result + ((clientTransportData == null) ? 0 : clientTransportData.hashCode());
-        result = prime * result + ((lastUpdate == null) ? 0 : lastUpdate.hashCode());
-        result = prime * result + (int) (lifeTimeInSec ^ (lifeTimeInSec >>> 32));
-        result = prime * result + ((lwM2mVersion == null) ? 0 : lwM2mVersion.hashCode());
-        result = prime * result + Arrays.hashCode(objectLinks);
-        result = prime * result + ((queueMode == null) ? 0 : queueMode.hashCode());
-        result = prime * result + ((registrationDate == null) ? 0 : registrationDate.hashCode());
-        result = prime * result + ((rootPath == null) ? 0 : rootPath.hashCode());
-        result = prime * result + ((smsNumber == null) ? 0 : smsNumber.hashCode());
-        result = prime * result + ((supportedContentFormats == null) ? 0 : supportedContentFormats.hashCode());
-        result = prime * result + ((supportedObjects == null) ? 0 : supportedObjects.hashCode());
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Registration)) return false;
+        Registration that = (Registration) o;
+        return lifeTimeInSec == that.lifeTimeInSec && Objects.equals(registrationDate, that.registrationDate)
+                && Objects.equals(clientTransportData, that.clientTransportData) && Objects.equals(smsNumber, that.smsNumber)
+                && Objects.equals(lwM2mVersion, that.lwM2mVersion) && Objects.equals(bindingMode, that.bindingMode)
+                && Objects.equals(queueMode, that.queueMode) && Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(id, that.id) && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(additionalRegistrationAttributes, that.additionalRegistrationAttributes) && Objects.equals(rootPath, that.rootPath)
+                && Objects.equals(supportedContentFormats, that.supportedContentFormats) && Objects.equals(supportedObjects, that.supportedObjects)
+                && Objects.equals(availableInstances, that.availableInstances) && Objects.equals(lastUpdate, that.lastUpdate)
+                && Objects.equals(applicationData, that.applicationData);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        Registration other = (Registration) obj;
-        if (additionalRegistrationAttributes == null) {
-            if (other.additionalRegistrationAttributes != null)
-                return false;
-        } else if (!additionalRegistrationAttributes.equals(other.additionalRegistrationAttributes))
-            return false;
-        if (applicationData == null) {
-            if (other.applicationData != null)
-                return false;
-        } else if (!applicationData.equals(other.applicationData))
-            return false;
-        if (availableInstances == null) {
-            if (other.availableInstances != null)
-                return false;
-        } else if (!availableInstances.equals(other.availableInstances))
-            return false;
-        if (bindingMode == null) {
-            if (other.bindingMode != null)
-                return false;
-        } else if (!bindingMode.equals(other.bindingMode))
-            return false;
-        if (endpoint == null) {
-            if (other.endpoint != null)
-                return false;
-        } else if (!endpoint.equals(other.endpoint))
-            return false;
-        if (id == null) {
-            if (other.id != null)
-                return false;
-        } else if (!id.equals(other.id))
-            return false;
-        if (clientTransportData == null) {
-            if (other.clientTransportData != null)
-                return false;
-        } else if (!clientTransportData.equals(other.clientTransportData))
-            return false;
-        if (lastUpdate == null) {
-            if (other.lastUpdate != null)
-                return false;
-        } else if (!lastUpdate.equals(other.lastUpdate))
-            return false;
-        if (lifeTimeInSec != other.lifeTimeInSec)
-            return false;
-        if (lwM2mVersion == null) {
-            if (other.lwM2mVersion != null)
-                return false;
-        } else if (!lwM2mVersion.equals(other.lwM2mVersion))
-            return false;
-        if (!Arrays.equals(objectLinks, other.objectLinks))
-            return false;
-        if (queueMode == null) {
-            if (other.queueMode != null)
-                return false;
-        } else if (!queueMode.equals(other.queueMode))
-            return false;
-        if (registrationDate == null) {
-            if (other.registrationDate != null)
-                return false;
-        } else if (!registrationDate.equals(other.registrationDate))
-            return false;
-        if (rootPath == null) {
-            if (other.rootPath != null)
-                return false;
-        } else if (!rootPath.equals(other.rootPath))
-            return false;
-        if (smsNumber == null) {
-            if (other.smsNumber != null)
-                return false;
-        } else if (!smsNumber.equals(other.smsNumber))
-            return false;
-        if (supportedContentFormats == null) {
-            if (other.supportedContentFormats != null)
-                return false;
-        } else if (!supportedContentFormats.equals(other.supportedContentFormats))
-            return false;
-        if (supportedObjects == null) {
-            if (other.supportedObjects != null)
-                return false;
-        } else if (!supportedObjects.equals(other.supportedObjects))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(registrationDate, clientTransportData, lifeTimeInSec, smsNumber, lwM2mVersion,
+                bindingMode, queueMode, endpoint, id, Arrays.hashCode(objectLinks), additionalRegistrationAttributes,
+                rootPath, supportedContentFormats, supportedObjects, availableInstances, lastUpdate, applicationData);
     }
 
     public static class Builder {

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/Registration.java
@@ -384,20 +384,22 @@ public class Registration {
                 && Objects.equals(smsNumber, that.smsNumber) && Objects.equals(lwM2mVersion, that.lwM2mVersion)
                 && Objects.equals(bindingMode, that.bindingMode) && Objects.equals(queueMode, that.queueMode)
                 && Objects.equals(endpoint, that.endpoint) && Objects.equals(id, that.id)
-                && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Arrays.equals(objectLinks, that.objectLinks)
                 && Objects.equals(additionalRegistrationAttributes, that.additionalRegistrationAttributes)
                 && Objects.equals(rootPath, that.rootPath)
                 && Objects.equals(supportedContentFormats, that.supportedContentFormats)
                 && Objects.equals(supportedObjects, that.supportedObjects)
                 && Objects.equals(availableInstances, that.availableInstances)
-                && Objects.equals(lastUpdate, that.lastUpdate) && Objects.equals(applicationData, that.applicationData);
+                && Objects.equals(lastUpdate, that.lastUpdate) && Objects.equals(applicationData, that.applicationData)
+                && Objects.equals(lastEndpointUsed, that.lastEndpointUsed);
     }
 
     @Override
     public final int hashCode() {
         return Objects.hash(registrationDate, clientTransportData, lifeTimeInSec, smsNumber, lwM2mVersion, bindingMode,
                 queueMode, endpoint, id, Arrays.hashCode(objectLinks), additionalRegistrationAttributes, rootPath,
-                supportedContentFormats, supportedObjects, availableInstances, lastUpdate, applicationData);
+                supportedContentFormats, supportedObjects, availableInstances, lastUpdate, applicationData,
+                lastEndpointUsed);
     }
 
     public static class Builder {

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -232,34 +232,15 @@ public class RegistrationUpdate {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + Arrays.hashCode(objectLinks);
-        result = prime * result + Objects.hash(additionalAttributes, alternatePath, applicationData, availableInstances,
-                bindingMode, clientTransportData, lifeTimeInSec, registrationId, smsNumber, supportedContentFormats,
-                supportedObjects);
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof RegistrationUpdate)) return false;
+        RegistrationUpdate that = (RegistrationUpdate) o;
+        return Objects.equals(registrationId, that.registrationId) && Objects.equals(clientTransportData, that.clientTransportData) && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber) && Objects.equals(bindingMode, that.bindingMode) && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(alternatePath, that.alternatePath) && Objects.equals(supportedContentFormats, that.supportedContentFormats) && Objects.equals(supportedObjects, that.supportedObjects) && Objects.equals(availableInstances, that.availableInstances) && Objects.equals(additionalAttributes, that.additionalAttributes) && Objects.equals(applicationData, that.applicationData);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        RegistrationUpdate other = (RegistrationUpdate) obj;
-        return Objects.equals(additionalAttributes, other.additionalAttributes)
-                && Objects.equals(alternatePath, other.alternatePath)
-                && Objects.equals(applicationData, other.applicationData)
-                && Objects.equals(availableInstances, other.availableInstances)
-                && Objects.equals(bindingMode, other.bindingMode)
-                && Objects.equals(clientTransportData, other.clientTransportData)
-                && Objects.equals(lifeTimeInSec, other.lifeTimeInSec) && Arrays.equals(objectLinks, other.objectLinks)
-                && Objects.equals(registrationId, other.registrationId) && Objects.equals(smsNumber, other.smsNumber)
-                && Objects.equals(supportedContentFormats, other.supportedContentFormats)
-                && Objects.equals(supportedObjects, other.supportedObjects);
+    public final int hashCode() {
+        return Objects.hash(registrationId, clientTransportData, lifeTimeInSec, smsNumber, bindingMode, Arrays.hashCode(objectLinks), alternatePath, supportedContentFormats, supportedObjects, availableInstances, additionalAttributes, applicationData);
     }
 }

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -241,7 +241,7 @@ public class RegistrationUpdate {
         return Objects.equals(registrationId, that.registrationId)
                 && Objects.equals(clientTransportData, that.clientTransportData)
                 && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber)
-                && Objects.equals(bindingMode, that.bindingMode) && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(bindingMode, that.bindingMode) && Arrays.equals(objectLinks, that.objectLinks)
                 && Objects.equals(alternatePath, that.alternatePath)
                 && Objects.equals(supportedContentFormats, that.supportedContentFormats)
                 && Objects.equals(supportedObjects, that.supportedObjects)

--- a/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
+++ b/leshan-lwm2m-server/src/main/java/org/eclipse/leshan/server/registration/RegistrationUpdate.java
@@ -233,14 +233,27 @@ public class RegistrationUpdate {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof RegistrationUpdate)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof RegistrationUpdate))
+            return false;
         RegistrationUpdate that = (RegistrationUpdate) o;
-        return Objects.equals(registrationId, that.registrationId) && Objects.equals(clientTransportData, that.clientTransportData) && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber) && Objects.equals(bindingMode, that.bindingMode) && Objects.deepEquals(objectLinks, that.objectLinks) && Objects.equals(alternatePath, that.alternatePath) && Objects.equals(supportedContentFormats, that.supportedContentFormats) && Objects.equals(supportedObjects, that.supportedObjects) && Objects.equals(availableInstances, that.availableInstances) && Objects.equals(additionalAttributes, that.additionalAttributes) && Objects.equals(applicationData, that.applicationData);
+        return Objects.equals(registrationId, that.registrationId)
+                && Objects.equals(clientTransportData, that.clientTransportData)
+                && Objects.equals(lifeTimeInSec, that.lifeTimeInSec) && Objects.equals(smsNumber, that.smsNumber)
+                && Objects.equals(bindingMode, that.bindingMode) && Objects.deepEquals(objectLinks, that.objectLinks)
+                && Objects.equals(alternatePath, that.alternatePath)
+                && Objects.equals(supportedContentFormats, that.supportedContentFormats)
+                && Objects.equals(supportedObjects, that.supportedObjects)
+                && Objects.equals(availableInstances, that.availableInstances)
+                && Objects.equals(additionalAttributes, that.additionalAttributes)
+                && Objects.equals(applicationData, that.applicationData);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(registrationId, clientTransportData, lifeTimeInSec, smsNumber, bindingMode, Arrays.hashCode(objectLinks), alternatePath, supportedContentFormats, supportedObjects, availableInstances, additionalAttributes, applicationData);
+        return Objects.hash(registrationId, clientTransportData, lifeTimeInSec, smsNumber, bindingMode,
+                Arrays.hashCode(objectLinks), alternatePath, supportedContentFormats, supportedObjects,
+                availableInstances, additionalAttributes, applicationData);
     }
 }

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
@@ -24,8 +24,10 @@ import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
+import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.junit.jupiter.api.Test;
 

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationSortObjectLinksTest.java
@@ -24,10 +24,8 @@ import java.net.Inet4Address;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.link.Link;
-import org.eclipse.leshan.core.node.ObjectLink;
 import org.eclipse.leshan.core.peer.IpPeer;
 import org.junit.jupiter.api.Test;
 

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
@@ -40,6 +39,8 @@ import org.eclipse.leshan.core.request.ContentFormat;
 import org.eclipse.leshan.server.registration.Registration.Builder;
 import org.eclipse.leshan.server.registration.RegistrationDataExtractor.RegistrationData;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class RegistrationTest {
 

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -298,6 +298,6 @@ public class RegistrationTest {
 
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(Registration.class).withIgnoredFields("lastEndpointUsed").verify();
+        EqualsVerifier.forClass(Registration.class).verify();
     }
 }

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.LwM2m.LwM2mVersion;
 import org.eclipse.leshan.core.LwM2m.Version;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
@@ -292,5 +293,10 @@ public class RegistrationTest {
         builder.availableInstances(dataFromObjectLinks.getAvailableInstances());
 
         return builder.build();
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Registration.class).withIgnoredFields("lastEndpointUsed").verify();
     }
 }

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
@@ -23,8 +23,10 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.peer.IpPeer;
+import org.eclipse.leshan.senml.SenMLPack;
 import org.eclipse.leshan.server.queue.PresenceService;
 import org.junit.jupiter.api.Test;
 
@@ -91,5 +93,10 @@ public class RegistrationUpdateTest {
         assertEquals("1", updatedAppData.get("x"));
         assertEquals("10", updatedAppData.get("y"));
         assertEquals("100", updatedAppData.get("z"));
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(RegistrationUpdate.class).verify();
     }
 }

--- a/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
+++ b/leshan-lwm2m-server/src/test/java/org/eclipse/leshan/server/registration/RegistrationUpdateTest.java
@@ -23,12 +23,12 @@ import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.peer.IpPeer;
-import org.eclipse.leshan.senml.SenMLPack;
 import org.eclipse.leshan.server.queue.PresenceService;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * tests the implementation of {@link PresenceService}

--- a/leshan-lwm2m-servers-shared/pom.xml
+++ b/leshan-lwm2m-servers-shared/pom.xml
@@ -52,9 +52,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-servers-shared/pom.xml
+++ b/leshan-lwm2m-servers-shared/pom.xml
@@ -52,5 +52,9 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
@@ -19,6 +19,7 @@ package org.eclipse.leshan.servers.security;
 import java.io.Serializable;
 import java.security.PublicKey;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.leshan.core.oscore.InvalidOscoreSettingException;
 import org.eclipse.leshan.core.oscore.OscoreSetting;
@@ -197,56 +198,6 @@ public class SecurityInfo implements Serializable {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((endpoint == null) ? 0 : endpoint.hashCode());
-        result = prime * result + ((pskIdentity == null) ? 0 : pskIdentity.hashCode());
-        result = prime * result + Arrays.hashCode(preSharedKey);
-        result = prime * result + ((rawPublicKey == null) ? 0 : rawPublicKey.hashCode());
-        result = prime * result + (useX509Cert ? 1231 : 1237);
-        result = prime * result + ((oscoreSetting == null) ? 0 : oscoreSetting.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        SecurityInfo other = (SecurityInfo) obj;
-        if (endpoint == null) {
-            if (other.endpoint != null)
-                return false;
-        } else if (!endpoint.equals(other.endpoint))
-            return false;
-        if (pskIdentity == null) {
-            if (other.pskIdentity != null)
-                return false;
-        } else if (!pskIdentity.equals(other.pskIdentity))
-            return false;
-        if (!Arrays.equals(preSharedKey, other.preSharedKey))
-            return false;
-        if (rawPublicKey == null) {
-            if (other.rawPublicKey != null)
-                return false;
-        } else if (!rawPublicKey.equals(other.rawPublicKey))
-            return false;
-        if (useX509Cert != other.useX509Cert)
-            return false;
-        if (oscoreSetting == null) {
-            if (other.oscoreSetting != null)
-                return false;
-        } else if (!oscoreSetting.equals(other.oscoreSetting))
-            return false;
-
-        return true;
-    }
-
-    @Override
     public String toString() {
         // TODO make a better toString()
         // Note : preSharedKey is explicitly excluded from display for security purposes
@@ -256,4 +207,16 @@ public class SecurityInfo implements Serializable {
                 useOSCORE() ? new OscoreIdentity(getOscoreSetting().getRecipientId()) : "");
     }
 
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SecurityInfo)) return false;
+        SecurityInfo that = (SecurityInfo) o;
+        return useX509Cert == that.useX509Cert && Objects.equals(endpoint, that.endpoint) && Objects.equals(pskIdentity, that.pskIdentity) && Objects.deepEquals(preSharedKey, that.preSharedKey) && Objects.equals(rawPublicKey, that.rawPublicKey) && Objects.equals(oscoreSetting, that.oscoreSetting);
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(endpoint, pskIdentity, Arrays.hashCode(preSharedKey), rawPublicKey, useX509Cert, oscoreSetting);
+    }
 }

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
@@ -209,14 +209,19 @@ public class SecurityInfo implements Serializable {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof SecurityInfo)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof SecurityInfo))
+            return false;
         SecurityInfo that = (SecurityInfo) o;
-        return useX509Cert == that.useX509Cert && Objects.equals(endpoint, that.endpoint) && Objects.equals(pskIdentity, that.pskIdentity) && Objects.deepEquals(preSharedKey, that.preSharedKey) && Objects.equals(rawPublicKey, that.rawPublicKey) && Objects.equals(oscoreSetting, that.oscoreSetting);
+        return useX509Cert == that.useX509Cert && Objects.equals(endpoint, that.endpoint)
+                && Objects.equals(pskIdentity, that.pskIdentity) && Objects.deepEquals(preSharedKey, that.preSharedKey)
+                && Objects.equals(rawPublicKey, that.rawPublicKey) && Objects.equals(oscoreSetting, that.oscoreSetting);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(endpoint, pskIdentity, Arrays.hashCode(preSharedKey), rawPublicKey, useX509Cert, oscoreSetting);
+        return Objects.hash(endpoint, pskIdentity, Arrays.hashCode(preSharedKey), rawPublicKey, useX509Cert,
+                oscoreSetting);
     }
 }

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/SecurityInfo.java
@@ -215,7 +215,7 @@ public class SecurityInfo implements Serializable {
             return false;
         SecurityInfo that = (SecurityInfo) o;
         return useX509Cert == that.useX509Cert && Objects.equals(endpoint, that.endpoint)
-                && Objects.equals(pskIdentity, that.pskIdentity) && Objects.deepEquals(preSharedKey, that.preSharedKey)
+                && Objects.equals(pskIdentity, that.pskIdentity) && Arrays.equals(preSharedKey, that.preSharedKey)
                 && Objects.equals(rawPublicKey, that.rawPublicKey) && Objects.equals(oscoreSetting, that.oscoreSetting);
     }
 

--- a/leshan-lwm2m-servers-shared/src/test/java/org/eclipse/leshan/servers/security/SecurityInfoTest.java
+++ b/leshan-lwm2m-servers-shared/src/test/java/org/eclipse/leshan/servers/security/SecurityInfoTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.servers.security;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class SecurityInfoTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(SecurityInfo.class).verify();
+    }
+}

--- a/leshan-lwm2m-servers-shared/src/test/java/org/eclipse/leshan/servers/security/SecurityInfoTest.java
+++ b/leshan-lwm2m-servers-shared/src/test/java/org/eclipse/leshan/servers/security/SecurityInfoTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.servers.security;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class SecurityInfoTest {
     @Test

--- a/leshan-tl-cf-server-coap/pom.xml
+++ b/leshan-tl-cf-server-coap/pom.xml
@@ -59,10 +59,10 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/leshan-tl-cf-server-coap/pom.xml
+++ b/leshan-tl-cf-server-coap/pom.xml
@@ -59,6 +59,10 @@ Contributors:
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 
   <build>

--- a/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
+++ b/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
@@ -23,9 +23,13 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.Link;
@@ -55,6 +59,8 @@ import org.eclipse.leshan.server.request.UplinkDeviceManagementRequestReceiver;
 import org.eclipse.leshan.servers.security.ServerSecurityInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ObservationServiceTest {
 
@@ -262,9 +268,10 @@ public class ObservationServiceTest {
 
     private class ExtendedObservation extends Observation {
         public ExtendedObservation(ObservationIdentifier id, String registrationId, Map<String, String> context,
-                                   Map<String, String> protocolData) {
+                Map<String, String> protocolData) {
             super(id, registrationId, context, protocolData);
         }
+
         @Override
         public boolean canEqual(Object obj) {
             return (obj instanceof ExtendedObservation);

--- a/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
+++ b/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
@@ -26,7 +26,6 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -34,6 +33,7 @@ import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.Link;
 import org.eclipse.leshan.core.node.LwM2mPath;
+import org.eclipse.leshan.core.observation.CompositeObservation;
 import org.eclipse.leshan.core.observation.Observation;
 import org.eclipse.leshan.core.observation.ObservationIdentifier;
 import org.eclipse.leshan.core.observation.SingleObservation;
@@ -266,20 +266,11 @@ public class ObservationServiceTest {
         }
     }
 
-    private class ExtendedObservation extends Observation {
-        public ExtendedObservation(ObservationIdentifier id, String registrationId, Map<String, String> context,
-                Map<String, String> protocolData) {
-            super(id, registrationId, context, protocolData);
-        }
-
-        @Override
-        public boolean canEqual(Object obj) {
-            return (obj instanceof ExtendedObservation);
-        }
-    }
-
     @Test
     public void assertEqualsHashcode() {
-        EqualsVerifier.forClass(Observation.class).withRedefinedSubclass(ExtendedObservation.class).verify();
+        EqualsVerifier.forClass(Observation.class).withRedefinedSubclass(CompositeObservation.class)
+                .withIgnoredFields("protocolData").verify();
+        EqualsVerifier.forClass(Observation.class).withRedefinedSubclass(SingleObservation.class)
+                .withIgnoredFields("protocolData").verify();
     }
 }

--- a/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
+++ b/leshan-tl-cf-server-coap/src/test/java/org/eclipse/leshan/transport/californium/server/observation/ObservationServiceTest.java
@@ -23,12 +23,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
+import nl.jqno.equalsverifier.EqualsVerifier;
 import org.eclipse.leshan.core.endpoint.EndpointUriUtil;
 import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.link.Link;
@@ -261,5 +258,21 @@ public class ObservationServiceTest {
         @Override
         public void destroy() {
         }
+    }
+
+    private class ExtendedObservation extends Observation {
+        public ExtendedObservation(ObservationIdentifier id, String registrationId, Map<String, String> context,
+                                   Map<String, String> protocolData) {
+            super(id, registrationId, context, protocolData);
+        }
+        @Override
+        public boolean canEqual(Object obj) {
+            return (obj instanceof ExtendedObservation);
+        }
+    }
+
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(Observation.class).withRedefinedSubclass(ExtendedObservation.class).verify();
     }
 }

--- a/leshan-tl-cf-shared-oscore/pom.xml
+++ b/leshan-tl-cf-shared-oscore/pom.xml
@@ -51,9 +51,9 @@ Contributors:
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/leshan-tl-cf-shared-oscore/pom.xml
+++ b/leshan-tl-cf-shared-oscore/pom.xml
@@ -51,5 +51,9 @@ Contributors:
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
   </dependencies>
 </project>

--- a/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
+++ b/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
@@ -79,14 +79,19 @@ public class OscoreParameters {
 
     @Override
     public final boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof OscoreParameters)) return false;
+        if (this == o)
+            return true;
+        if (!(o instanceof OscoreParameters))
+            return false;
         OscoreParameters that = (OscoreParameters) o;
-        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId) && Objects.deepEquals(masterSecret, that.masterSecret) && aeadAlgorithm == that.aeadAlgorithm && hmacAlgorithm == that.hmacAlgorithm && Objects.deepEquals(masterSalt, that.masterSalt);
+        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId)
+                && Objects.deepEquals(masterSecret, that.masterSecret) && aeadAlgorithm == that.aeadAlgorithm
+                && hmacAlgorithm == that.hmacAlgorithm && Objects.deepEquals(masterSalt, that.masterSalt);
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret), aeadAlgorithm, hmacAlgorithm, Arrays.hashCode(masterSalt));
+        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret),
+                aeadAlgorithm, hmacAlgorithm, Arrays.hashCode(masterSalt));
     }
 }

--- a/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
+++ b/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
@@ -16,6 +16,7 @@
 package org.eclipse.leshan.transport.californium.oscore.cf;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.californium.cose.AlgorithmID;
 import org.eclipse.leshan.core.util.Hex;
@@ -77,45 +78,15 @@ public class OscoreParameters {
     }
 
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((aeadAlgorithm == null) ? 0 : aeadAlgorithm.hashCode());
-        result = prime * result + ((hmacAlgorithm == null) ? 0 : hmacAlgorithm.hashCode());
-        result = prime * result + Arrays.hashCode(masterSalt);
-        result = prime * result + Arrays.hashCode(masterSecret);
-        result = prime * result + Arrays.hashCode(recipientId);
-        result = prime * result + Arrays.hashCode(senderId);
-        return result;
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof OscoreParameters)) return false;
+        OscoreParameters that = (OscoreParameters) o;
+        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId) && Objects.deepEquals(masterSecret, that.masterSecret) && aeadAlgorithm == that.aeadAlgorithm && hmacAlgorithm == that.hmacAlgorithm && Objects.deepEquals(masterSalt, that.masterSalt);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        OscoreParameters other = (OscoreParameters) obj;
-        if (aeadAlgorithm == null) {
-            if (other.aeadAlgorithm != null)
-                return false;
-        } else if (!aeadAlgorithm.equals(other.aeadAlgorithm))
-            return false;
-        if (hmacAlgorithm == null) {
-            if (other.hmacAlgorithm != null)
-                return false;
-        } else if (!hmacAlgorithm.equals(other.hmacAlgorithm))
-            return false;
-        if (!Arrays.equals(masterSalt, other.masterSalt))
-            return false;
-        if (!Arrays.equals(masterSecret, other.masterSecret))
-            return false;
-        if (!Arrays.equals(recipientId, other.recipientId))
-            return false;
-        if (!Arrays.equals(senderId, other.senderId))
-            return false;
-        return true;
+    public final int hashCode() {
+        return Objects.hash(Arrays.hashCode(senderId), Arrays.hashCode(recipientId), Arrays.hashCode(masterSecret), aeadAlgorithm, hmacAlgorithm, Arrays.hashCode(masterSalt));
     }
 }

--- a/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
+++ b/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParameters.java
@@ -84,9 +84,9 @@ public class OscoreParameters {
         if (!(o instanceof OscoreParameters))
             return false;
         OscoreParameters that = (OscoreParameters) o;
-        return Objects.deepEquals(senderId, that.senderId) && Objects.deepEquals(recipientId, that.recipientId)
-                && Objects.deepEquals(masterSecret, that.masterSecret) && aeadAlgorithm == that.aeadAlgorithm
-                && hmacAlgorithm == that.hmacAlgorithm && Objects.deepEquals(masterSalt, that.masterSalt);
+        return Arrays.equals(senderId, that.senderId) && Arrays.equals(recipientId, that.recipientId)
+                && Arrays.equals(masterSecret, that.masterSecret) && aeadAlgorithm == that.aeadAlgorithm
+                && hmacAlgorithm == that.hmacAlgorithm && Arrays.equals(masterSalt, that.masterSalt);
     }
 
     @Override

--- a/leshan-tl-cf-shared-oscore/src/test/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParametersTest.java
+++ b/leshan-tl-cf-shared-oscore/src/test/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParametersTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.transport.californium.oscore.cf;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class OscoreParametersTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(OscoreParameters.class).verify();
+    }
+}

--- a/leshan-tl-cf-shared-oscore/src/test/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParametersTest.java
+++ b/leshan-tl-cf-shared-oscore/src/test/java/org/eclipse/leshan/transport/californium/oscore/cf/OscoreParametersTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.transport.californium.oscore.cf;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class OscoreParametersTest {
     @Test

--- a/leshan-tl-jc-client-coap/pom.xml
+++ b/leshan-tl-jc-client-coap/pom.xml
@@ -37,6 +37,22 @@ Contributors:
       <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-shared</artifactId>
     </dependency>
+      <dependency>
+          <groupId>nl.jqno.equalsverifier</groupId>
+          <artifactId>equalsverifier</artifactId>
+      </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.10.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/leshan-tl-jc-client-coap/pom.xml
+++ b/leshan-tl-jc-client-coap/pom.xml
@@ -37,10 +37,10 @@ Contributors:
       <groupId>org.eclipse.leshan</groupId>
       <artifactId>leshan-tl-jc-shared</artifactId>
     </dependency>
-      <dependency>
-          <groupId>nl.jqno.equalsverifier</groupId>
-          <artifactId>equalsverifier</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>

--- a/leshan-tl-jc-client-coap/pom.xml
+++ b/leshan-tl-jc-client-coap/pom.xml
@@ -42,15 +42,8 @@ Contributors:
       <artifactId>equalsverifier</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <version>5.10.1</version>
+      <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
@@ -100,8 +100,10 @@ public class HashMapObserversStore implements ObserversStore {
 
         @Override
         public final boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof ObserverKey)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof ObserverKey))
+                return false;
             ObserverKey that = (ObserverKey) o;
             return Objects.equals(token, that.token) && Objects.equals(peerAddress, that.peerAddress);
         }

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStore.java
@@ -93,26 +93,22 @@ public class HashMapObserversStore implements ObserversStore {
         }
 
         @Override
-        public int hashCode() {
-            return Objects.hash(peerAddress, token);
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj)
-                return true;
-            if (obj == null)
-                return false;
-            if (getClass() != obj.getClass())
-                return false;
-            ObserverKey other = (ObserverKey) obj;
-            return Objects.equals(peerAddress, other.peerAddress) && Objects.equals(token, other.token);
-        }
-
-        @Override
         public String toString() {
             return String.format("ObserverKey [token=%s, peerAddress=%s]", token != null ? token.toHex() : "null",
                     peerAddress);
+        }
+
+        @Override
+        public final boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof ObserverKey)) return false;
+            ObserverKey that = (ObserverKey) o;
+            return Objects.equals(token, that.token) && Objects.equals(peerAddress, that.peerAddress);
+        }
+
+        @Override
+        public final int hashCode() {
+            return Objects.hash(token, peerAddress);
         }
     }
 }

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterService.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterService.java
@@ -158,8 +158,10 @@ public class RouterService implements Service<CoapRequest, CoapResponse> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof RequestMatcher)) return false;
+            if (this == o)
+                return true;
+            if (!(o instanceof RequestMatcher))
+                return false;
             RequestMatcher that = (RequestMatcher) o;
             return isPrefixed == that.isPrefixed && method == that.method && Objects.equals(uriPath, that.uriPath);
         }

--- a/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterService.java
+++ b/leshan-tl-jc-client-coap/src/main/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterService.java
@@ -124,7 +124,7 @@ public class RouterService implements Service<CoapRequest, CoapResponse> {
     static final class RequestMatcher {
         private final Method method;
         private final String uriPath;
-        private transient final boolean isPrefixed;
+        private final boolean isPrefixed;
 
         RequestMatcher(Method method, String uriPath) {
             this.method = method;
@@ -158,20 +158,15 @@ public class RouterService implements Service<CoapRequest, CoapResponse> {
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
+            if (this == o) return true;
+            if (!(o instanceof RequestMatcher)) return false;
             RequestMatcher that = (RequestMatcher) o;
-            return method == that.method && Objects.equals(uriPath, that.uriPath)
-                    && Objects.equals(isPrefixed, that.isPrefixed);
+            return isPrefixed == that.isPrefixed && method == that.method && Objects.equals(uriPath, that.uriPath);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(method, isPrefixed, uriPath);
+            return Objects.hash(method, uriPath, isPrefixed);
         }
     }
 }

--- a/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStoreTest.java
+++ b/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStoreTest.java
@@ -1,0 +1,11 @@
+package org.eclipse.leshan.transport.javacoap.client.observe;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class HashMapObserversStoreTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(HashMapObserversStore.ObserverKey.class).verify();
+    }
+}

--- a/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStoreTest.java
+++ b/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/observe/HashMapObserversStoreTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.transport.javacoap.client.observe;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class HashMapObserversStoreTest {
     @Test

--- a/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterServiceTest.java
+++ b/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterServiceTest.java
@@ -1,0 +1,12 @@
+package org.eclipse.leshan.transport.javacoap.client.resource;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.jupiter.api.Test;
+
+class RouterServiceTest {
+    @Test
+    public void assertEqualsHashcode() {
+        EqualsVerifier.forClass(RouterService.RequestMatcher.class).verify();
+    }
+
+}

--- a/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterServiceTest.java
+++ b/leshan-tl-jc-client-coap/src/test/java/org/eclipse/leshan/transport/javacoap/client/resource/RouterServiceTest.java
@@ -1,7 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Natalia Krzykała Orange Polska S.A. - initial implementation
+ *******************************************************************************/
 package org.eclipse.leshan.transport.javacoap.client.resource;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 class RouterServiceTest {
     @Test


### PR DESCRIPTION
This pull request is according to #1504 

I separated modified and added files into commits by categories. You can find commits dividing:

- classes that I used instanceof + final in and corresponding test classes
- classes that I added canEqual to and corresponding test classes
- classes with ignored fields (excluding "coapRequest") in the EqualsVerifier tests and corresponding test classes (because maybe the ignored fields shouldn't be avoided at some point in the future)
- classes which had not final fields (and in EqualsVerifier we suppressed the warning about it - we may deal with it in the future as mentioned in the issue) and corresponding test classes
- classes which had not final fields (and we made them final) and corresponding test classes
- pom files with added dependencies
- fixup, fe. deleting unused variables, sorting imports and adding headers

