### PR TITLE
Enable usage of OSCORE Appendix B.2 context re-derivation procedure

### DIFF
--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/oscore/OscoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/oscore/OscoreTest.java
@@ -231,10 +231,6 @@ public class OscoreTest {
 
         // Start it and wait for registration
         client.start();
-        // TODO to remove
-        // Uncomment to see the failure
-//        Failure failure = client.waitForRegistrationFailureTo(server);
-//        System.out.println(failure);
 
         server.waitForReRegistrationOf(registration);
 

--- a/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/oscore/OscoreTest.java
+++ b/leshan-integration-tests/src/test/java/org/eclipse/leshan/integration/tests/oscore/OscoreTest.java
@@ -236,7 +236,7 @@ public class OscoreTest {
 //        Failure failure = client.waitForRegistrationFailureTo(server);
 //        System.out.println(failure);
 
-        server.waitForNewRegistrationOf(client);
+        server.waitForReRegistrationOf(registration);
 
         // Check client is well registered
         assertThat(client).isRegisteredAt(server);

--- a/leshan-tl-cf-client-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/client/endpoint/coap/CoapOscoreClientEndpointFactory.java
+++ b/leshan-tl-cf-client-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/client/endpoint/coap/CoapOscoreClientEndpointFactory.java
@@ -110,6 +110,7 @@ public class CoapOscoreClientEndpointFactory extends CoapClientEndpointFactory {
                     hkdfAlg, masterSalt);
 
             InMemoryOscoreContextDB oscoreCtxDB = new InMemoryOscoreContextDB(new StaticOscoreStore(oscoreParameters));
+            oscoreCtxDB.setClientRole(true);
             builder.setCustomCoapStackArgument(oscoreCtxDB).setCoapStackFactory(new OSCoreCoapStackFactory());
         }
 

--- a/leshan-tl-cf-client-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/client/endpoint/coap/CoapOscoreClientEndpointFactory.java
+++ b/leshan-tl-cf-client-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/client/endpoint/coap/CoapOscoreClientEndpointFactory.java
@@ -109,8 +109,8 @@ public class CoapOscoreClientEndpointFactory extends CoapClientEndpointFactory {
                     serverInfo.oscoreSetting.getRecipientId(), serverInfo.oscoreSetting.getMasterSecret(), aeadAlg,
                     hkdfAlg, masterSalt);
 
-            InMemoryOscoreContextDB oscoreCtxDB = new InMemoryOscoreContextDB(new StaticOscoreStore(oscoreParameters));
-            oscoreCtxDB.setClientRole(true);
+            InMemoryOscoreContextDB oscoreCtxDB = new InMemoryOscoreContextDB(new StaticOscoreStore(oscoreParameters),
+                    true);
             builder.setCustomCoapStackArgument(oscoreCtxDB).setCoapStackFactory(new OSCoreCoapStackFactory());
         }
 

--- a/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
+++ b/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
@@ -58,7 +58,7 @@ public class OscoreContextCleaner implements RegistrationListener, SecurityStore
     @Override
     public void unregistered(Registration registration, Collection<Observation> observations, boolean expired,
             Registration newReg) {
-        if (registration.getClientTransportData().getIdentity() instanceof OscoreIdentity) {
+        if (registration.getClientTransportData().getIdentity() instanceof OscoreIdentity && newReg == null) {
             removeContext(((OscoreIdentity) registration.getClientTransportData().getIdentity()).getRecipientId());
         }
     }
@@ -67,11 +67,7 @@ public class OscoreContextCleaner implements RegistrationListener, SecurityStore
     public void securityInfoRemoved(boolean infosAreCompromised, SecurityInfo... infos) {
         for (SecurityInfo securityInfo : infos) {
             if (securityInfo.useOSCORE()) {
-                if (infosAreCompromised) {
-                    removeContextCompromised(securityInfo.getOscoreSetting().getRecipientId());
-                } else {
-                    removeContext(securityInfo.getOscoreSetting().getRecipientId());
-                }
+                removeContext(securityInfo.getOscoreSetting().getRecipientId());
             }
         }
     }
@@ -79,13 +75,6 @@ public class OscoreContextCleaner implements RegistrationListener, SecurityStore
     private void removeContext(byte[] rid) {
         OSCoreCtx context = oscoreCtxDB.getContext(rid);
         if (context != null)
-            if (!oscoreCtxDB.getContext(rid).getContextRederivationEnabled()) {
-                oscoreCtxDB.removeContext(context);
-            }
-    }
-
-    private void removeContextCompromised(byte[] rid) {
-        OSCoreCtx context = oscoreCtxDB.getContext(rid);
-        oscoreCtxDB.removeContext(context);
+            oscoreCtxDB.removeContext(context);
     }
 }

