### PR TITLE
Split EditableSecurityStore into ObservableSecStore and EditableSecStore

### DIFF
--- a/leshan-lwm2m-server-redis/src/main/java/org/eclipse/leshan/server/redis/RedisSecurityStore.java
+++ b/leshan-lwm2m-server-redis/src/main/java/org/eclipse/leshan/server/redis/RedisSecurityStore.java
@@ -26,6 +26,7 @@ import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.server.redis.serialization.SecurityInfoSerDes;
 import org.eclipse.leshan.servers.security.EditableSecurityStore;
 import org.eclipse.leshan.servers.security.NonUniqueSecurityInfoException;
+import org.eclipse.leshan.servers.security.ObservableSecurityStore;
 import org.eclipse.leshan.servers.security.SecurityInfo;
 import org.eclipse.leshan.servers.security.SecurityStore;
 import org.eclipse.leshan.servers.security.SecurityStoreListener;
@@ -41,7 +42,7 @@ import redis.clients.jedis.util.Pool;
  * Security info are stored using the endpoint as primary key and secondary indexes are created for endpoint lookup by
  * PSK identity and OSCORE Recipient ID (RID).
  */
-public class RedisSecurityStore implements EditableSecurityStore {
+public class RedisSecurityStore implements EditableSecurityStore, ObservableSecurityStore {
 
     private final String securityInfoByEndpointPrefix;
     private final String endpointByPskIdKey;

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/EditableSecurityStore.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/EditableSecurityStore.java
@@ -17,6 +17,9 @@ package org.eclipse.leshan.servers.security;
 
 import java.util.Collection;
 
+/**
+ * A {@link SecurityStore} which can be edited. This is not used by Leshan library but mainly for test and Leshan Demo.
+ */
 public interface EditableSecurityStore extends SecurityStore {
 
     /**
@@ -46,14 +49,4 @@ public interface EditableSecurityStore extends SecurityStore {
      * @return the removed {@link SecurityInfo} or <code>null</code> if no info for the end-point.
      */
     SecurityInfo remove(String endpoint, boolean infosAreCompromised);
-
-    /**
-     * Adds a new {@link SecurityStoreListener} to this store.
-     */
-    void addListener(SecurityStoreListener listener);
-
-    /**
-     * Removes the given {@link SecurityStoreListener} from the listeners of this store .
-     */
-    void removeListener(SecurityStoreListener listener);
 }

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/InMemorySecurityStore.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/InMemorySecurityStore.java
@@ -31,7 +31,7 @@ import org.eclipse.leshan.core.peer.OscoreIdentity;
 /**
  * A {@link SecurityStore} which store {@link SecurityInfo} in memory.
  */
-public class InMemorySecurityStore implements EditableSecurityStore {
+public class InMemorySecurityStore implements EditableSecurityStore, ObservableSecurityStore {
 
     // lock for the two maps
     protected final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();

--- a/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/ObservableSecurityStore.java
+++ b/leshan-lwm2m-servers-shared/src/main/java/org/eclipse/leshan/servers/security/ObservableSecurityStore.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2013-2015 Sierra Wireless and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ *
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v20.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ *
+ * Contributors:
+ *     Sierra Wireless - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.leshan.servers.security;
+
+/**
+ * A {@link SecurityStore} which can be observed. Its is used by Leshan library to remove secure connection and so force
+ * handshake when {@link SecurityInfo} is removed because it was compromised. See
+ * {@link SecurityStoreListener#securityInfoRemoved(boolean, SecurityInfo...)}
+ */
+public interface ObservableSecurityStore extends SecurityStore {
+
+    /**
+     * Adds a new {@link SecurityStoreListener} to this store.
+     */
+    void addListener(SecurityStoreListener listener);
+
+    /**
+     * Removes the given {@link SecurityStoreListener} from the listeners of this store .
+     */
+    void removeListener(SecurityStoreListener listener);
+}

--- a/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
+++ b/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/OscoreContextCleaner.java
@@ -25,7 +25,7 @@ import org.eclipse.leshan.core.peer.OscoreIdentity;
 import org.eclipse.leshan.server.registration.Registration;
 import org.eclipse.leshan.server.registration.RegistrationListener;
 import org.eclipse.leshan.server.registration.RegistrationUpdate;
-import org.eclipse.leshan.servers.security.EditableSecurityStore;
+import org.eclipse.leshan.servers.security.ObservableSecurityStore;
 import org.eclipse.leshan.servers.security.SecurityInfo;
 import org.eclipse.leshan.servers.security.SecurityStoreListener;
 
@@ -35,7 +35,7 @@ import org.eclipse.leshan.servers.security.SecurityStoreListener;
  * {@link OSCoreCtx} is removed when :
  * <ul>
  * <li>a {@link Registration} using OSCORE is removed.
- * <li>an OSCORE {@link SecurityInfo} is removed from {@link EditableSecurityStore}.
+ * <li>an OSCORE {@link SecurityInfo} is removed from {@link ObservableSecurityStore}.
  * </ul>
  *
  */

--- a/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/coap/CoapOscoreServerEndpointFactory.java
+++ b/leshan-tl-cf-server-coap-oscore/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/coap/CoapOscoreServerEndpointFactory.java
@@ -35,7 +35,7 @@ import org.eclipse.leshan.core.util.Hex;
 import org.eclipse.leshan.server.LeshanServer;
 import org.eclipse.leshan.server.endpoint.EffectiveEndpointUriProvider;
 import org.eclipse.leshan.server.observation.LwM2mNotificationReceiver;
-import org.eclipse.leshan.servers.security.EditableSecurityStore;
+import org.eclipse.leshan.servers.security.ObservableSecurityStore;
 import org.eclipse.leshan.transport.californium.identity.IdentityHandler;
 import org.eclipse.leshan.transport.californium.oscore.cf.InMemoryOscoreContextDB;
 import org.eclipse.leshan.transport.californium.server.LwM2mOscoreStore;
@@ -84,8 +84,8 @@ public class CoapOscoreServerEndpointFactory extends CoapServerEndpointFactory {
             OscoreContextCleaner oscoreCtxCleaner = new OscoreContextCleaner(oscoreCtxDB);
             server.getRegistrationService().addListener(oscoreCtxCleaner);
 
-            if (server.getSecurityStore() instanceof EditableSecurityStore) {
-                ((EditableSecurityStore) server.getSecurityStore()).addListener(oscoreCtxCleaner);
+            if (server.getSecurityStore() instanceof ObservableSecurityStore) {
+                ((ObservableSecurityStore) server.getSecurityStore()).addListener(oscoreCtxCleaner);
             }
         }
 

--- a/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/coaps/CoapsServerEndpointFactory.java
+++ b/leshan-tl-cf-server-coap/src/main/java/org/eclipse/leshan/transport/californium/server/endpoint/coaps/CoapsServerEndpointFactory.java
@@ -49,7 +49,7 @@ import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.server.LeshanServer;
 import org.eclipse.leshan.server.endpoint.EffectiveEndpointUriProvider;
 import org.eclipse.leshan.server.observation.LwM2mNotificationReceiver;
-import org.eclipse.leshan.servers.security.EditableSecurityStore;
+import org.eclipse.leshan.servers.security.ObservableSecurityStore;
 import org.eclipse.leshan.servers.security.SecurityStore;
 import org.eclipse.leshan.servers.security.ServerSecurityInfo;
 import org.eclipse.leshan.transport.californium.DefaultCoapsExceptionTranslator;
@@ -311,12 +311,12 @@ public class CoapsServerEndpointFactory implements CaliforniumServerEndpointFact
 
     protected void createConnectionCleaner(SecurityStore securityStore, CoapEndpoint securedEndpoint) {
         if (securedEndpoint != null && securedEndpoint.getConnector() instanceof DTLSConnector
-                && securityStore instanceof EditableSecurityStore) {
+                && securityStore instanceof ObservableSecurityStore) {
 
             final ConnectionCleaner connectionCleaner = new ConnectionCleaner(
                     (DTLSConnector) securedEndpoint.getConnector());
 
-            ((EditableSecurityStore) securityStore).addListener((infosAreCompromised, infos) -> {
+            ((ObservableSecurityStore) securityStore).addListener((infosAreCompromised, infos) -> {
                 if (infosAreCompromised) {
                     connectionCleaner.cleanConnectionFor(infos);
                 }

--- a/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/JavaCoapsTcpServerEndpointsProvider.java
+++ b/leshan-tl-jc-server-coaptcp/src/main/java/org/eclipse/leshan/transport/javacoap/server/coaptcp/endpoint/JavaCoapsTcpServerEndpointsProvider.java
@@ -30,7 +30,7 @@ import org.eclipse.leshan.core.endpoint.Protocol;
 import org.eclipse.leshan.core.security.certificate.util.X509CertUtil;
 import org.eclipse.leshan.core.security.certificate.verifier.DefaultCertificateVerifier;
 import org.eclipse.leshan.core.security.jsse.LwM2mX509TrustManager;
-import org.eclipse.leshan.servers.security.EditableSecurityStore;
+import org.eclipse.leshan.servers.security.ObservableSecurityStore;
 import org.eclipse.leshan.servers.security.SecurityInfo;
 import org.eclipse.leshan.servers.security.SecurityStore;
 import org.eclipse.leshan.servers.security.SecurityStoreListener;
@@ -124,8 +124,8 @@ public class JavaCoapsTcpServerEndpointsProvider extends AbstractJavaCoapServerE
     }
 
     protected void createAndAttachConnectionCleaner(NettyCoapTcpTransport transport, SecurityStore securityStore) {
-        if (securityStore instanceof EditableSecurityStore) {
-            ((EditableSecurityStore) securityStore).addListener(new SecurityStoreListener() {
+        if (securityStore instanceof ObservableSecurityStore) {
+            ((ObservableSecurityStore) securityStore).addListener(new SecurityStoreListener() {
 
                 @Override
                 public void securityInfoRemoved(boolean infosAreCompromised, SecurityInfo... infos) {


### PR DESCRIPTION
We split `EditableSecurityStore` into `ObservableSecurityStore` and `EditableSecurityStore`.

Why ? 
Because observable API is used by Leshan library to update some state is security info was compromised.
Where edit API (add/remove/getall) is just for demo and test.

In real world, we can easily imagine users that want to implement the observable API to get benefit Leshan library behavior... but doesn't really need the add/remove/getall stuff.. 