--- a/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
+++ b/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
@@ -67,7 +67,11 @@ public class OscoreContextCleaner implements RegistrationListener, SecurityStore
     public void securityInfoRemoved(boolean infosAreCompromised, SecurityInfo... infos) {
         for (SecurityInfo securityInfo : infos) {
             if (securityInfo.useOSCORE()) {
-                removeContext(securityInfo.getOscoreSetting().getRecipientId());
+                if (infosAreCompromised) {
+                    removeContextCompromised(securityInfo.getOscoreSetting().getRecipientId());
+                } else {
+                    removeContext(securityInfo.getOscoreSetting().getRecipientId());
+                }
             }
         }
     }
@@ -75,6 +79,13 @@ public class OscoreContextCleaner implements RegistrationListener, SecurityStore
     private void removeContext(byte[] rid) {
         OSCoreCtx context = oscoreCtxDB.getContext(rid);
         if (context != null)
-            oscoreCtxDB.removeContext(context);
+            if (!oscoreCtxDB.getContext(rid).getContextRederivationEnabled()) {
+                oscoreCtxDB.removeContext(context);
+            }
+    }
+
+    private void removeContextCompromised(byte[] rid) {
+        OSCoreCtx context = oscoreCtxDB.getContext(rid);
+        oscoreCtxDB.removeContext(context);
     }
 }

--- a/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/InMemoryOscoreContextDB.java
+++ b/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/InMemoryOscoreContextDB.java
@@ -39,7 +39,12 @@ public class InMemoryOscoreContextDB extends HashMapCtxDB {
     public boolean clientRole = false;
 
     public InMemoryOscoreContextDB(OscoreStore oscoreStore) {
+        this(oscoreStore, false);
+    }
+
+    public InMemoryOscoreContextDB(OscoreStore oscoreStore, boolean clientRole) {
         this.store = oscoreStore;
+        this.clientRole = clientRole;
     }
 
     @Override
@@ -133,9 +138,5 @@ public class InMemoryOscoreContextDB extends HashMapCtxDB {
             LOG.error("Unable to derive context from {}", oscoreParameters, e);
             return null;
         }
-    }
-
-    public void setClientRole(boolean clientRole) {
-        this.clientRole = clientRole;
     }
 }

--- a/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/InMemoryOscoreContextDB.java
+++ b/leshan-tl-cf-shared-oscore/src/main/java/org/eclipse/leshan/transport/californium/oscore/cf/InMemoryOscoreContextDB.java
@@ -36,7 +36,7 @@ public class InMemoryOscoreContextDB extends HashMapCtxDB {
 
     private final OscoreStore store;
 
-    public boolean clientRole = false;
+    private final boolean clientRole;
 
     public InMemoryOscoreContextDB(OscoreStore oscoreStore) {
         this(oscoreStore, false);


### PR DESCRIPTION
This pull request adds support for running the OSCORE context re-derivation procedure from Appendix B.2 of the OSCORE RFC. This procedure securely re-generates OSCORE Security Context information for both peers. The LWM2M client now uses this procedure towards the LWM2M server and LWM2M bootstrap server.
See https://tools.ietf.org/html/rfc8613#appendix-B.2

It is specified in the LWM2M 1.1 Transport Bindings document section 5.5.3 that Appendix B.2 of OSCORE should be used. Using the procedure in Appendix B.2 will derive a new OSCORE Security Context (with new Sender and Recipient keys). The benefit this has is that if a LWM2M client reboots and starts using the same Security Context that it was originally configured with, it will not be using the same Sender Key while starting over from sequence number 0 (thus performing nonce and key reuse). Rather it will first run Appendix B.2 to generate a new Context (Sender and Recipient keys) with the LWM2M Server or LWM2M Bootstrap server.

Every time the client connects the first time using OSCORE to a LWM2M Server or LWM2M Bootstrap server, Appendix B.2 will be run. Furthermore, currently if the client is restarted but the server is not, the server will complain about replayed messages. But since Appendix B.2 refreshes the security context (creating new keys and resetting the replay window) this problem will no longer exist.
